### PR TITLE
iOS-1177 Design system | Change image colors | update slash menu (p4) 

### DIFF
--- a/Anytype/Resources/Assets.xcassets/ObjectSettings/Actions/delete.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/ObjectSettings/Actions/delete.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_clear.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_clear.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_copy.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_copy.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_duplicate.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_duplicate.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_move.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_move.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_moveTo.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_moveTo.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_paste.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Actions/slash_menu_action_paste.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Alignment/slash_menu_alignment_center.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Alignment/slash_menu_alignment_center.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Alignment/slash_menu_alignment_left.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Alignment/slash_menu_alignment_left.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Alignment/slash_menu_alignment_right.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Alignment/slash_menu_alignment_right.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Other/slash_menu_dots_divider.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Other/slash_menu_dots_divider.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Other/slash_menu_line_divider.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Other/slash_menu_line_divider.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Other/slash_menu_table.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Other/slash_menu_table.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/Other/slash_menu_table_of_contents.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/Other/slash_menu_table_of_contents.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/_Groups/slash_menu_group_actions.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/_Groups/slash_menu_group_actions.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/relations/slash_menu_addRelation.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/relations/slash_menu_addRelation.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/slash_back_arrow.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/slash_back_arrow.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Anytype/Resources/Assets.xcassets/SlashMenu/slash_menu_link_to.imageset/Contents.json
+++ b/Anytype/Resources/Assets.xcassets/SlashMenu/slash_menu_link_to.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
set template render mode for slash menu.

Slash menu image container is 40x40. Figma doesn't contains a lot of images in it size. I set template render mode for current images. In future with designer i will migrate icons to design system [IOS-1323](https://linear.app/anytype/issue/IOS-1323/update-slash-menu-icons)
