### PR TITLE
IOS-2958 Do not wait for membership subscription to start

### DIFF
--- a/Anytype/Sources/ServiceLayer/Auth/LoginStateService.swift
+++ b/Anytype/Sources/ServiceLayer/Auth/LoginStateService.swift
@@ -72,8 +72,11 @@ final class LoginStateService: LoginStateServiceProtocol {
         await accountParticipantsStorage.startSubscription()
         await activeSpaceParticipantStorage.startSubscription()
         await participantSpacesStorage.startSubscription()
-        await membershipStatusStorage.startSubscription()
         storeKitService.startListenForTransactions()
+        
+        Task {
+            await membershipStatusStorage.startSubscription()
+        }
     }
     
     private func stopSubscriptions() async {


### PR DESCRIPTION
Desktop and Android apps are not waiting for the MembershipGetStatus to finish.
Because when you do it with noCache=true it can take a while if you have a bad internet connection