### PR TITLE
iOS-2596 Remove edit/+ buttons in Relations list when object is locked

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/RelationsListView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/RelationsListView.swift
@@ -16,11 +16,17 @@ struct RelationsListView: View {
     
     private var navigationBar: some View {
         HStack {
-            editButton
+            if !viewModel.navigationBarButtonsDisabled {
+                editButton
+            }
+            
             Spacer()
             AnytypeText(Loc.relations, style: .uxTitle1Semibold, color: .Text.primary)
             Spacer()
-            createNewRelationButton
+            
+            if !viewModel.navigationBarButtonsDisabled {
+                createNewRelationButton
+            }
         }
         .frame(height: 48)
         .padding(.horizontal, 16)
@@ -35,10 +41,9 @@ struct RelationsListView: View {
             AnytypeText(
                 editingMode ? Loc.done : Loc.edit,
                 style: .uxBodyRegular,
-                color: viewModel.navigationBarButtonsDisabled ? .Button.inactive : .Text.secondary
+                color: .Text.secondary
             )
         }
-        .disabled(viewModel.navigationBarButtonsDisabled)
     }
     
     private var createNewRelationButton: some View {
@@ -46,9 +51,8 @@ struct RelationsListView: View {
             viewModel.showAddNewRelationView()
         } label: {
             Image(asset: .X32.plus)
-                .foregroundColor(viewModel.navigationBarButtonsDisabled ? .Button.inactive : .Button.active)
+                .foregroundColor(.Button.active)
         }
-        .disabled(viewModel.navigationBarButtonsDisabled)
     }
     
     private var relationsList: some View {


### PR DESCRIPTION
<img src='https://github.com/anyproto/anytype-swift/assets/6065952/a7dea587-8fe2-454b-8d4a-cf086148649d' width='300'>
