### PR TITLE
iOS-2584 Fix PassthroughSubjectDictionary crash on the start

### DIFF
--- a/Modules/AnytypeCore/AnytypeCore/Utils/Publishers/PublishedDictionary.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/Publishers/PublishedDictionary.swift
@@ -3,7 +3,7 @@ import Combine
 
 public final class PassthroughSubjectDictionary<K, V> where K: Hashable, V: Equatable {
     
-    private var dictionary = SynchronizedDictionary<K, AnytypePassthroughSubject<V?>>()
+    private let dictionary = SynchronizedDictionary<K, AnytypePassthroughSubject<V?>>()
 
     public init() {}
     
@@ -29,7 +29,7 @@ public final class PassthroughSubjectDictionary<K, V> where K: Hashable, V: Equa
     }
     
     public func publishAllValues() {
-        dictionary.dictionary.values.forEach { $0.sendUpdate() }
+        dictionary.values.forEach { $0.sendUpdate() }
     }
     
     public func publishValue(for key: K) {

--- a/Modules/AnytypeCore/AnytypeCore/Utils/Synchronized colections/SynchronizedDictionary.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/Synchronized colections/SynchronizedDictionary.swift
@@ -3,10 +3,9 @@ import Foundation
 
 public final class SynchronizedDictionary<K, V> where K: Hashable {
 
-    var dictionary: [K: V] = [:]
-
     // MARK: - Private variables
-
+    
+    private var dictionary: [K: V] = [:]
     private let lock = NSLock()
 
     // MARK: - Initializers
@@ -44,6 +43,14 @@ public final class SynchronizedDictionary<K, V> where K: Hashable {
         lock.unlock()
         
         return keys
+    }
+    
+    public var values: Dictionary<K, V>.Values {
+        lock.lock()
+        let values = dictionary.values
+        lock.unlock()
+        
+        return values
     }
     
     public func removeAll() {


### PR DESCRIPTION
Sometimes it crashes on the start in `publishAllValues`