### PR TITLE
IOS-2907 SpaceShareTip | Fix show

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceShare/SpaceShareTip/SpaceShareTip.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceShare/SpaceShareTip/SpaceShareTip.swift
@@ -7,7 +7,7 @@ struct SpaceShareTip: Tip {
     static var didOpenPrivateSpace: Bool = false
     
     var title: Text {
-        Text(verbatim: "")
+        Text(verbatim: Loc.unknown)
     }
     
     var options: [TipOption] {


### PR DESCRIPTION
Without text tip can't be shown