### PR TITLE
IOS-1560 Sentry | Disable some errors

### DIFF
--- a/Anytype/Sources/CoreLayer/NetwrokLayer/DownloadableImageViewWrapper/DownloadableImageViewWrapper.swift
+++ b/Anytype/Sources/CoreLayer/NetwrokLayer/DownloadableImageViewWrapper/DownloadableImageViewWrapper.swift
@@ -86,7 +86,8 @@ extension DownloadableImageViewWrapper: DownloadableImageViewWrapperProtocol {
             guard
                 case .failure(let error) = result,
                 !error.isTaskCancelled,
-                !error.isImageSettingError
+                !error.isImageSettingError,
+                error.errorCode != 500
             else { return }
  
             anytypeAssertionFailure(error.localizedDescription)

--- a/Anytype/Sources/CoreLayer/Sentry/SentryConfiguration.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/SentryConfiguration.swift
@@ -18,6 +18,7 @@ final class SentryConfigurator: AppConfiguratorProtocol {
             options.enableCaptureFailedRequests = false
             options.enableMetricKit = true
             options.swiftAsyncStacktraces = true
+            options.enableAppHangTracking = false
             
             #if DEBUG
             options.attachViewHierarchy = true


### PR DESCRIPTION
- Disable App Hanging
- Disable 500 for download image. Middleware handles this error