### PR TITLE
IOS-2718 Core | Rename debug project

### DIFF
--- a/Anytype.xcodeproj/project.pbxproj
+++ b/Anytype.xcodeproj/project.pbxproj
@@ -1765,7 +1765,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0303ECFB22D8EDAA005C552B /* Anytype Dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Anytype Dev.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0303ECFB22D8EDAA005C552B /* Anytype.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Anytype.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0303ECFE22D8EDAA005C552B /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0303ED0022D8EDAA005C552B /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		0303ED0422D8EDAD005C552B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Anytype/Resources/Assets.xcassets; sourceTree = SOURCE_ROOT; };
@@ -3552,7 +3552,7 @@
 		0303ECFC22D8EDAA005C552B /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				0303ECFB22D8EDAA005C552B /* Anytype Dev.app */,
+				0303ECFB22D8EDAA005C552B /* Anytype.app */,
 				03C5C54022DFD90C00DD91DE /* AnytypeTests.xctest */,
 				C960DFA928D88615002898AE /* AnytypeWidgetExtension.appex */,
 				862D55902A8F78330018103F /* AnytypeShareExtension.appex */,
@@ -10400,7 +10400,7 @@
 				2A30B2072BB44A0C00206806 /* QRCode */,
 			);
 			productName = Anytype;
-			productReference = 0303ECFB22D8EDAA005C552B /* Anytype Dev.app */;
+			productReference = 0303ECFB22D8EDAA005C552B /* Anytype.app */;
 			productType = "com.apple.product-type.application";
 		};
 		03C5C53F22DFD90C00DD91DE /* AnytypeTests */ = {
@@ -12545,6 +12545,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				BUILD_APP_URL_SCHEME = "dev-anytype";
+				BUNDLE_NAME = "$(TARGET_NAME) Dev";
 				CODE_SIGN_ENTITLEMENTS = Anytype/Anytype.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
@@ -12569,7 +12570,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ConciseMagicFile";
 				PRODUCT_BUNDLE_IDENTIFIER = io.anytype.app.dev;
-				PRODUCT_NAME = "$(TARGET_NAME) Dev";
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development io.anytype.app.dev";
 				SENTRY_ENV = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -12589,6 +12590,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				BUILD_APP_URL_SCHEME = "prod-anytype";
+				BUNDLE_NAME = "$(TARGET_NAME)";
 				CODE_SIGN_ENTITLEMENTS = Anytype/Anytype.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
@@ -12745,6 +12747,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				BUILD_APP_URL_SCHEME = "dev-anytype";
+				BUNDLE_NAME = "$(TARGET_NAME) Dev";
 				CODE_SIGN_ENTITLEMENTS = Anytype/Anytype.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;

--- a/Anytype.xcodeproj/project.pbxproj
+++ b/Anytype.xcodeproj/project.pbxproj
@@ -1765,7 +1765,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0303ECFB22D8EDAA005C552B /* Anytype.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Anytype.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0303ECFB22D8EDAA005C552B /* Anytype Dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Anytype Dev.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0303ECFE22D8EDAA005C552B /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0303ED0022D8EDAA005C552B /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		0303ED0422D8EDAD005C552B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Anytype/Resources/Assets.xcassets; sourceTree = SOURCE_ROOT; };
@@ -3552,7 +3552,7 @@
 		0303ECFC22D8EDAA005C552B /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				0303ECFB22D8EDAA005C552B /* Anytype.app */,
+				0303ECFB22D8EDAA005C552B /* Anytype Dev.app */,
 				03C5C54022DFD90C00DD91DE /* AnytypeTests.xctest */,
 				C960DFA928D88615002898AE /* AnytypeWidgetExtension.appex */,
 				862D55902A8F78330018103F /* AnytypeShareExtension.appex */,
@@ -10400,7 +10400,7 @@
 				2A30B2072BB44A0C00206806 /* QRCode */,
 			);
 			productName = Anytype;
-			productReference = 0303ECFB22D8EDAA005C552B /* Anytype.app */;
+			productReference = 0303ECFB22D8EDAA005C552B /* Anytype Dev.app */;
 			productType = "com.apple.product-type.application";
 		};
 		03C5C53F22DFD90C00DD91DE /* AnytypeTests */ = {
@@ -12569,7 +12569,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ConciseMagicFile";
 				PRODUCT_BUNDLE_IDENTIFIER = io.anytype.app.dev;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(TARGET_NAME) Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development io.anytype.app.dev";
 				SENTRY_ENV = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -12769,7 +12769,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ConciseMagicFile";
 				PRODUCT_BUNDLE_IDENTIFIER = io.anytype.app.dev;
-				PRODUCT_NAME = "Anytype Dev";
+				PRODUCT_NAME = "$(TARGET_NAME) Dev";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore io.anytype.app.dev";
 				SENTRY_ENV = development;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Anytype/Supporting files/Info.plist
+++ b/Anytype/Supporting files/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>$(BUNDLE_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>

--- a/fastlane/FastfileDeploy
+++ b/fastlane/FastfileDeploy
@@ -95,7 +95,6 @@ platform :ios do
       )
     end
 
-    build_name = options[:release] ? "Anytype" : "Anytype Dev"
     dsym_paths = []
     Dir.chdir("..") do
       dsym_paths = Dir["./build/result/*.dSYM.zip"]


### PR DESCRIPTION
If you build release and dev for simulator or device by cabel, difficult to understand where is which build. This change fixed it
![Simulator Screenshot - iPhone 15 Pro (member) - 2024-04-19 at 14 00 57](https://github.com/anyproto/anytype-swift/assets/2483784/3a065f7c-9f82-4af3-b1b0-e35c685f55b1)
