### PR TITLE
iOS-1523 Trim typed/inserted text in recovery phrase text view

### DIFF
--- a/Anytype.xcodeproj/project.pbxproj
+++ b/Anytype.xcodeproj/project.pbxproj
@@ -722,6 +722,7 @@
 		2E0DAF2528A2723C00F43320 /* SetViewSettingsImagePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0DAF2428A2723C00F43320 /* SetViewSettingsImagePreviewView.swift */; };
 		2E0DAF2728A273FC00F43320 /* SetViewSettingsImagePreviewCover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0DAF2628A273FC00F43320 /* SetViewSettingsImagePreviewCover.swift */; };
 		2E0DAF2928A2767B00F43320 /* SetViewSettingsImagePreviewRowConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0DAF2828A2767B00F43320 /* SetViewSettingsImagePreviewRowConfiguration.swift */; };
+		2E0E007F2A680D8600F1D95B /* PhraseTextValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0E007E2A680D8600F1D95B /* PhraseTextValidator.swift */; };
 		2E1146D0293124ED0057C753 /* SetKanbanColumnSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1146CF293124ED0057C753 /* SetKanbanColumnSettingsViewModel.swift */; };
 		2E1146D2293125610057C753 /* SetKanbanColumnSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1146D1293125610057C753 /* SetKanbanColumnSettingsView.swift */; };
 		2E1C80E52A2F6EF000217C47 /* AboutApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1C80E42A2F6EF000217C47 /* AboutApp.swift */; };
@@ -2170,6 +2171,7 @@
 		2E0DAF2428A2723C00F43320 /* SetViewSettingsImagePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetViewSettingsImagePreviewView.swift; sourceTree = "<group>"; };
 		2E0DAF2628A273FC00F43320 /* SetViewSettingsImagePreviewCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetViewSettingsImagePreviewCover.swift; sourceTree = "<group>"; };
 		2E0DAF2828A2767B00F43320 /* SetViewSettingsImagePreviewRowConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetViewSettingsImagePreviewRowConfiguration.swift; sourceTree = "<group>"; };
+		2E0E007E2A680D8600F1D95B /* PhraseTextValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhraseTextValidator.swift; sourceTree = "<group>"; };
 		2E1146CF293124ED0057C753 /* SetKanbanColumnSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetKanbanColumnSettingsViewModel.swift; sourceTree = "<group>"; };
 		2E1146D1293125610057C753 /* SetKanbanColumnSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetKanbanColumnSettingsView.swift; sourceTree = "<group>"; };
 		2E1C80E42A2F6EF000217C47 /* AboutApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutApp.swift; sourceTree = "<group>"; };
@@ -6061,6 +6063,7 @@
 			children = (
 				2EFBBEF92A41DBD900734A0B /* PhraseTextView.swift */,
 				2EFBBEFB2A42512300734A0B /* UIPhraseTextView.swift */,
+				2E0E007E2A680D8600F1D95B /* PhraseTextValidator.swift */,
 			);
 			path = PhraseTextView;
 			sourceTree = "<group>";
@@ -8843,6 +8846,7 @@
 				03E2AD5523A93D3800C701CE /* UserIconView.swift in Sources */,
 				12F6072826D7DF0D00876C92 /* ObjectIconImageView.swift in Sources */,
 				3D3040B027DBAD3500FFE0EB /* EditorBarButtonItem.swift in Sources */,
+				2E0E007F2A680D8600F1D95B /* PhraseTextValidator.swift in Sources */,
 				2E52DE692A1CDF5500F16815 /* LineProgressBarConfiguration.swift in Sources */,
 				C9C49A8527049D0200D86463 /* AlertsFactory.swift in Sources */,
 				C98F6A6C27A90F210063DD7A /* BlockConfiguration.swift in Sources */,

--- a/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextValidator.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextValidator.swift
@@ -16,13 +16,14 @@ struct PhraseTextValidator: PhraseTextValidatorProtocol {
         
         guard FeatureFlags.validateRecoveryPhrase else { return textNoNewlines }
         
+        let emptyRawComponentsCount = textNoNewlines.filter { $0 == " " }.count
+        let emptyPrevRawComponentsCount = prevText.filter { $0 == " " }.count
+        
+        // if any whitespaces are added - we should validate
+        guard emptyRawComponentsCount != emptyPrevRawComponentsCount else { return textNoNewlines }
+        
         let rawComponents = textNoNewlines.components(separatedBy: .whitespaces)
         let prevRawComponents = prevText.components(separatedBy: .whitespaces)
-        
-        let emptyRawComponentsCount = rawComponents.filter { $0.isEmpty }.count
-        let emptyPrevRawComponentsCount = prevRawComponents.filter { $0.isEmpty }.count
-        
-        guard emptyRawComponentsCount != emptyPrevRawComponentsCount else { return textNoNewlines }
         
         var suffix = ""
         if rawComponents.count > 1 && (rawComponents.last?.isEmpty ?? false) {

--- a/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextValidator.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextValidator.swift
@@ -12,17 +12,17 @@ struct PhraseTextValidator: PhraseTextValidatorProtocol {
     }
     
     func validated(prevText: String, text : String) -> String {
-        let textNoNewlines = text.trimmingCharacters(in: .newlines)
+        let textWithoutNewlines = text.trimmingCharacters(in: .newlines)
         
-        guard FeatureFlags.validateRecoveryPhrase else { return textNoNewlines }
+        guard FeatureFlags.validateRecoveryPhrase else { return textWithoutNewlines }
         
-        let emptyRawComponentsCount = textNoNewlines.filter { $0 == " " }.count
-        let emptyPrevRawComponentsCount = prevText.filter { $0 == " " }.count
+        let whitespacesTextCount = textWithoutNewlines.filter { $0 == " " }.count
+        let whitespacesPrevTextCount = prevText.filter { $0 == " " }.count
         
-        // if any whitespaces are added - we should validate
-        guard emptyRawComponentsCount != emptyPrevRawComponentsCount else { return textNoNewlines }
+        // if any whitespaces are added / deleted - we should validate
+        guard whitespacesTextCount != whitespacesPrevTextCount else { return textWithoutNewlines }
         
-        let rawComponents = textNoNewlines.components(separatedBy: .whitespaces)
+        let rawComponents = textWithoutNewlines.components(separatedBy: .whitespaces)
         let prevRawComponents = prevText.components(separatedBy: .whitespaces)
         
         var suffix = ""
@@ -39,8 +39,7 @@ struct PhraseTextValidator: PhraseTextValidatorProtocol {
             }
         }
         
-        let result = words.joined(separator: " ") + suffix
-                return result
+        return words.joined(separator: " ") + suffix
     }
     
 }

--- a/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextValidator.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextValidator.swift
@@ -1,3 +1,5 @@
+import AnytypeCore
+
 protocol PhraseTextValidatorProtocol {
     func validated(prevText: String, text : String) -> String
 }
@@ -11,7 +13,10 @@ struct PhraseTextValidator: PhraseTextValidatorProtocol {
     
     func validated(prevText: String, text : String) -> String {
         let textNoNewlines = text.trimmingCharacters(in: .newlines)
-                let rawComponents = textNoNewlines.components(separatedBy: .whitespaces)
+        
+        guard FeatureFlags.validateRecoveryPhrase else { return textNoNewlines }
+        
+        let rawComponents = textNoNewlines.components(separatedBy: .whitespaces)
         let prevRawComponents = prevText.components(separatedBy: .whitespaces)
         
         let emptyRawComponentsCount = rawComponents.filter { $0.isEmpty }.count

--- a/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextValidator.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextValidator.swift
@@ -1,0 +1,41 @@
+protocol PhraseTextValidatorProtocol {
+    func validated(prevText: String, text : String) -> String
+}
+
+struct PhraseTextValidator: PhraseTextValidatorProtocol {
+    
+    private enum Constants {
+        static let maxWordsCount = 12
+        static let maxCharactersPerWordCount = 8
+    }
+    
+    func validated(prevText: String, text : String) -> String {
+        let textNoNewlines = text.trimmingCharacters(in: .newlines)
+                let rawComponents = textNoNewlines.components(separatedBy: .whitespaces)
+        let prevRawComponents = prevText.components(separatedBy: .whitespaces)
+        
+        let emptyRawComponentsCount = rawComponents.filter { $0.isEmpty }.count
+        let emptyPrevRawComponentsCount = prevRawComponents.filter { $0.isEmpty }.count
+        
+        guard emptyRawComponentsCount != emptyPrevRawComponentsCount else { return textNoNewlines }
+        
+        var suffix = ""
+        if rawComponents.count > 1 && (rawComponents.last?.isEmpty ?? false) {
+            suffix = " "
+        }
+        
+        let rawWords = rawComponents.filter { $0.isNotEmpty }
+        let words = rawWords.prefix(Constants.maxWordsCount).map { word in
+            if word.count > Constants.maxCharactersPerWordCount {
+                return String(word.prefix(Constants.maxCharactersPerWordCount))
+            } else {
+                return word
+            }
+        }
+        
+        let result = words.joined(separator: " ") + suffix
+                return result
+    }
+    
+}
+

--- a/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextValidator.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextValidator.swift
@@ -23,7 +23,6 @@ struct PhraseTextValidator: PhraseTextValidatorProtocol {
         guard whitespacesTextCount != whitespacesPrevTextCount else { return textWithoutNewlines }
         
         let rawComponents = textWithoutNewlines.components(separatedBy: .whitespaces)
-        let prevRawComponents = prevText.components(separatedBy: .whitespaces)
         
         var suffix = ""
         if rawComponents.count > 1 && (rawComponents.last?.isEmpty ?? false) {

--- a/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextView.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextView.swift
@@ -7,9 +7,7 @@ struct PhraseTextView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UIPhraseTextView {
         let textView = UIPhraseTextView()
-        textView.textDidChange = { text in
-            self.text = text.trimmingCharacters(in: .newlines)
-        }
+        textView.textDidChange = context.coordinator.textDidChange(_:)
         textView.expandable = expandable
         return textView
     }
@@ -17,4 +15,26 @@ struct PhraseTextView: UIViewRepresentable {
     func updateUIView(_ textView: UIPhraseTextView, context: UIViewRepresentableContext<PhraseTextView>) {
         textView.update(with: text, alignToCenter: alignTextToCenter)
     }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator($text)
+    }
+}
+
+extension PhraseTextView {
+     
+    @MainActor
+    class Coordinator: NSObject {
+        @Binding var text: String
+        private let phraseTextValidator: PhraseTextValidatorProtocol = PhraseTextValidator()
+     
+        init(_ text: Binding<String>) {
+            _text = text
+        }
+        
+        func textDidChange(_ text: String) {
+            self.text = phraseTextValidator.validated(prevText: self.text, text: text)
+        }
+    }
+    
 }

--- a/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextView.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/PhraseTextView/PhraseTextView.swift
@@ -32,6 +32,7 @@ extension PhraseTextView {
             _text = text
         }
         
+        @MainActor
         func textDidChange(_ text: String) {
             self.text = phraseTextValidator.validated(prevText: self.text, text: text)
         }

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -82,6 +82,12 @@ public extension FeatureDescription {
         defaultValue: true
     )
     
+    static let validateRecoveryPhrase = FeatureDescription(
+        title: "Trim typed/inserted text in recovery phrase field",
+        type: .feature(author: "joe_pusya@anytype.io", releaseVersion: "0.24.0"),
+        defaultValue: true
+    )
+    
     // MARK: - Debug
     
     static let rainbowViews = FeatureDescription(

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/Generated/FeatureFlags+Flags.swift
@@ -58,6 +58,10 @@ public extension FeatureFlags {
         value(for: .superNewButtonLoadingState)
     }
 
+    static var validateRecoveryPhrase: Bool {
+        value(for: .validateRecoveryPhrase)
+    }
+
     static var rainbowViews: Bool {
         value(for: .rainbowViews)
     }
@@ -89,6 +93,7 @@ public extension FeatureFlags {
         .deleteObjectPlaceholder,
         .showAllFilesInBin,
         .superNewButtonLoadingState,
+        .validateRecoveryPhrase,
         .rainbowViews,
         .showAlertOnAssert,
         .analytics,


### PR DESCRIPTION
Validate typing and inserting recovery phrase - max 12 words + 8 characters per word, place it under the toggle.
Not so obvious in my opinion but we want to try how it will work.

https://github.com/anyproto/anytype-swift/assets/6065952/0b678fc5-7409-47fd-b1f3-809108e9449c

