### PR TITLE
iOS-3050 Handle accountSelect cancelation error

### DIFF
--- a/Anytype/Sources/PresentationLayer/Auth/LoginFlow/LoginViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Auth/LoginFlow/LoginViewModel.swift
@@ -199,6 +199,8 @@ final class LoginViewModel: ObservableObject {
                 }
             } catch is CancellationError {
                 // Ignore cancellations
+            } catch SelectAccountError.accountLoadIsCanceled {
+                // Ignore load cancellation
             } catch SelectAccountError.accountIsDeleted {
                 errorText = Loc.vaultDeleted
             } catch SelectAccountError.failedToFetchRemoteNodeHasIncompatibleProtoVersion {

--- a/Modules/Services/Sources/Services/Auth/AuthMiddleService.swift
+++ b/Modules/Services/Sources/Services/Auth/AuthMiddleService.swift
@@ -96,7 +96,7 @@ final class AuthMiddleService: AuthMiddleServiceProtocol {
                 $0.disableLocalNetworkSync = false
                 $0.networkMode = networkMode
                 $0.networkCustomConfigFilePath = configPath ?? ""
-            }).invoke()
+            }).invoke(ignoreLogErrors: .accountLoadIsCanceled)
             
             return try response.account.asModel()
         } catch let responseError as Anytype_Rpc.Account.Select.Response.Error {

--- a/Modules/Services/Sources/Services/Auth/Errors/SelectAccountError.swift
+++ b/Modules/Services/Sources/Services/Auth/Errors/SelectAccountError.swift
@@ -4,6 +4,7 @@ import ProtobufMessages
 public enum SelectAccountError: Error {
     case accountIsDeleted
     case failedToFetchRemoteNodeHasIncompatibleProtoVersion
+    case accountLoadIsCanceled
 }
 
 extension Anytype_Rpc.Account.Select.Response.Error {
@@ -13,6 +14,8 @@ extension Anytype_Rpc.Account.Select.Response.Error {
             return .accountIsDeleted
         case .failedToFetchRemoteNodeHasIncompatibleProtoVersion:
             return .failedToFetchRemoteNodeHasIncompatibleProtoVersion
+        case .accountLoadIsCanceled:
+            return .accountLoadIsCanceled
         default:
             return nil
         }


### PR DESCRIPTION
It happens when we cancel selectAccount by tap back - should skip this error