### PR TITLE
fix: blocks moved to another object are out of order

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Handler/SlashMenuActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Handler/SlashMenuActionHandler.swift
@@ -195,7 +195,9 @@ final class SlashMenuActionHandler {
             actionHandler.duplicate(blockId: blockId, spaceId: document.spaceId)
         case .moveTo:
             router.showMoveTo { [weak self] details in
-                self?.actionHandler.moveToPage(blockId: blockId, pageId: details.id)
+                Task {
+                    try await self?.actionHandler.moveToPage(blockId: blockId, pageId: details.id)
+                }
             }
         case .copy:
             try await pasteboardService.copy(document: document, blocksIds: [blockId], selectedTextRange: NSRange())

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Handler/SlashMenuActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Handler/SlashMenuActionHandler.swift
@@ -196,7 +196,7 @@ final class SlashMenuActionHandler {
         case .moveTo:
             router.showMoveTo { [weak self] details in
                 Task {
-                    try await self?.actionHandler.moveToPage(blockId: blockId, pageId: details.id)
+                    try await self?.actionHandler.moveToPage(blockIds: [blockId], pageId: details.id)
                 }
             }
         case .copy:

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageBlocksStateManager.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageBlocksStateManager.swift
@@ -441,9 +441,8 @@ final class EditorPageBlocksStateManager: EditorPageBlocksStateManagerProtocol {
         case .moveTo:
             router.showMoveTo { [weak self] details in
                 Task {
-                    for element in elements {
-                        try await self?.actionHandler.moveToPage(blockId: element.blockId, pageId: details.id)
-                    }
+                    let blockIds = elements.map(\.blockId)
+                    try await self?.actionHandler.moveToPage(blockIds: blockIds, pageId: details.id)
 
                     self?.editingState = .editing
 

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandler.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandler.swift
@@ -130,13 +130,12 @@ final class BlockActionHandler: BlockActionHandlerProtocol {
         service.delete(blockIds: blockIds)
     }
     
-    func moveToPage(blockId: String, pageId: String) {
+    func moveToPage(blockId: String, pageId: String) async throws {
         AnytypeAnalytics.instance().logMoveBlock()
-        Task {
-            try await blockService.moveToPage(objectId: document.objectId, blockId: blockId, pageId: pageId)
-        }
+        try await blockService.moveToPage(objectId: document.objectId, blockId: blockId, pageId: pageId)
     }
-    
+
+
     func createEmptyBlock(parentId: String, spaceId: String) {
         Task {
             let emptyBlock = BlockInformation.emptyText

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandler.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandler.swift
@@ -130,9 +130,9 @@ final class BlockActionHandler: BlockActionHandlerProtocol {
         service.delete(blockIds: blockIds)
     }
     
-    func moveToPage(blockId: String, pageId: String) async throws {
+    func moveToPage(blockIds: [String], pageId: String) async throws {
         AnytypeAnalytics.instance().logMoveBlock()
-        try await blockService.moveToPage(objectId: document.objectId, blockId: blockId, pageId: pageId)
+        try await blockService.moveToPage(objectId: document.objectId, blockIds: blockIds, pageId: pageId)
     }
 
 

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandlerProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandlerProtocol.swift
@@ -15,7 +15,7 @@ protocol BlockActionHandlerProtocol: AnyObject {
     func toggle(blockId: String)
     func setAlignment(_ alignment: LayoutAlignment, blockIds: [String])
     func delete(blockIds: [String])
-    func moveToPage(blockId: String, pageId: String) async throws
+    func moveToPage(blockIds: [String], pageId: String) async throws
     func createEmptyBlock(parentId: String, spaceId: String)
     func addLink(targetDetails: ObjectDetails, blockId: String)
     func changeMarkup(blockIds: [String], markType: MarkupType)

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandlerProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandlerProtocol.swift
@@ -15,7 +15,7 @@ protocol BlockActionHandlerProtocol: AnyObject {
     func toggle(blockId: String)
     func setAlignment(_ alignment: LayoutAlignment, blockIds: [String])
     func delete(blockIds: [String])
-    func moveToPage(blockId: String, pageId: String)
+    func moveToPage(blockId: String, pageId: String) async throws
     func createEmptyBlock(parentId: String, spaceId: String)
     func addLink(targetDetails: ObjectDetails, blockId: String)
     func changeMarkup(blockIds: [String], markType: MarkupType)

--- a/Modules/Services/Sources/Services/BlockService/BlockService.swift
+++ b/Modules/Services/Sources/Services/BlockService/BlockService.swift
@@ -131,10 +131,10 @@ final class BlockService: BlockServiceProtocol {
         }).invoke()
     }
     
-    public func moveToPage(objectId: String, blockId: String, pageId: String) async throws {
+    public func moveToPage(objectId: String, blockIds: [String], pageId: String) async throws {
         try await ClientCommands.blockListMoveToExistingObject(.with {
             $0.contextID = objectId
-            $0.blockIds = [blockId]
+            $0.blockIds = blockIds
             $0.targetContextID = pageId
             $0.dropTargetID = ""
             $0.position = .bottom

--- a/Modules/Services/Sources/Services/BlockService/BlockServiceProtocol.swift
+++ b/Modules/Services/Sources/Services/BlockService/BlockServiceProtocol.swift
@@ -14,7 +14,7 @@ public protocol BlockServiceProtocol: AnyObject, Sendable {
     
     func replace(objectId: String, blockIds: [String], targetId: String) async throws
     func move(objectId: String, blockId: String, targetId: String, position: Anytype_Model_Block.Position) async throws
-    func moveToPage(objectId: String, blockId: String, pageId: String) async throws
+    func moveToPage(objectId: String, blockIds: [String], pageId: String) async throws
     func setLinkAppearance(objectId: String, blockIds: [String], appearance: BlockLink.Appearance) async throws
     func changeMarkup(objectId: String, blockIds: [String], markType: MarkupType) async throws
     


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

#### Issue
Moving several blocks to a new page does not always preserve the order.

#### Cause 
The `EditorPageBlocksStateManager` iterates over all selected blocks and moves them one at a time (seemingly synchronously) via the `BlockActionHandler`. However, the action handler internally fires a `Task` to asynchronously move the block via the `BlockService`. Without any synchronization, it is undefined in which order the tasks will run, resulting in the elements being moved out of order.

#### Solution
Don't hide a task inside `BlockActionHandler.moveToPage(blockId:pageId)`, instead make it `async throws`, then await for each move to complete before iterating to the next block.

#### Note
I marked the method as throws so errors are propagated up, but it gets ignored anyway in the enclosing task. I didn't notice error handling in similar methods (most of the errors get lost in the `Task`) so I wasn't sure if or how it should be handled.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
Fixes #2274

### Mobile & Desktop Screenshots/Recordings

Before:
![Simulator Screen Recording - iPhone 16 Pro - 2024-10-24 at 23 18 44](https://github.com/user-attachments/assets/6a7ce21f-ef71-46e9-a505-6f7f7d935c7f)

After:
![Simulator Screen Recording - iPhone 16 Pro - 2024-10-24 at 23 17 04](https://github.com/user-attachments/assets/16800f71-dd95-4447-80bc-09c6f7163afc)

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

I didn't see any tests for relevant objects (such as `EditorPageBlocksStateManager`) so I'm not sure what your testing strategy is.

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

