### PR TITLE
iOS-2113 Subscribe on objectType updates in BaseDocument

### DIFF
--- a/Anytype/Sources/ServiceLayer/DocumentsProvider/DocumentsProvider.swift
+++ b/Anytype/Sources/ServiceLayer/DocumentsProvider/DocumentsProvider.swift
@@ -72,7 +72,8 @@ final class DocumentsProvider: DocumentsProviderProtocol {
             objectId: objectId,
             forPreview: forPreview,
             blockActionsService: blockActionsService,
-            relationDetailsStorage: relationDetailsStorage
+            relationDetailsStorage: relationDetailsStorage, 
+            objectTypeProvider: objectTypeProvider
         )
     }
 }


### PR DESCRIPTION
We should add it to BaseDocument subscriptions for changing type in document from Anytype Library. 
Otherwise it look like deleted
<img src='https://github.com/anyproto/anytype-swift/assets/6065952/e6f1a1d6-490f-459f-a54f-b45ae5b9cf47' width='200'>
