### PR TITLE
IOS-2785 Editor | Fix checkbox

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/Stylers/TextBlockLeadingView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/Stylers/TextBlockLeadingView.swift
@@ -12,14 +12,16 @@ final class TextBlockLeadingView: UIView {
     private(set) var calloutIconView: UIView?
     
     private var currentStyle: TextBlockLeadingStyle?
-
-    func update(style: TextBlockLeadingStyle) {
-        guard currentStyle != style else { return }
+    private var currentBockId: String?
+    
+    func update(blockId: String, style: TextBlockLeadingStyle) {
+        guard currentBockId != blockId || currentStyle != style else { return }
         
         removeAllSubviews()
         isHidden = false
         
         currentStyle = style
+        currentBockId = blockId
 
         let innerView: UIView
         switch style {

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView.swift
@@ -98,7 +98,7 @@ final class TextBlockContentView: UIView, BlockContentView, DynamicHeightView, F
         textView.textView.textStorage.setAttributedString(configuration.attributedString)
         TextBlockLeftViewStyler.applyStyle(contentStackView: contentStackView, configuration: configuration)
         
-        textBlockLeadingView.update(style: TextBlockLeadingStyle(with: configuration))
+        textBlockLeadingView.update(blockId: configuration.blockId, style: TextBlockLeadingStyle(with: configuration))
     
         let restrictions = BlockRestrictionsBuilder.build(textContentType: configuration.content.contentType)
         TextBlockTextViewStyler.applyStyle(textView: textView, configuration: configuration, restrictions: restrictions)


### PR DESCRIPTION
Toggle action in TextBlockLeadingStyle was not update during the reuse. Added block id for reuse comparation.