### PR TITLE
iOS-2376 Editor | Refactoring fixes | Remove redundant params

### DIFF
--- a/AnyTypeTests/Text/KeyboardActionHandlerTests.swift
+++ b/AnyTypeTests/Text/KeyboardActionHandlerTests.swift
@@ -546,8 +546,7 @@ class KeyboardActionHandlerTests: XCTestCase {
         let childInfo = info(id:"", style: .bulleted, hasChild: false, parent: nil, horizontalAlignment: .left)
 
         let string = NSAttributedString(string: "Title text")
-        handler.handle(info: blockInfo, textView: textView,
-                       action: .enterAtTheBegining(string: string, NSRange(location: 0, length: 0)))
+        handler.handle(info: blockInfo, textView: textView, action: .enterAtTheBegining)
         
         XCTAssertEqual(service.addNumberOfCalls, 1)
         XCTAssertEqual(service.addInfo, childInfo)
@@ -562,8 +561,7 @@ class KeyboardActionHandlerTests: XCTestCase {
         let childInfo = info(id:"", style: .toggle, hasChild: false, parent: nil, horizontalAlignment: .left)
         
         let string = NSAttributedString(string: "Toogle")
-        handler.handle(info: blockInfo, textView: textView,
-                       action: .enterAtTheBegining(string: string, NSRange(location: 0, length: 0)))
+        handler.handle(info: blockInfo, textView: textView, action: .enterAtTheBegining)
         
         XCTAssertEqual(service.addNumberOfCalls, 1)
         XCTAssertEqual(service.addInfo, childInfo)
@@ -578,8 +576,7 @@ class KeyboardActionHandlerTests: XCTestCase {
         let childInfo = info(id:"", style: .title, hasChild: false, parent: nil, horizontalAlignment: .left)
         
         let string = NSAttributedString(string: "Title text")
-        handler.handle(info: blockInfo, textView: textView,
-                       action: .enterAtTheBegining(string: string, NSRange(location: 0, length: 0)))
+        handler.handle(info: blockInfo, textView: textView, action: .enterAtTheBegining)
 
         XCTAssertEqual(service.addNumberOfCalls, 1)
         XCTAssertEqual(service.addInfo, childInfo)
@@ -595,8 +592,7 @@ class KeyboardActionHandlerTests: XCTestCase {
         let childInfo = info(id:"", style: .description, hasChild: false, parent: nil, horizontalAlignment: .left)
         
         let string = NSAttributedString(string: text)
-        handler.handle(info: blockInfo, textView: textView,
-                       action: .enterAtTheBegining(string: string, NSRange(location: 0, length: 0)))
+        handler.handle(info: blockInfo, textView: textView, action: .enterAtTheBegining)
 
         XCTAssertEqual(service.addNumberOfCalls, 1)
         XCTAssertEqual(service.addInfo, childInfo)

--- a/Anytype/Sources/PresentationLayer/Common/UIKit/TextView/Models/CustomTextViewKeyboardAction.swift
+++ b/Anytype/Sources/PresentationLayer/Common/UIKit/TextView/Models/CustomTextViewKeyboardAction.swift
@@ -6,7 +6,7 @@ extension CustomTextView {
         case enterForEmpty
         case enterInside(string: NSAttributedString, NSRange)
         case enterAtTheEnd(string: NSAttributedString, NSRange)
-        case enterAtTheBegining(string: NSAttributedString, NSRange)
+        case enterAtTheBegining
         
         case delete
     }
@@ -32,7 +32,7 @@ extension CustomTextView.KeyboardAction {
             }
             
             if text.startIndex == textRange.lowerBound {
-                return .enterAtTheBegining(string: attributedText, range)
+                return .enterAtTheBegining
             }
             
             return .enterInside(string: attributedText, range)

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/KeyboardActionHandler/KeyboardActionHandler.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/KeyboardActionHandler/KeyboardActionHandler.swift
@@ -96,7 +96,7 @@ final class KeyboardActionHandler: KeyboardActionHandlerProtocol {
             }
             onEnterAtTheEndOfContent(info: info, text: text, range: range, action: action, newString: string)
             editorCollectionController.scrollToTextViewIfNotVisible(textView: textView)
-        case let .enterAtTheBegining(_, range):
+        case .enterAtTheBegining:
             service.add(
                 info: .empty(content: .text(.empty(contentType: text.contentType))),
                 targetBlockId: info.id,


### PR DESCRIPTION
Logic was changed, now we add new block above current block instead of split when set Enter in the beginning (`enterAtTheBegining`), so we don't need range and string