### PR TITLE
IOS-1347 Editor | Fix autolayout warning

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/EditorAccessoryView/ChangeTypeAccessoryView/ChangeTypeAccessoryView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/EditorAccessoryView/ChangeTypeAccessoryView/ChangeTypeAccessoryView.swift
@@ -15,7 +15,8 @@ class ChangeTypeAccessoryView: UIView {
     let viewModel: ChangeTypeAccessoryViewModel
 
     private let topView = UIView(frame: .zero)
-    private let changeTypeView: UIView
+    private let changeTypeViewSource: UIView
+    private let changeTypeView = UIView()
     private lazy var stackView = UIStackView()
     private var cancellables = [AnyCancellable]()
 
@@ -25,7 +26,7 @@ class ChangeTypeAccessoryView: UIView {
 
     init(viewModel: ChangeTypeAccessoryViewModel, changeTypeView: UIView) {
         self.viewModel = viewModel
-        self.changeTypeView = changeTypeView
+        self.changeTypeViewSource = changeTypeView
 
         super.init(frame: .zero)
 
@@ -37,7 +38,7 @@ class ChangeTypeAccessoryView: UIView {
         backgroundColor = .Background.primary
 
         addSubview(stackView) {
-            $0.pinToSuperviewPreservingReadability() 
+            $0.pinToSuperviewPreservingReadability(excluding: [.bottom])
         }
 
         topView.addSubview(doneButton) {
@@ -64,6 +65,11 @@ class ChangeTypeAccessoryView: UIView {
         stackView.addArrangedSubview(dividerView)
         stackView.addArrangedSubview(changeTypeView)
 
+        // Fix swiftui animation
+        changeTypeView.addSubview(changeTypeViewSource) {
+            $0.pinToSuperview(excluding: [.bottom])
+        }
+        
         let changeTypeViewHeightConstraint = changeTypeView.heightAnchor.constraint(equalToConstant: 96)
         changeTypeViewHeightConstraint.isActive = true
         changeTypeViewHeightConstraint.priority = .init(rawValue: 999)


### PR DESCRIPTION
Fix animation and this:
```
2023-06-02 19:22:27.674403+0300 Anytype[8748:100343] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x600000df80a0 UIView:0x158d19d20.height == 48   (active)>",
    "<NSLayoutConstraint:0x600000df88c0 UIView:0x158d28cd0.height == 0.5   (active)>",
    "<NSLayoutConstraint:0x600000d9b660 V:|-(0)-[UIStackView:0x158d1a0a0]   (active, names: '|':Anytype.ChangeTypeAccessoryView:0x158d19b60 )>",
    "<NSLayoutConstraint:0x600000d98c30 UIStackView:0x158d1a0a0.bottom == Anytype.ChangeTypeAccessoryView:0x158d19b60.bottom   (active)>",
    "<NSLayoutConstraint:0x600000df8aa0 Anytype.ChangeTypeAccessoryView:0x158d19b60.height == 48   (active)>",
    "<NSLayoutConstraint:0x600000df2170 'UISV-canvas-connection' UIStackView:0x158d1a0a0.top == UIView:0x158d19d20.top   (active)>",
    "<NSLayoutConstraint:0x600000df21c0 'UISV-canvas-connection' V:[UIView:0x158d28cd0]-(0)-|   (active, names: '|':UIStackView:0x158d1a0a0 )>",
    "<NSLayoutConstraint:0x600000df2210 'UISV-spacing' V:[UIView:0x158d19d20]-(0)-[UIView:0x158d28cd0]   (active)>"
)
```