### PR TITLE
IOS-1945 Space Switch | Fix shadow for long tap

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceSwitch/Components/SpacePlusRow.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceSwitch/Components/SpacePlusRow.swift
@@ -10,7 +10,7 @@ struct SpacePlusRow: View {
             .frame(width: 96, height: 96)
             .foregroundColor(.Text.white)
             .background(.white.opacity(0.2))
-            .cornerRadius(8, style: .continuous)
+            .cornerRadius(2, style: .continuous)
             .onTapGesture {
                 onTap()
             }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceSwitch/Components/SpaceRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceSwitch/Components/SpaceRowView.swift
@@ -23,6 +23,11 @@ struct SpaceRowView: View {
     var body: some View {
         VStack {
             ZStack {
+                // Fix shadow for contextMenu
+                Color.black
+                    .cornerRadius(2)
+                    .frame(width: Self.width, height: Self.width)
+                    .shadow(color: .Shadow.primary, radius: 20)
                 ZStack {
                     // Outer border
                     if model.isSelected {
@@ -31,7 +36,6 @@ struct SpaceRowView: View {
                     }
                     IconView(icon: model.icon)
                         .frame(width: Self.width, height: Self.width)
-                        .shadow(color: .Shadow.primary, radius: 20)
                 }
                 .frame(width: Self.width + additionalSize, height: Self.width + additionalSize)
                 .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 2))


### PR DESCRIPTION
Example - RED shadow

Bug

https://github.com/anyproto/anytype-swift/assets/2483784/1e87208d-b4f7-4c90-a665-6b33e58e96df


Fix


https://github.com/anyproto/anytype-swift/assets/2483784/f007ffe7-de2e-4b25-bba9-ed8a377641a1


