### PR TITLE
iOS-1614 Update JoinFlowState creating logic

### DIFF
--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/CreatingSoulView/CreatingSoulView.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/CreatingSoulView/CreatingSoulView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CreatingSoulView: View {
     
-    @ObservedObject var model: CreatingSoulViewModel
+    @StateObject var model: CreatingSoulViewModel
     @State private var showSpaceTitle = false
     
     var body: some View {

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/CreatingSoulView/CreatingSoulViewModuleAssembly.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/CreatingSoulView/CreatingSoulViewModuleAssembly.swift
@@ -21,8 +21,8 @@ final class CreatingSoulViewModuleAssembly: CreatingSoulViewModuleAssemblyProtoc
             model: CreatingSoulViewModel(
                 state: state,
                 output: output,
-                accountManager: serviceLocator.accountManager(),
-                subscriptionService: serviceLocator.singleObjectSubscriptionService()
+                accountManager: self.serviceLocator.accountManager(),
+                subscriptionService: self.serviceLocator.singleObjectSubscriptionService()
             )
         ).eraseToAnyView()
     }

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/JoinFlowCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/JoinFlowCoordinator.swift
@@ -16,10 +16,6 @@ final class JoinFlowCoordinator: JoinFlowCoordinatorProtocol, JoinFlowOutput {
     private let soulViewModuleAssembly: SoulViewModuleAssemblyProtocol
     private let creatingSoulViewModuleAssembly: CreatingSoulViewModuleAssemblyProtocol
     
-    // MARK: - State
-    
-    private let state = JoinFlowState()
-    
     init(
         joinFlowModuleAssembly: JoinFlowModuleAssemblyProtocol,
         voidViewModuleAssembly: VoidViewModuleAssemblyProtocol,
@@ -42,7 +38,7 @@ final class JoinFlowCoordinator: JoinFlowCoordinatorProtocol, JoinFlowOutput {
     
     // MARK: - JoinFlowOutput
     
-    func onStepChanged(_ step: JoinFlowStep, output: JoinFlowStepOutput) -> AnyView {
+    func onStepChanged(_ step: JoinFlowStep, state: JoinFlowState, output: JoinFlowStepOutput) -> AnyView {
         switch step {
         case .void:
             return voidViewModuleAssembly.make(state: state, output: output)

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/JoinFlowModuleAssembly.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/JoinFlowModuleAssembly.swift
@@ -20,7 +20,7 @@ final class JoinFlowModuleAssembly: JoinFlowModuleAssemblyProtocol {
         return JoinFlowView(
             model: JoinFlowViewModel(
                 output: output,
-                applicationStateService: serviceLocator.applicationStateService()
+                applicationStateService: self.serviceLocator.applicationStateService()
             )
         )
         .eraseToAnyView()

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/JoinFlowOutput.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/JoinFlowOutput.swift
@@ -3,6 +3,6 @@ import SwiftUI
 @MainActor
 protocol JoinFlowOutput: AnyObject {
     
-    func onStepChanged(_ step: JoinFlowStep, output: JoinFlowStepOutput) -> AnyView
+    func onStepChanged(_ step: JoinFlowStep, state: JoinFlowState, output: JoinFlowStepOutput) -> AnyView
     
 }

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/JoinFlowView.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/JoinFlowView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct JoinFlowView: View {
     
-    @ObservedObject var model: JoinFlowViewModel
+    @StateObject var model: JoinFlowViewModel
     @Environment(\.presentationMode) @Binding private var presentationMode
     
     var body: some View {

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/JoinFlowViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/JoinFlowViewModel.swift
@@ -25,6 +25,9 @@ final class JoinFlowViewModel: ObservableObject, JoinFlowStepOutput {
         "\(step.rawValue) / \(JoinFlowStep.totalCount)"
     }
     
+    // MARK: - State
+    private let state = JoinFlowState()
+    
     private weak var output: JoinFlowOutput?
     private let applicationStateService: ApplicationStateServiceProtocol
     
@@ -37,7 +40,7 @@ final class JoinFlowViewModel: ObservableObject, JoinFlowStepOutput {
     
     @ViewBuilder
     func content() -> some View {
-        output?.onStepChanged(step, output: self)
+        output?.onStepChanged(step, state: state, output: self)
     }
     
     // MARK: - JoinStepOutput

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/KeyPhraseView/KeyPhraseView.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/KeyPhraseView/KeyPhraseView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct KeyPhraseView: View {
     
-    @ObservedObject var model: KeyPhraseViewModel
+    @StateObject var model: KeyPhraseViewModel
     
     var body: some View {
         VStack(spacing: 0) {

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/KeyPhraseView/KeyPhraseViewModuleAssembly.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/KeyPhraseView/KeyPhraseViewModuleAssembly.swift
@@ -21,7 +21,7 @@ final class KeyPhraseViewModuleAssembly: KeyPhraseViewModuleAssemblyProtocol {
             model: KeyPhraseViewModel(
                 state: state,
                 output: output,
-                alertOpener: uiHelpersDI.alertOpener()
+                alertOpener: self.uiHelpersDI.alertOpener()
             )
         ).eraseToAnyView()
     }

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/SoulView/SoulView.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/SoulView/SoulView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct SoulView: View {
     
-    @ObservedObject var model: SoulViewModel
+    @StateObject var model: SoulViewModel
     
     var body: some View {
         VStack(spacing: 0) {

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/SoulView/SoulViewModuleAssembly.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/SoulView/SoulViewModuleAssembly.swift
@@ -21,8 +21,8 @@ final class SoulViewModuleAssembly: SoulViewModuleAssemblyProtocol {
             model: SoulViewModel(
                 state: state,
                 output: output,
-                accountManager: serviceLocator.accountManager(),
-                objectActionsService: serviceLocator.objectActionsService()
+                accountManager: self.serviceLocator.accountManager(),
+                objectActionsService: self.serviceLocator.objectActionsService()
             )
         ).eraseToAnyView()
     }

--- a/Anytype/Sources/PresentationLayer/New auth/JoinFlow/VoidView/VoidViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/New auth/JoinFlow/VoidView/VoidViewModel.swift
@@ -26,8 +26,12 @@ final class VoidViewModel: ObservableObject {
     }
     
     func onNextButtonTap() {
-        output?.disableBackAction(true)
-        createAccount()
+        if state.mnemonic.isEmpty {
+            output?.disableBackAction(true)
+            createAccount()
+        } else {
+            output?.onNext()
+        }
     }
     
     private func createAccount() {


### PR DESCRIPTION
Move `JoinFlowState` creating to the `JoinFlowViewModel` to recreate every time we go to the join flow + 
Replace `ObservedObject` with `StateObject` on the join flow 