### PR TITLE
iOS-1578 Remove redundant sorting for the options (tags / statuses)

### DIFF
--- a/Anytype/Sources/ServiceLayer/Object/Search/SearchService.swift
+++ b/Anytype/Sources/ServiceLayer/Object/Search/SearchService.swift
@@ -202,11 +202,6 @@ final class SearchService: ObservableObject, SearchServiceProtocol {
     }
 
     func searchRelationOptions(text: String, relationKey: String, excludedObjectIds: [String]) async throws -> [RelationOption] {
-        let sort = SearchHelper.sort(
-            relation: BundledRelationKey.name,
-            type: .asc
-        )
-
         var filters = buildFilters(
             isArchived: false,
             layouts: [DetailsLayout.relationOption]
@@ -214,7 +209,7 @@ final class SearchService: ObservableObject, SearchServiceProtocol {
         filters.append(SearchHelper.relationKey(relationKey))
         filters.append(SearchHelper.excludedIdsFilter(excludedObjectIds))
         
-        let details = try await search(filters: filters, sorts: [sort], fullText: text, limit: 0)
+        let details = try await search(filters: filters, sorts: [], fullText: text, limit: 0)
         return details.map { RelationOption(details: $0) }
     }
 


### PR DESCRIPTION
Remove sorting by name for options (it's actual for statuses and tags) to have the same behaviour like on desktop