### PR TITLE
#2208 Add interactive dragging to .anytypeSheet

### DIFF
--- a/Anytype/Sources/Design system/SheetView/SheetView.swift
+++ b/Anytype/Sources/Design system/SheetView/SheetView.swift
@@ -40,6 +40,7 @@ struct SheetView<Content: View>: View {
         VStack(spacing: 0) {
             Spacer.fixedHeight(max(0, spacerHeight))
             content
+                .fixedSize(horizontal: false, vertical: true)
                 .background(Color.Background.secondary)
                 .cornerRadius(16, style: .continuous)
                 .shadow(radius: 20)

--- a/Anytype/Sources/Design system/SheetView/SheetView.swift
+++ b/Anytype/Sources/Design system/SheetView/SheetView.swift
@@ -6,7 +6,9 @@ struct SheetView<Content: View>: View {
     private let dismissOnBackgroundView: Bool
     private var content: Content
     private let cancelAction: (() -> Void)?
-    
+
+    @State private var spacerHeight: CGFloat = 0
+
     init(
         dismissOnBackgroundView: Bool,
         content: () -> Content,
@@ -35,19 +37,30 @@ struct SheetView<Content: View>: View {
     }
     
     private var contentView: some View {
-        content
+        VStack(spacing: 0) {
+            Spacer.fixedHeight(max(0, spacerHeight))
+            VStack(spacing: 0) {
+                DragIndicator()
+                Spacer.fixedHeight(12)
+                content
+            }
+            .background(Color.Background.secondary)
             .cornerRadius(16, style: .continuous)
             .shadow(radius: 20)
             .padding(.horizontal, 8)
-            .gesture(
-                DragGesture()
-                    .onEnded { value in
-                        if value.translation.height > 0 {
-                            dismiss()
-                            cancelAction?()
-                        }
+        }
+        .gesture(
+            DragGesture()
+                .onChanged { value in
+                    spacerHeight = value.translation.height
+                }
+                .onEnded { value in
+                    if value.translation.height > 0 {
+                        dismiss()
+                        cancelAction?()
                     }
-            )
-            .fitIPadToReadableContentGuide()
+                }
+        )
+        .fitIPadToReadableContentGuide()
     }
 }

--- a/Anytype/Sources/Design system/SheetView/SheetView.swift
+++ b/Anytype/Sources/Design system/SheetView/SheetView.swift
@@ -39,15 +39,11 @@ struct SheetView<Content: View>: View {
     private var contentView: some View {
         VStack(spacing: 0) {
             Spacer.fixedHeight(max(0, spacerHeight))
-            VStack(spacing: 0) {
-                DragIndicator()
-                Spacer.fixedHeight(12)
-                content
-            }
-            .background(Color.Background.secondary)
-            .cornerRadius(16, style: .continuous)
-            .shadow(radius: 20)
-            .padding(.horizontal, 8)
+            content
+                .background(Color.Background.secondary)
+                .cornerRadius(16, style: .continuous)
+                .shadow(radius: 20)
+                .padding(.horizontal, 8)
         }
         .gesture(
             DragGesture()

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsView.swift
@@ -19,6 +19,9 @@ struct ObjectSettingsView: View {
     
     private var settings: some View {
         VStack(spacing: 0) {
+            DragIndicator()
+            Spacer.fixedHeight(Constants.dragIndicatorSpacing)
+
             settingsList
 
             ObjectActionsView(objectId: viewModel.objectId, output: viewModel)
@@ -58,5 +61,6 @@ struct ObjectSettingsView: View {
     private enum Constants {
         static let edgeInset: CGFloat = 16
         static let dividerSpacing: CGFloat = 12
+        static let dragIndicatorSpacing: CGFloat = 12
     }
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

This PR adds interactive dragging capability to `.anytypeSheet` used for popup like presentation (object settings for example). It should fix #2208.

### What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

https://github.com/anyproto/anytype-swift/issues/2208

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

https://github.com/user-attachments/assets/af37656e-3927-4e9d-bbf4-078d0fa5431f

### Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [X] 🙅 no documentation needed
