### PR TITLE
iOS-2383 Disable trackingSessionEvents

### DIFF
--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics.swift
@@ -29,12 +29,9 @@ final class AnytypeAnalytics: AnytypeAnalyticsProtocol {
     
     private init() {
         // Disable IDFA/IPAddress for Amplitude
-        if let trackingOptions = AMPTrackingOptions().disableIDFA().disableIPAddress(){
+        if let trackingOptions = AMPTrackingOptions().disableIDFA().disableIPAddress() {
             Amplitude.instance().setTrackingOptions(trackingOptions)
         }
-
-        // Enable sending automatic session events
-        Amplitude.instance().trackingSessionEvents = true
         
         userProperties[Keys.interfaceLang] = Locale.current.languageCode
     }


### PR DESCRIPTION
This events were sent only by iOS and they sometimes overestimate retention, Vadim asked to remove this events from the app