### PR TITLE
Remove github token for downloading middleware

### DIFF
--- a/Scripts/ruby/workers/download_file_worker.rb
+++ b/Scripts/ruby/workers/download_file_worker.rb
@@ -10,7 +10,6 @@ class DownloadFileAtURLWorker
 
   def work
     headers = {}
-    headers["Authorization"] = "token #{token}"
     headers["Accept"] = "application/octet-stream"
     headersString = headers.map{|k, v| "-H '#{k}: #{v}'"}.join(' ')
     action = "curl -L -o #{filePath} #{headersString} #{url}"

--- a/Scripts/ruby/workers/remote_info_worker.rb
+++ b/Scripts/ruby/workers/remote_info_worker.rb
@@ -3,34 +3,17 @@ require 'json'
 
 require_relative '../constants'
 
-# version=`curl -H "Authorization: token $token" -H "Accept: application/vnd.github.v3+json" -sL https://$GITHUB/repos/$REPO/releases | jq ".[] | select(.tag_name == \"$MIDDLEWARE_VERSION_BY_TAG_NAME\")"`
+# version=`curl -H "Accept: application/vnd.github.v3+json" -sL https://$GITHUB/repos/$REPO/releases | jq ".[] | select(.tag_name == \"$MIDDLEWARE_VERSION_BY_TAG_NAME\")"`
 class GetRemoteInformationWorker
   attr_accessor :token
   def initialize(token)
     self.token = token
   end
 
-  def is_valid?
-    (self.token || '').empty? == false
-  end
-
   def work
-    unless is_valid?
-      puts <<-__REASON__
-      Access token does not exist. 
-      Please, provide it by cli argument or environment variable. 
-      Run `ruby #{$0} --help`
-      __REASON__
-      exit(1)
-    end
-    perform_work
-  end
-  
-  def perform_work
-    # fetch curl -H "Authorization: token Token" -H "Accept: application/vnd.github.v3+json" -sL https://api.github.com/repos/anytypeio/go-anytype-middleware/releases
+    # fetch curl -H "Accept: application/vnd.github.v3+json" -sL https://api.github.com/repos/anytypeio/go-anytype-middleware/releases
     uri = URI(Constants::REPOSITORY_URL)
     request = Net::HTTP::Get.new(uri)
-    request["Authorization"] = "token #{token}"
     request["Accept"] = "application/vnd.github.v3+json"
     response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http|
       http.request(request)


### PR DESCRIPTION




<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
Github authentication token is no longer needed since anytype-heart repo went public. I removed the lines that are responsible for requesting auth so that the `make setup-middle` works without the `--token` argument. 
For now, there are still traces of the `token` variable left in the ruby script since i kept the changes to a minimal and it's easier to revert if needed in the future. But let me know if you'd prefer a comprehensive rewrite.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
--

### Mobile & Desktop Screenshots/Recordings
--

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
