### PR TITLE
IOS-2053 Editor | Fix numeric list

### DIFF
--- a/Anytype/Sources/Models/Documents/Events/EventsListener.swift
+++ b/Anytype/Sources/Models/Documents/Events/EventsListener.swift
@@ -94,13 +94,13 @@ final class EventsListener: EventsListenerProtocol {
         let localUpdates = events.localEvents.compactMap { localConverter.convert($0) }
         let markupUpdates = [mentionMarkupEventProvider.updateMentionsEvent()].compactMap { $0 }
 
-        let updates = middlewareUpdates + markupUpdates + localUpdates
-        
-        IndentationBuilder.build(
+        let builderChangedIds = IndentationBuilder.build(
             container: infoContainer,
             id: objectId
         )
-
+        let builderUpdates: [DocumentUpdate] = builderChangedIds.isNotEmpty ? [.blocks(blockIds: Set(builderChangedIds))] : []
+    
+        let updates = middlewareUpdates + markupUpdates + localUpdates + builderUpdates
         receiveUpdates(updates.filteredUpdates)
     }
     

--- a/Modules/Services/Sources/Models/Block/IndentationBuilder.swift
+++ b/Modules/Services/Sources/Models/Block/IndentationBuilder.swift
@@ -75,12 +75,12 @@ public enum IndentationBuilder {
             return child.updated(content: content)
         // Ignore reset value between items in one level.
         // Example. Two div, but there are one numeric list.
-        // div(2)
-        //   text num
-        //   text num
-        // div(3) <- Don't reset num value here for use numberValue in childs
-        //   text num
-        //   text num
+        // div(2) <- This item contains text num(2) value
+        //   text num(1)
+        //   text num(2)
+        // div(3) <- This item using div(1) final num value for child items.
+        //   text num(3)
+        //   text num(4)
         case let .layout(style) where style == BlockLayout(style: .div):
             break
         default:

--- a/Modules/Services/Sources/Models/Block/IndentationBuilder.swift
+++ b/Modules/Services/Sources/Models/Block/IndentationBuilder.swift
@@ -1,20 +1,23 @@
 import Foundation
 
 public enum IndentationBuilder {
-    public static func build(container: InfoContainerProtocol, id: String) {
-        privateBuild(container: container, id: id)
+    public static func build(container: InfoContainerProtocol, id: String) -> [String] {
+        var numberValue = 0
+        return privateBuild(container: container, numberValue: &numberValue, id: id)
     }
 
     private static func privateBuild(
         container: InfoContainerProtocol,
+        numberValue: inout Int,
         id: String
-    ) {
+    ) -> [String] {
+        var changedIds = [String]()
         if let parent = container.get(id: id) {
-            var updatedBlockNumber = 0
 
             parent.childrenIds.forEach { childrenId in
+                
                 guard let child = container.get(id: childrenId) else { return }
-
+                
                 let updatedMetadataChild = child.updated(
                     metadata: BlockInformationMetadata(
                         parentId: parent.id,
@@ -24,26 +27,43 @@ public enum IndentationBuilder {
 
 
                 let updatedChild = updatedNumberedValueIfNeeded(
-                    container: container,
                     child: updatedMetadataChild,
-                    numberValue: &updatedBlockNumber
+                    numberValue: &numberValue
                 )
 
                 if child != updatedChild {
                     container.add(updatedChild)
+                    changedIds.append(childrenId)
                 }
+                
+                // Don't reset value between parent-child for div
+                // Example.
+                // div(1)
+                //   text num
+                //   text num <- Copy this value to next parent div(2)
+                // div(2) <- Use value here
+                //   text num
+                //   text num
+                let useNumberFromParent = child.content == BlockContent.layout(BlockLayout(style: .div))
+                var childNumberValue = useNumberFromParent ? numberValue : 0
 
-                privateBuild(
+                let childChangesIds = privateBuild(
                     container: container,
+                    numberValue: &childNumberValue,
                     id: childrenId
                 )
+                
+                changedIds.append(contentsOf: childChangesIds)
+                
+                if useNumberFromParent {
+                    numberValue = childNumberValue
+                }
             }
         }
+        return changedIds
     }
-
     
     private static func updatedNumberedValueIfNeeded(
-        container: InfoContainerProtocol,
         child: BlockInformation,
         numberValue: inout Int
     ) -> BlockInformation {
@@ -53,6 +73,16 @@ public enum IndentationBuilder {
             let content = BlockContent.text(text.updated(number: numberValue))
 
             return child.updated(content: content)
+        // Ignore reset value between items in one level.
+        // Example. Two div, but there are one numeric list.
+        // div(2)
+        //   text num
+        //   text num
+        // div(3) <- Don't reset num value here for use numberValue in childs
+        //   text num
+        //   text num
+        case let .layout(style) where style == BlockLayout(style: .div):
+            break
         default:
             numberValue = 0
         }


### PR DESCRIPTION
Middleware uses div block for split a lot of child items. If block contains ~40 items, middleware will split one big block to two div blocks with ~20 child items. We did not support this case.

https://github.com/anyproto/anytype-swift/assets/2483784/e35ed9fb-1997-4638-9def-5c756d7ee1bc

