### PR TITLE
iOS-1530 Remake AudioSession handling

### DIFF
--- a/Anytype/Sources/ApplicationLayer/AppConfigurators/Configurators/AudioPlaybackConfigurator.swift
+++ b/Anytype/Sources/ApplicationLayer/AppConfigurators/Configurators/AudioPlaybackConfigurator.swift
@@ -1,34 +1,18 @@
-//
-//  AudioPlaybackConfigurator.swift
-//  Anytype
-//
-//  Created by Denis Batvinkin on 17.09.2021.
-//  Copyright © 2021 Anytype. All rights reserved.
-//
-
 import AVFoundation
 import UIKit
+import AnytypeCore
 
 
 final class AudioPlaybackConfigurator: AppConfiguratorProtocol {
 
+    private let audioSessionService = ServiceLocator.shared.audioSessionService()
+    
     func configure() {
-        do {
-            try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback)
-
-            if !AVAudioSession.sharedInstance().isOtherAudioPlaying {
-                try AVAudioSession.sharedInstance().setActive(true)
-            }
-
-            UIApplication.shared.beginReceivingRemoteControlEvents()
-
-            //!! IMPORTANT !!
-            /*
-             If you're using 3rd party libraries to play sound or generate sound you should
-             set sample rate manually here.
-             Otherwise you wont be able to hear any sound when you lock screen
-             */
-            //try AVAudioSession.sharedInstance().setPreferredSampleRate(4096)
-        } catch { }
+        if FeatureFlags.fixAudioSession {
+            audioSessionService.setCategorypPlaybackMixWithOthers()
+        } else {
+            audioSessionService.setCategorypPlaybackLegacy()
+        }
+        UIApplication.shared.beginReceivingRemoteControlEvents()
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Assembly/EditorPageAssembly.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Assembly/EditorPageAssembly.swift
@@ -293,7 +293,8 @@ final class EditorAssembly {
             simpleTableDependenciesBuilder: simpleTableDependenciesBuilder,
             subjectsHolder: focusSubjectHolder,
             pageService: serviceLocator.pageService(),
-            detailsService: serviceLocator.detailsService(objectId: document.objectId)
+            detailsService: serviceLocator.detailsService(objectId: document.objectId),
+            audioSessionService: serviceLocator.audioSessionService()
         )
 
         actionHandler.blockSelectionHandler = blocksStateManager

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/File/Audio/AudioBlockPlayerDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/File/Audio/AudioBlockPlayerDelegate.swift
@@ -1,11 +1,3 @@
-//
-//  AudioBlockPlayerDelegate.swift
-//  Anytype
-//
-//  Created by Denis Batvinkin on 06.10.2021.
-//  Copyright © 2021 Anytype. All rights reserved.
-//
-
 import Foundation
 
 
@@ -31,9 +23,11 @@ extension AudioBlockViewModel: AudioPlayerViewDelegate {
 
     func playButtonDidPress(sliderValue: Double) {
         if audioPlayer.isPlaying(audioId: info.id) {
+            setAudioSessionCategorypPlaybackMixWithOthers()
             audioPlayer.pause(audioId: info.id)
             audioPlayerView?.pause()
         } else {
+            setAudioSessionCategorypPlayback()
             audioPlayer.play(
                 audioId: info.id,
                 name: fileData.metadata.name,
@@ -68,6 +62,7 @@ extension AudioBlockViewModel: AnytypeAudioPlayerDelegate {
     }
 
     func playerItemDidPlayToEndTime() {
+        setAudioSessionCategorypPlaybackMixWithOthers()
         audioPlayerView?.trackTimeChanged(0)
         audioPlayerView?.pause()
     }
@@ -78,6 +73,7 @@ extension AudioBlockViewModel: AnytypeAudioPlayerDelegate {
     }
 
     func stopPlaying() {
+        setAudioSessionCategorypPlaybackMixWithOthers()
         audioPlayerView?.pause()
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/File/Audio/AudioBlockViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/File/Audio/AudioBlockViewModel.swift
@@ -1,6 +1,7 @@
 import Services
 import UIKit
 import AVFoundation
+import AnytypeCore
 
 
 final class AudioBlockViewModel: BlockViewModelProtocol {
@@ -10,6 +11,7 @@ final class AudioBlockViewModel: BlockViewModelProtocol {
 
     let info: BlockInformation
     let fileData: BlockFile
+    let audioSessionService: AudioSessionServiceProtocol
 
     let showAudioPicker: (BlockId) -> ()
 
@@ -21,10 +23,12 @@ final class AudioBlockViewModel: BlockViewModelProtocol {
     init(
         info: BlockInformation,
         fileData: BlockFile,
+        audioSessionService: AudioSessionServiceProtocol,
         showAudioPicker: @escaping (BlockId) -> ()
     ) {
         self.info = info
         self.fileData = fileData
+        self.audioSessionService = audioSessionService
         self.showAudioPicker = showAudioPicker
 
         if let url = fileData.metadata.contentUrl {
@@ -75,5 +79,19 @@ final class AudioBlockViewModel: BlockViewModelProtocol {
             indentationSettings: .init(with: info.configurationData),
             dragConfiguration: .init(id: info.id)
         )
+    }
+    
+    func setAudioSessionCategorypPlayback() {
+        if FeatureFlags.fixAudioSession {
+            audioSessionService.setCategorypPlayback()
+        } else {
+            audioSessionService.setAudioSessionActiveLegacy()
+        }
+    }
+    
+    func setAudioSessionCategorypPlaybackMixWithOthers() {
+        if FeatureFlags.fixAudioSession {
+            audioSessionService.setCategorypPlaybackMixWithOthers()
+        }
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/File/Audio/Audioplayer/AnytypeAudioPlayer.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/File/Audio/Audioplayer/AnytypeAudioPlayer.swift
@@ -1,13 +1,6 @@
-//
-//  AnytypeAudioPlayer.swift
-//  Anytype
-//
-//  Created by Denis Batvinkin on 19.09.2021.
-//  Copyright © 2021 Anytype. All rights reserved.
-//
-
 import AVKit
 import MediaPlayer
+import AnytypeCore
 
 
 final class AnytypeAudioPlayer: NSObject, AnytypeAudioPlayerProtocol {
@@ -133,7 +126,6 @@ final class AnytypeAudioPlayer: NSObject, AnytypeAudioPlayerProtocol {
     }
 
     func play() {
-        try? AVAudioSession.sharedInstance().setActive(true)
         audioPlayer.play()
         updatePlayingInfo()
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/File/Video/VideoBlockContentViewConfiguration.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/File/Video/VideoBlockContentViewConfiguration.swift
@@ -5,4 +5,11 @@ struct VideoBlockConfiguration: BlockConfiguration {
     typealias View = VideoBlockContentView
     
     let file: BlockFile
+    
+    @EquatableNoop private(set) var action: (VideoControlStatus?) -> Void
+}
+
+enum VideoControlStatus {
+    case playing
+    case paused
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/File/Video/VideoBlockViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/File/Video/VideoBlockViewModel.swift
@@ -6,6 +6,7 @@ struct VideoBlockViewModel: BlockViewModelProtocol {
     
     let info: BlockInformation
     let fileData: BlockFile
+    let audioSessionService: AudioSessionServiceProtocol
     
     let showVideoPicker: (BlockId) -> ()
     
@@ -29,7 +30,18 @@ struct VideoBlockViewModel: BlockViewModelProtocol {
         case .error:
             return emptyViewConfiguration(text: Loc.Content.Common.error, state: .error)
         case .done:
-            return VideoBlockConfiguration(file: fileData).cellBlockConfiguration(
+            return VideoBlockConfiguration(
+                file: fileData,
+                action: { status in
+                    guard let status else { return }
+                    switch status {
+                    case .playing:
+                        audioSessionService.setCategorypPlayback()
+                    case .paused:
+                        audioSessionService.setCategorypPlaybackMixWithOthers()
+                    }
+                }
+            ).cellBlockConfiguration(
                 indentationSettings: .init(with: info.configurationData),
                 dragConfiguration: .init(id: info.id)
             )

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelBuilder.swift
@@ -15,6 +15,7 @@ final class BlockViewModelBuilder {
     private let simpleTableDependenciesBuilder: SimpleTableDependenciesBuilder
     private let pageService: PageServiceProtocol
     private let detailsService: DetailsServiceProtocol
+    private let audioSessionService: AudioSessionServiceProtocol
 
     init(
         document: BaseDocumentProtocol,
@@ -26,7 +27,8 @@ final class BlockViewModelBuilder {
         simpleTableDependenciesBuilder: SimpleTableDependenciesBuilder,
         subjectsHolder: FocusSubjectsHolder,
         pageService: PageServiceProtocol,
-        detailsService: DetailsServiceProtocol
+        detailsService: DetailsServiceProtocol,
+        audioSessionService: AudioSessionServiceProtocol
     ) {
         self.document = document
         self.handler = handler
@@ -38,6 +40,7 @@ final class BlockViewModelBuilder {
         self.subjectsHolder = subjectsHolder
         self.pageService = pageService
         self.detailsService = detailsService
+        self.audioSessionService = audioSessionService
     }
 
     func buildEditorItems(infos: [BlockInformation]) -> [EditorItem] {
@@ -159,6 +162,7 @@ final class BlockViewModelBuilder {
                 return VideoBlockViewModel(
                     info: info,
                     fileData: content,
+                    audioSessionService: audioSessionService,
                     showVideoPicker: { [weak self] blockId in
                         self?.showMediaPicker(type: .videos, blockId: blockId)
                     }
@@ -167,6 +171,7 @@ final class BlockViewModelBuilder {
                 return AudioBlockViewModel(
                     info: info,
                     fileData: content,
+                    audioSessionService: audioSessionService,
                     showAudioPicker: { [weak self] blockId in
                         self?.showFilePicker(blockId: blockId, types: [.audio])
                     }

--- a/Anytype/Sources/ServiceLayer/ServiceLocator.swift
+++ b/Anytype/Sources/ServiceLayer/ServiceLocator.swift
@@ -253,6 +253,11 @@ final class ServiceLocator {
         _deviceSceneStateListener
     }
     
+    private lazy var _audioSessionService = AudioSessionService()
+    func audioSessionService() -> AudioSessionServiceProtocol {
+        _audioSessionService
+    }
+    
     // MARK: - Private
     
     private func subscriptionToggler() -> SubscriptionTogglerProtocol {

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -88,6 +88,12 @@ public extension FeatureDescription {
         defaultValue: true
     )
     
+    static let fixAudioSession = FeatureDescription(
+        title: "Fix AudioSession to avoid stop playing misic on the new onboarding",
+        type: .feature(author: "joe_pusya@anytype.io", releaseVersion: "0.23.0"),
+        defaultValue: true
+    )
+    
     // MARK: - Debug
     
     static let rainbowViews = FeatureDescription(

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/Generated/FeatureFlags+Flags.swift
@@ -62,6 +62,10 @@ public extension FeatureFlags {
         value(for: .clearAccountDataOnDeletedStatus)
     }
 
+    static var fixAudioSession: Bool {
+        value(for: .fixAudioSession)
+    }
+
     static var rainbowViews: Bool {
         value(for: .rainbowViews)
     }
@@ -94,6 +98,7 @@ public extension FeatureFlags {
         .getMoreSpace,
         .fixAVCaptureSessionError,
         .clearAccountDataOnDeletedStatus,
+        .fixAudioSession,
         .rainbowViews,
         .showAlertOnAssert,
         .analytics,

--- a/Modules/Services/Sources/Services/AudioSessionService/AudioSessionService.swift
+++ b/Modules/Services/Sources/Services/AudioSessionService/AudioSessionService.swift
@@ -1,0 +1,52 @@
+import AVFoundation
+import Combine
+
+//!! IMPORTANT !!
+/*
+ If you're using 3rd party libraries to play sound or generate sound you should
+ set sample rate manually here.
+ Otherwise you wont be able to hear any sound when you lock screen
+ */
+//try AVAudioSession.sharedInstance().setPreferredSampleRate(4096)
+
+public protocol AudioSessionServiceProtocol {
+    func setCategorypPlayback()
+    func setCategorypPlaybackMixWithOthers()
+    
+    // TODO: remove with FeatureFlags.fixAudioSession
+    func setCategorypPlaybackLegacy()
+    func setAudioSessionActiveLegacy()
+}
+
+public final class AudioSessionService: AudioSessionServiceProtocol {
+    
+    public init() {}
+    
+    public func setCategorypPlayback() {
+        setCategorypPlayback(with: [])
+    }
+    
+    public func setCategorypPlaybackMixWithOthers() {
+        setCategorypPlayback(with: [.mixWithOthers])
+    }
+    
+    public func setCategorypPlaybackLegacy() {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback)
+            if !AVAudioSession.sharedInstance().isOtherAudioPlaying {
+                try AVAudioSession.sharedInstance().setActive(true)
+            }
+        } catch { }
+    }
+    
+    public func setAudioSessionActiveLegacy() {
+        try? AVAudioSession.sharedInstance().setActive(true)
+    }
+    
+    private func setCategorypPlayback(with options: AVAudioSession.CategoryOptions) {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, options: options)
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {}
+    }
+}


### PR DESCRIPTION
We found the bug - music stop playing when open Anytype on the auth.
 It happens because of background video, whether there is an audio track or not.

I had to redo AudioSession handling.
Now, by default, we do not intercept audio at the start of the app, but only intercept by the button `play` and return control when `pause`.
Also I wrapped this new logic under the `fixAudioSession` toggle.
