### PR TITLE
iOS-2515 Fix collection view diffing warning and crash

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedRelationsBlockViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedRelationsBlockViewModel.swift
@@ -26,7 +26,7 @@ final class FeaturedRelationsBlockViewModel: BlockViewModelProtocol {
         self.collectionController = collectionController
         self.onRelationTap = onRelationValueTap
         
-        document.featuredRelationsForEditorPublisher.sink { [weak self] newFeaturedRelations in
+        document.featuredRelationsForEditorPublisher.receiveOnMain().sink { [weak self] newFeaturedRelations in
             guard let self else { return }
             if featuredRelationValues != newFeaturedRelations {
                 self.featuredRelationValues = newFeaturedRelations

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/TableOfContents/TableOfContentsView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/TableOfContents/TableOfContentsView.swift
@@ -33,6 +33,7 @@ final class TableOfContentsView: UIView, BlockContentView {
             .$content
             .dropFirst()
             .removeDuplicates()
+            .receiveOnMain()
             .sink { [weak self] content in
                 self?.updateView(content: content)
                 

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Code/CodeBlockViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Code/CodeBlockViewModel.swift
@@ -29,7 +29,7 @@ struct CodeBlockViewModel: BlockViewModelProtocol {
             anytypeText: anytypeText,
             backgroundColor: info.backgroundColor,
             codeLanguage: codeLanguage,
-            actions: .init(
+            actions: CodeBlockContentConfiguration.Actions(
                 becomeFirstResponder: { becomeFirstResponder(info) },
                 textDidChange: { textView in
                     handler.changeText(textView.attributedText, blockId: info.id)


### PR DESCRIPTION
⚠️ Warning

`Warning: applying updates in a non-thread confined manner is dangerous and can lead to deadlocks. Please always submit updates either always on the main queue or always off the main queue - view=<Anytype.EditorCollectionView: 0x12c046400; baseClass = UICollectionView; frame = (0 0; 430 932); clipsToBounds = YES; gestureRecognizers = <NSArray: 0x600000caed90>; backgroundColor = UIExtendedGrayColorSpace 0 0; layer = <CALayer: 0x600000288ec0>; contentOffset: {0, 0}; contentSize: {430, 623}; adjustedContentInset: {0, 0, 184, 0}; layout: <Anytype.EditorCollectionFlowLayout: 0x12652e590>; dataSource: <TtGC5UIKit34UICollectionViewDiffableDataSourceO7Anytype13EditorSectionOS1_10EditorItem: 0x60000000f3c0>>`

💥 Crash

`*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Deadlock detected: calling this method on the main queue with outstanding async updates is not permitted and will deadlock. Please always submit updates either always on the main queue or always off the main queue - view=<Anytype.EditorCollectionView: 0x12d0c6000; baseClass = UICollectionView; frame = (0 0; 430 932); clipsToBounds = YES; gestureRecognizers = <NSArray: 0x600000cea640>; backgroundColor = UIExtendedGrayColorSpace 0 0; layer = <CALayer: 0x60000031c1c0>; contentOffset: {0, 0}; contentSize: {430, 582}; adjustedContentInset: {0, 0, 184, 0}; layout: <Anytype.EditorCollectionFlowLayout: 0x10685db00>; dataSource: <TtGC5UIKit34UICollectionViewDiffableDataSourceO7Anytype13EditorSectionOS1_10EditorItem: 0x60000003c2b0>>'`