### PR TITLE
IOS-1561 Editor | Fix range in mentions

### DIFF
--- a/Anytype/Sources/Models/Documents/Events/MentionMarkupEventProvider.swift
+++ b/Anytype/Sources/Models/Documents/Events/MentionMarkupEventProvider.swift
@@ -89,16 +89,16 @@ final class MentionMarkupEventProvider {
     }
     
     private func mentionRange(in string: String, range: Anytype_Model_Range) -> Range<String.Index>? {
-        guard range.from < string.count, range.to <= string.count else {
+        guard range.from < string.utf16.count, range.to <= string.utf16.count else {
             anytypeAssertionFailure("Index out of bounds", info: [
                 "range from": "\(range.from)",
                 "range to": "\(range.to)",
-                "string lenght": "\(string.count)"
+                "string lenght": "\(string.utf16.count)"
             ])
             return nil
         }
-        let from = string.index(string.startIndex, offsetBy: Int(range.from))
-        let to = string.index(string.startIndex, offsetBy: Int(range.to))
+        let from = string.utf16.index(string.utf16.startIndex, offsetBy: Int(range.from))
+        let to = string.utf16.index(string.utf16.startIndex, offsetBy: Int(range.to))
         return from..<to
     }
     


### PR DESCRIPTION
This problem reproduced if text contains emoji + link to object. Emoji before the link. Emoji contains two or more utf-16 characters.

Example:
Text: 🦫 <ins>All</ins>
🦫 - 2 utf-16 characters

Middleware uses utf-16 for range. We are using string interpretation where 🦫 - 1 symbol. 
If we get `string.count` for exaple it will be 5, but for middleware is 6