### PR TITLE
IOS-2205 Add robust error message for make install

### DIFF
--- a/Scripts/middle-install.sh
+++ b/Scripts/middle-install.sh
@@ -24,10 +24,23 @@ else
 fi
 
 curl https://maven.pkg.github.com/anyproto/anytype-heart/io.anyproto/anytype-heart-ios/${MIDDLE_VERSION}/anytype-heart-ios-${MIDDLE_VERSION}.gz -f --header "Authorization: token ${token}" -L --output ${PROJECT_DIR}/lib.gz
-rm -rf ${PROJECT_DIR}/Dependencies/Middleware/*
-mkdir -p ${PROJECT_DIR}/Dependencies/Middleware
-tar xzf lib.gz -C ${PROJECT_DIR}/Dependencies/Middleware
-rm lib.gz
 
-rm -rf ${PROJECT_DIR}/Modules/ProtobufMessages/Sources/Protocol/*
-cp -r ${PROJECT_DIR}/Dependencies/Middleware/protobuf/*.swift ${PROJECT_DIR}/Modules/ProtobufMessages/Sources/Protocol
+if [ $?  -eq  0 ]
+then
+    rm -rf ${PROJECT_DIR}/Dependencies/Middleware/*
+    mkdir -p ${PROJECT_DIR}/Dependencies/Middleware
+    tar xzf lib.gz -C ${PROJECT_DIR}/Dependencies/Middleware
+    rm lib.gz
+
+    rm -rf ${PROJECT_DIR}/Modules/ProtobufMessages/Sources/Protocol/*
+    cp -r ${PROJECT_DIR}/Dependencies/Middleware/protobuf/*.swift ${PROJECT_DIR}/Modules/ProtobufMessages/Sources/Protocol
+
+    GREEN='\033[0;32m'
+    printf "${GREEN}Success"
+    echo -e "\a" # play sound
+else
+    RED='\033[0;31m'
+    TERMINATOR='\n\e[0m'
+    printf "${RED}Error downloading middleware, check out token provided${TERMINATOR}"
+    printf "use \"make change-github-token\" command to update token"
+fi


### PR DESCRIPTION
Added error validation for middleware download for more user friendly setup. Based on my own experience.