### PR TITLE
iOS-1707 Support default type template if no activeview's template was selected

### DIFF
--- a/Anytype/Sources/Models/Extensions/ObjectType+Extensions.swift
+++ b/Anytype/Sources/Models/Extensions/ObjectType+Extensions.swift
@@ -14,7 +14,8 @@ extension ObjectType {
         isArchived: false,
         isDeleted: false,
         sourceObject: "",
-        recommendedRelations: []
+        recommendedRelations: [],
+        defaultTemplateId: ""
     )
     
 }

--- a/Anytype/Sources/PresentationLayer/Templates/Views/Selection/Objects/TemplatePreviewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Templates/Views/Selection/Objects/TemplatePreviewModel.swift
@@ -43,6 +43,17 @@ enum TemplateType: Equatable {
     case blank
     case addTemplate
     case installed(TemplateModel)
+    
+    var id: String {
+        switch self {
+        case .blank:
+            return "blank"
+        case .addTemplate:
+            return "Add template"
+        case let .installed(model):
+            return model.id
+        }
+    }
 }
 
 struct TemplatePreviewModel: Identifiable, Equatable {
@@ -53,14 +64,7 @@ struct TemplatePreviewModel: Identifiable, Equatable {
 
 extension TemplatePreviewModel: IdProvider {
     var id: BlockId {
-        switch mode {
-        case .blank:
-            return ""
-        case .addTemplate:
-            return "Add template"
-        case let .installed(model):
-            return model.id
-        }
+        mode.id
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/Templates/Views/Selection/TemplatesSelectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Templates/Views/Selection/TemplatesSelectionViewModel.swift
@@ -53,7 +53,7 @@ final class TemplatesSelectionViewModel: ObservableObject {
                 route: setDocument.isCollection() ? .collection : .set
             )
         case .blank:
-            onTemplateSelection(nil)
+            onTemplateSelection("")
             AnytypeAnalytics.instance().logTemplateSelection(
                 objectType: nil,
                 route: setDocument.isCollection() ? .collection : .set

--- a/Anytype/Sources/PresentationLayer/TextEditor/Assembly/EditorPageAssembly.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Assembly/EditorPageAssembly.swift
@@ -81,7 +81,8 @@ final class EditorAssembly {
             textService: serviceLocator.textService,
             groupsSubscriptionsHandler: serviceLocator.groupsSubscriptionsHandler(),
             setSubscriptionDataBuilder: SetSubscriptionDataBuilder(accountManager: serviceLocator.accountManager()),
-            setTemplatesInteractor: serviceLocator.setTemplatesInteractor
+            setTemplatesInteractor: serviceLocator.setTemplatesInteractor,
+            objectTypeProvider: serviceLocator.objectTypeProvider()
         )
         let controller = EditorSetHostingController(objectId: data.objectId, model: model)
         let navigationContext = NavigationContext(rootViewController: browser ?? controller)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -130,6 +130,7 @@ final class EditorSetViewModel: ObservableObject {
     private let groupsSubscriptionsHandler: GroupsSubscriptionsHandlerProtocol
     private let setSubscriptionDataBuilder: SetSubscriptionDataBuilderProtocol
     private let setTemplatesInteractor: SetTemplatesInteractorProtocol
+    private let objectTypeProvider: ObjectTypeProviderProtocol
     private var subscriptions = [AnyCancellable]()
     private var titleSubscription: AnyCancellable?
 
@@ -143,7 +144,8 @@ final class EditorSetViewModel: ObservableObject {
         textService: TextServiceProtocol,
         groupsSubscriptionsHandler: GroupsSubscriptionsHandlerProtocol,
         setSubscriptionDataBuilder: SetSubscriptionDataBuilderProtocol,
-        setTemplatesInteractor: SetTemplatesInteractorProtocol
+        setTemplatesInteractor: SetTemplatesInteractorProtocol,
+        objectTypeProvider: ObjectTypeProviderProtocol
     ) {
         self.setDocument = setDocument
         self.subscriptionService = subscriptionService
@@ -155,7 +157,7 @@ final class EditorSetViewModel: ObservableObject {
         self.groupsSubscriptionsHandler = groupsSubscriptionsHandler
         self.setSubscriptionDataBuilder = setSubscriptionDataBuilder
         self.setTemplatesInteractor = setTemplatesInteractor
-
+        self.objectTypeProvider = objectTypeProvider
         self.titleString = setDocument.details?.pageCellTitle ?? ""
     }
     
@@ -560,16 +562,18 @@ final class EditorSetViewModel: ObservableObject {
     }
     
     func createObject() {
-        createObject(selectedTemplateId: activeView.defaultTemplateID)
+        createObject(selectedTemplateId: nil)
     }
     
     func createObject(selectedTemplateId: BlockId?) {
         if setDocument.isCollection() {
+            let objectTypeId = setDocument.activeView.defaultObjectTypeIDWithFallback
+            let templateId = selectedTemplateId ?? defaultTemplateId(for: objectTypeId)
             createObject(
-                with: setDocument.activeView.defaultObjectTypeIDWithFallback,
+                with: objectTypeId,
                 shouldSelectType: true,
                 relationsDetails: [],
-                templateId: selectedTemplateId,
+                templateId: templateId,
                 completion: { details in
                     Task { @MainActor [weak self] in
                         guard let self else { return }
@@ -588,26 +592,38 @@ final class EditorSetViewModel: ObservableObject {
                 guard let source = self?.details?.setOf else { return false }
                 return source.contains(detail.id)
             }
+            let objectTypeId = setDocument.activeView.defaultObjectTypeIDWithFallback
+            let templateId = selectedTemplateId ?? defaultTemplateId(for: objectTypeId)
             createObject(
                 with: setDocument.activeView.defaultObjectTypeIDWithFallback,
                 shouldSelectType: true,
                 relationsDetails: relationsDetails,
-                templateId: selectedTemplateId,
+                templateId: templateId,
                 completion: { [weak self] details in
                     self?.openObject(details: details)
                 }
             )
         } else {
-            let type = details?.setOf.first ?? ""
+            let objectTypeId = details?.setOf.first ?? ""
+            let templateId = selectedTemplateId ?? defaultTemplateId(for: objectTypeId)
             createObject(
-                with: type,
-                shouldSelectType: type.isEmpty,
+                with: objectTypeId,
+                shouldSelectType: templateId.isEmpty,
                 relationsDetails: [],
-                templateId: selectedTemplateId,
+                templateId: templateId,
                 completion: { [weak self] details in
                     self?.handleCreatedObject(details: details)
                 }
             )
+        }
+    }
+    
+    private func defaultTemplateId(for objectTypeId: String) -> String {
+        if let defaultTemplateID = activeView.defaultTemplateID, defaultTemplateID.isNotEmpty {
+            let templateID = defaultTemplateID == TemplateType.blank.id ? "" : defaultTemplateID
+            return templateID
+        } else {
+            return objectTypeProvider.objectType(id: objectTypeId)?.defaultTemplateId ?? ""
         }
     }
     
@@ -853,6 +869,7 @@ extension EditorSetViewModel {
         textService: TextService(),
         groupsSubscriptionsHandler: DI.preview.serviceLocator.groupsSubscriptionsHandler(),
         setSubscriptionDataBuilder: SetSubscriptionDataBuilder(accountManager: DI.preview.serviceLocator.accountManager()),
-        setTemplatesInteractor: DI.preview.serviceLocator.setTemplatesInteractor
+        setTemplatesInteractor: DI.preview.serviceLocator.setTemplatesInteractor,
+        objectTypeProvider: DI.preview.serviceLocator.objectTypeProvider()
     )
 }

--- a/Anytype/Sources/ServiceLayer/Object/ObjectType/ObjectTypeProvider.swift
+++ b/Anytype/Sources/ServiceLayer/Object/ObjectType/ObjectTypeProvider.swift
@@ -3,6 +3,7 @@ import Services
 import ProtobufMessages
 import Combine
 
+
 extension ObjectType: IdProvider {}
 
 final class ObjectTypeProvider: ObjectTypeProviderProtocol {
@@ -20,6 +21,7 @@ final class ObjectTypeProvider: ObjectTypeProviderProtocol {
     private let subscriptionBuilder: ObjectTypeSubscriptionDataBuilderProtocol
     
     private(set) var objectTypes = [ObjectType]()
+    
     private var searchTypesById = SynchronizedDictionary<String, ObjectType>()
     
     private init(
@@ -35,6 +37,9 @@ final class ObjectTypeProvider: ObjectTypeProviderProtocol {
     @Published
     var defaultObjectType: ObjectType = .fallbackType
     var defaultObjectTypePublisher: AnyPublisher<ObjectType, Never> { $defaultObjectType.eraseToAnyPublisher() }
+    
+    @Published var sync: () = ()
+    var syncPublisher: AnyPublisher<Void, Never> { $sync.eraseToAnyPublisher() }
     
     func setDefaulObjectType(type: ObjectType) {
         UserDefaultsConfig.defaultObjectType = type
@@ -57,7 +62,8 @@ final class ObjectTypeProvider: ObjectTypeProviderProtocol {
             isArchived: false,
             isDeleted: true,
             sourceObject: "",
-            recommendedRelations: []
+            recommendedRelations: [],
+            defaultTemplateId: ""
         )
     }
     
@@ -78,6 +84,7 @@ final class ObjectTypeProvider: ObjectTypeProviderProtocol {
     private func handleEvent(update: SubscriptionUpdate) {
         objectTypes.applySubscriptionUpdate(update, transform: { ObjectType(details: $0) })
         updateAllCache()
+        sync = ()
     }
     
     private func updateAllCache() {

--- a/Anytype/Sources/ServiceLayer/Object/ObjectType/ObjectTypeProvider.swift
+++ b/Anytype/Sources/ServiceLayer/Object/ObjectType/ObjectTypeProvider.swift
@@ -3,7 +3,6 @@ import Services
 import ProtobufMessages
 import Combine
 
-
 extension ObjectType: IdProvider {}
 
 final class ObjectTypeProvider: ObjectTypeProviderProtocol {
@@ -21,7 +20,6 @@ final class ObjectTypeProvider: ObjectTypeProviderProtocol {
     private let subscriptionBuilder: ObjectTypeSubscriptionDataBuilderProtocol
     
     private(set) var objectTypes = [ObjectType]()
-    
     private var searchTypesById = SynchronizedDictionary<String, ObjectType>()
     
     private init(

--- a/Anytype/Sources/ServiceLayer/Object/ObjectType/ObjectTypeProviderProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/Object/ObjectType/ObjectTypeProviderProtocol.swift
@@ -9,6 +9,8 @@ protocol ObjectTypeProviderProtocol: AnyObject {
     var defaultObjectTypePublisher: AnyPublisher<ObjectType, Never> { get }
     func setDefaulObjectType(type: ObjectType)
     
+    var syncPublisher: AnyPublisher<Void, Never> { get }
+    
     func objectType(id: String) -> ObjectType?
     func deleteObjectType(id: String) -> ObjectType
         

--- a/Anytype/Sources/ServiceLayer/Object/ObjectType/Subscription/ObjectTypeSubscriptionDataBuilder.swift
+++ b/Anytype/Sources/ServiceLayer/Object/ObjectType/Subscription/ObjectTypeSubscriptionDataBuilder.swift
@@ -35,7 +35,8 @@ final class ObjectTypeSubscriptionDataBuilder: ObjectTypeSubscriptionDataBuilder
             BundledRelationKey.isArchived.rawValue,
             BundledRelationKey.smartblockTypes.rawValue,
             BundledRelationKey.sourceObject.rawValue,
-            BundledRelationKey.recommendedRelations.rawValue
+            BundledRelationKey.recommendedRelations.rawValue,
+            BundledRelationKey.defaultTemplateId.rawValue
         ]
 
         return .search(

--- a/Modules/Services/Sources/Models/ObjectType.swift
+++ b/Modules/Services/Sources/Models/ObjectType.swift
@@ -21,6 +21,7 @@ public struct ObjectType: Equatable, Hashable, Codable {
     public let isArchived: Bool
     public let isDeleted: Bool
     public let sourceObject: String
+    public let defaultTemplateId: String
     
     public let recommendedRelations: [ObjectId]
     
@@ -35,7 +36,8 @@ public struct ObjectType: Equatable, Hashable, Codable {
         isArchived: Bool,
         isDeleted: Bool,
         sourceObject: String,
-        recommendedRelations: [ObjectId]
+        recommendedRelations: [ObjectId],
+        defaultTemplateId: String
     ) {
         self.id = id
         self.name = name
@@ -48,6 +50,7 @@ public struct ObjectType: Equatable, Hashable, Codable {
         self.isDeleted = isDeleted
         self.sourceObject = sourceObject
         self.recommendedRelations = recommendedRelations
+        self.defaultTemplateId = defaultTemplateId
     }
 }
 
@@ -65,7 +68,8 @@ extension ObjectType {
             isArchived: details.isArchived,
             isDeleted: details.isDeleted,
             sourceObject: details.sourceObject,
-            recommendedRelations: details.recommendedRelations
+            recommendedRelations: details.recommendedRelations,
+            defaultTemplateId: details.defaultTemplateId
         )
     }
     


### PR DESCRIPTION
1. Support object type default template if no activeview's template was selected
2. Support object type default templates changing via subscription to objectTypeProvider.syncPublisher
3. Add logic with `blank` to make difference with ""