### PR TITLE
iOS-2096 Update widgets bg color in dark mode

### DIFF
--- a/Anytype/Resources/SystemColors.xcassets/Widget/card.colorset/Contents.json
+++ b/Anytype/Resources/SystemColors.xcassets/Widget/card.colorset/Contents.json
@@ -23,8 +23,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x35",
-          "green" : "0x39",
+          "blue" : "0x3A",
+          "green" : "0x3A",
           "red" : "0x3A"
         }
       },


### PR DESCRIPTION
<img src='https://github.com/anyproto/anytype-swift/assets/6065952/b08ec688-8ba7-4185-9ac6-4672dd69ae18' width='200'>
