### PR TITLE
iOS-3536 Add empty state for Widget list screens

### DIFF
--- a/Anytype/Generated/Strings.swift
+++ b/Anytype/Generated/Strings.swift
@@ -434,12 +434,6 @@ internal enum Loc {
     }
   }
   internal enum AllContent {
-    internal enum Empty {
-      internal enum State {
-        internal static let subtitle = Loc.tr("Localizable", "AllContent.Empty.State.subtitle", fallback: "Create your first objects to get started.")
-        internal static let title = Loc.tr("Localizable", "AllContent.Empty.State.title", fallback: "It’s empty here.")
-      }
-    }
     internal enum Search {
       internal enum Empty {
         internal enum State {
@@ -836,6 +830,16 @@ internal enum Loc {
           internal static let title = Loc.tr("Localizable", "EditorSet.View.Not.Supported.Title", fallback: "Unsupported")
         }
       }
+    }
+  }
+  internal enum EmptyView {
+    internal enum Bin {
+      internal static let subtitle = Loc.tr("Localizable", "EmptyView.Bin.subtitle", fallback: "Looks like you’re all tidy and organized!")
+      internal static let title = Loc.tr("Localizable", "EmptyView.Bin.title", fallback: "Your trash is empty.")
+    }
+    internal enum Default {
+      internal static let subtitle = Loc.tr("Localizable", "EmptyView.Default.subtitle", fallback: "Create your first objects to get started.")
+      internal static let title = Loc.tr("Localizable", "EmptyView.Default.title", fallback: "It’s empty here.")
     }
   }
   internal enum Error {

--- a/Anytype/Resources/Strings/en.lproj/Localizable.strings
+++ b/Anytype/Resources/Strings/en.lproj/Localizable.strings
@@ -1241,8 +1241,6 @@ Please provide specific details of your needs here.";
 "AllContent.Settings.Unlinked.Title" = "Only unlinked";
 "AllContent.Settings.Unlinked.Description" = "Unlinked objects that do not have a direct link or backlink with other objects in the graph.";
 "AllContent.Settings.ViewBin" = "View Bin";
-"AllContent.Empty.State.title" = "It’s empty here.";
-"AllContent.Empty.State.subtitle" = "Create your first objects to get started.";
 "AllContent.Search.Empty.State.title" = "No results found.";
 "AllContent.Search.Empty.State.subtitle" = "Try searching with different keywords.";
 
@@ -1254,3 +1252,9 @@ Please provide specific details of your needs here.";
 "ReindexingWarningAlert.Title" = "Upgrading your search experience";
 "ReindexingWarningAlert.Description" = "We've implemented a new search library for faster and more accurate results.\nReindexing may take a few minutes.";
 "ReindexingWarningAlert.Button" = "I got it!";
+
+// MARK: - Empty view
+"EmptyView.Default.title" = "It’s empty here.";
+"EmptyView.Default.subtitle" = "Create your first objects to get started.";
+"EmptyView.Bin.title" = "Your trash is empty.";
+"EmptyView.Bin.subtitle" = "Looks like you’re all tidy and organized!";

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/EmptyStateView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/EmptyStateView.swift
@@ -3,19 +3,23 @@ import SwiftUI
 struct EmptyStateView: View {
     let title: String
     let subtitle: String
+    let style: Style
     let buttonData: ButtonData?
     
-    init(title: String, subtitle: String, buttonData: ButtonData? = nil) {
+    init(title: String, subtitle: String, style: Style, buttonData: ButtonData? = nil) {
         self.title = title
         self.subtitle = subtitle
+        self.style = style
         self.buttonData = buttonData
     }
     
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
-            ButtomAlertHeaderImageView(icon: .BottomAlert.error, style: .color(.red))
-            Spacer.fixedHeight(12)
+            if style == .withImage {
+                ButtomAlertHeaderImageView(icon: .BottomAlert.error, style: .color(.red))
+                Spacer.fixedHeight(12)
+            }
             AnytypeText(title, style: .uxCalloutMedium)
                 .foregroundColor(.Text.primary)
                 .multilineTextAlignment(.center)
@@ -40,12 +44,18 @@ extension EmptyStateView {
         let title: String
         let action: () -> ()
     }
+    
+    enum Style {
+        case withImage
+        case plain
+    }
 }
 
 #Preview {
     EmptyStateView(
         title: Loc.Relation.EmptyState.title,
         subtitle: Loc.Relation.EmptyState.description,
+        style: .withImage,
         buttonData: EmptyStateView.ButtonData(
             title: Loc.create,
             action: {}

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/RelationDetailsViews/Container/RelationListContainerView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/RelationDetailsViews/Container/RelationListContainerView.swift
@@ -116,6 +116,7 @@ struct RelationListContainerView<Content>: View where Content: View {
         EmptyStateView(
             title: Loc.Relation.EmptyState.title,
             subtitle: Loc.Relation.EmptyState.description,
+            style: .withImage,
             buttonData: EmptyStateView.ButtonData(
                 title: Loc.create,
                 action: { onCreate(nil) }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/Common/SearchView/SearchView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/Common/SearchView/SearchView.swift
@@ -73,7 +73,8 @@ struct SearchView<SearchData: SearchDataProtocol>: View {
     private var emptyState: some View {
         EmptyStateView(
             title: Loc.thereIsNoObjectNamed(searchText),
-            subtitle: Loc.createANewOneOrSearchForSomethingElse
+            subtitle: Loc.createANewOneOrSearchForSomethingElse,
+            style: .plain
         )
     }
 }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchView.swift
@@ -115,6 +115,7 @@ struct GlobalSearchView: View {
         EmptyStateView(
             title: Loc.nothingFound,
             subtitle: Loc.GlobalSearch.EmptyState.subtitle,
+            style: .plain,
             buttonData: EmptyStateView.ButtonData(
                 title: Loc.createObject,
                 action: {

--- a/Anytype/Sources/PresentationLayer/Flows/MembersipCoordinator/MembershipCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/MembersipCoordinator/MembershipCoordinator.swift
@@ -47,6 +47,7 @@ struct MembershipCoordinator: View {
         EmptyStateView(
             title: Loc.Error.Common.title,
             subtitle: Loc.Error.Common.message,
+            style: .withImage,
             buttonData: EmptyStateView.ButtonData(
                 title: Loc.Error.Common.tryAgain,
                 action: { model.loadTiers() }

--- a/Anytype/Sources/PresentationLayer/Modules/AllContent/AllContentView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/AllContent/AllContentView.swift
@@ -137,20 +137,13 @@ struct AllContentView: View {
     
     private var emptyState: some View {
         let emptySearchText = model.searchText.isEmpty
-        let title = emptySearchText ? Loc.AllContent.Empty.State.title : Loc.AllContent.Search.Empty.State.title
-        let subtitle = emptySearchText ? Loc.AllContent.Empty.State.subtitle : Loc.AllContent.Search.Empty.State.subtitle
-        return VStack(spacing: 0) {
-            Spacer()
-            AnytypeText(title, style: .uxCalloutMedium)
-                .foregroundColor(.Text.primary)
-                .multilineTextAlignment(.center)
-            AnytypeText(subtitle, style: .uxCalloutRegular)
-                .foregroundColor(.Text.secondary)
-                .multilineTextAlignment(.center)
-            Spacer.fixedHeight(80)
-            Spacer()
-        }
-        .padding(.horizontal, 16)
+        let title = emptySearchText ? Loc.EmptyView.Default.title : Loc.AllContent.Search.Empty.State.title
+        let subtitle = emptySearchText ? Loc.EmptyView.Default.subtitle : Loc.AllContent.Search.Empty.State.subtitle
+        return EmptyStateView(
+            title: title,
+            subtitle: subtitle,
+            style: .plain
+        )
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/Modules/GalleryInstallationPreview/GalleryInstallationPreviewView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/GalleryInstallationPreview/GalleryInstallationPreviewView.swift
@@ -33,6 +33,7 @@ struct GalleryInstallationPreviewView: View {
         EmptyStateView(
             title: Loc.Error.Common.title,
             subtitle: Loc.Error.Common.message,
+            style: .withImage,
             buttonData: EmptyStateView.ButtonData(
                 title: Loc.Error.Common.tryAgain,
                 action: { model.onTryAgainTap() }

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Bin/WidgetObjectListBinViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Bin/WidgetObjectListBinViewModel.swift
@@ -15,6 +15,10 @@ final class WidgetObjectListBinViewModel: WidgetObjectListInternalViewModelProto
     // MARK: - State
     
     let title = Loc.bin
+    let emptyStateData = WidgetObjectListEmptyStateData(
+        title: Loc.EmptyView.Bin.title,
+        subtitle: Loc.EmptyView.Bin.subtitle
+    )
     let editorScreenData: EditorScreenData
     var rowDetailsPublisher: AnyPublisher<[WidgetObjectListDetailsData], Never> { $rowDetails.eraseToAnyPublisher()}
     let editMode: WidgetObjectListEditMode = .normal(allowDnd: false)

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Chats/WidgetObjectListChatsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Chats/WidgetObjectListChatsViewModel.swift
@@ -14,6 +14,10 @@ final class WidgetObjectListChatsViewModel: WidgetObjectListInternalViewModelPro
     // MARK: - State
     
     let title = Loc.Widgets.Library.Chat.name
+    let emptyStateData = WidgetObjectListEmptyStateData(
+        title: Loc.EmptyView.Default.title,
+        subtitle: Loc.EmptyView.Default.subtitle
+    )
     let editorScreenData: EditorScreenData
     var rowDetailsPublisher: AnyPublisher<[WidgetObjectListDetailsData], Never> { $rowDetails.eraseToAnyPublisher()}
     let editMode: WidgetObjectListEditMode = .normal(allowDnd: false)

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Collections/WidgetObjectListCollectionsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Collections/WidgetObjectListCollectionsViewModel.swift
@@ -14,6 +14,10 @@ final class WidgetObjectListCollectionsViewModel: WidgetObjectListInternalViewMo
     // MARK: - State
     
     let title = Loc.collections
+    let emptyStateData = WidgetObjectListEmptyStateData(
+        title: Loc.EmptyView.Default.title,
+        subtitle: Loc.EmptyView.Default.subtitle
+    )
     let editorScreenData: EditorScreenData
     var rowDetailsPublisher: AnyPublisher<[WidgetObjectListDetailsData], Never> { $rowDetails.eraseToAnyPublisher()}
     let editMode: WidgetObjectListEditMode = .normal(allowDnd: false)

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Common/Internal/WidgetObjectListInternalViewModelProtocol.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Common/Internal/WidgetObjectListInternalViewModelProtocol.swift
@@ -8,6 +8,11 @@ struct WidgetObjectListDetailsData {
     var details: [ObjectDetails]
 }
 
+struct WidgetObjectListEmptyStateData {
+    let title: String
+    let subtitle: String
+}
+
 enum WidgetObjectListEditMode: Equatable {
     case normal(allowDnd: Bool)
     case editOnly
@@ -17,6 +22,7 @@ enum WidgetObjectListEditMode: Equatable {
 protocol WidgetObjectListInternalViewModelProtocol: AnyObject {
     
     var title: String { get }
+    var emptyStateData: WidgetObjectListEmptyStateData { get }
     var rowDetailsPublisher: AnyPublisher<[WidgetObjectListDetailsData], Never> { get }
     var editorScreenData: EditorScreenData { get }
     var editMode: WidgetObjectListEditMode { get }

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Common/WidgetObjectListView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Common/WidgetObjectListView.swift
@@ -49,8 +49,12 @@ struct WidgetObjectListView: View {
         switch model.data {
         case .list(let sections):
             dataList(sections: sections)
-        case .error(let error):
-            LegacySearchErrorView(error: error)
+        case .error(let title, let subtitle):
+            EmptyStateView(
+                title: title,
+                subtitle: subtitle,
+                style: .plain
+            )
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Common/WidgetObjectListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Common/WidgetObjectListViewModel.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 enum WidgetObjectListData {
     case list([ListSectionData<String?, WidgetObjectListRowModel>])
-    case error(LegacySearchError)
+    case error(title: String, subtitle: String)
 }
 
 @MainActor
@@ -185,9 +185,17 @@ final class WidgetObjectListViewModel: ObservableObject, OptionsItemProvider, Wi
         }
         
         if let searchText, rows.isEmpty {
-            data = .error(.noObjectError(searchText: searchText))
-        } else {
+            data = .error(
+                title: Loc.thereIsNoObjectNamed(searchText),
+                subtitle: Loc.createANewOneOrSearchForSomethingElse
+            )
+        } else if rows.first(where: { $0.rows.isNotEmpty }).isNotNil {
             data = .list(rows)
+        } else {
+            data = .error(
+                title: internalModel.emptyStateData.title,
+                subtitle: internalModel.emptyStateData.subtitle
+            )
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Favorites/WidgetObjectListFavoritesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Favorites/WidgetObjectListFavoritesViewModel.swift
@@ -20,6 +20,10 @@ final class WidgetObjectListFavoritesViewModel: WidgetObjectListInternalViewMode
     // MARK: - State
     
     let title = Loc.favorites
+    let emptyStateData = WidgetObjectListEmptyStateData(
+        title: Loc.EmptyView.Default.title,
+        subtitle: Loc.EmptyView.Default.subtitle
+    )
     let editorScreenData: EditorScreenData
     var rowDetailsPublisher: AnyPublisher<[WidgetObjectListDetailsData], Never> { $rowDetails.eraseToAnyPublisher() }
     let editMode: WidgetObjectListEditMode = .normal(allowDnd: true)

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Files/WidgetObjectListFilesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Files/WidgetObjectListFilesViewModel.swift
@@ -15,6 +15,10 @@ final class WidgetObjectListFilesViewModel: WidgetObjectListInternalViewModelPro
     // MARK: - State
     
     let title = Loc.FilesList.title
+    let emptyStateData = WidgetObjectListEmptyStateData(
+        title: Loc.EmptyView.Default.title,
+        subtitle: Loc.EmptyView.Default.subtitle
+    )
     let editorScreenData: EditorScreenData = .favorites(homeObjectId: "", spaceId: "") // Is not used
     var rowDetailsPublisher: AnyPublisher<[WidgetObjectListDetailsData], Never> { $rowDetails.eraseToAnyPublisher()}
     let editMode: WidgetObjectListEditMode = .editOnly

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Recent/WidgetObjectListRecentViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Recent/WidgetObjectListRecentViewModel.swift
@@ -20,6 +20,10 @@ final class WidgetObjectListRecentViewModel: WidgetObjectListInternalViewModelPr
     // MARK: - State
     
     var title: String { type.title }
+    let emptyStateData = WidgetObjectListEmptyStateData(
+        title: Loc.EmptyView.Default.title,
+        subtitle: Loc.EmptyView.Default.subtitle
+    )
     var editorScreenData: EditorScreenData { type.editorScreenData(spaceId: spaceId) }
     var rowDetailsPublisher: AnyPublisher<[WidgetObjectListDetailsData], Never> { $rowDetails.eraseToAnyPublisher()}
     let editMode: WidgetObjectListEditMode = .normal(allowDnd: false)

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Sets/WidgetObjectListSetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Sets/WidgetObjectListSetsViewModel.swift
@@ -14,6 +14,10 @@ final class WidgetObjectListSetsViewModel: WidgetObjectListInternalViewModelProt
     // MARK: - State
     
     let title = Loc.sets
+    let emptyStateData = WidgetObjectListEmptyStateData(
+        title: Loc.EmptyView.Default.title,
+        subtitle: Loc.EmptyView.Default.subtitle
+    )
     let editorScreenData: EditorScreenData
     var rowDetailsPublisher: AnyPublisher<[WidgetObjectListDetailsData], Never> { $rowDetails.eraseToAnyPublisher()}
     let editMode: WidgetObjectListEditMode = .normal(allowDnd: false)

--- a/Anytype/Sources/PresentationLayer/ObjectTypeSearch/ObjectTypeSearchView.swift
+++ b/Anytype/Sources/PresentationLayer/ObjectTypeSearch/ObjectTypeSearchView.swift
@@ -73,6 +73,7 @@ struct ObjectTypeSearchView: View {
                 EmptyStateView(
                     title: Loc.nothingFound,
                     subtitle: Loc.noTypeFoundText(viewModel.searchText),
+                    style: .plain,
                     buttonData: EmptyStateView.ButtonData(
                         title: Loc.createType,
                         action: { viewModel.createType(name: viewModel.searchText) }


### PR DESCRIPTION
Also add an option to EmptyView to create it without Image (for searches)
<img src='https://github.com/user-attachments/assets/5b02cfce-2391-4a1e-8df8-c2938dd9056d' width='300'>
<img src='https://github.com/user-attachments/assets/90c71cef-b6d2-4689-af36-48ca259f51f8' width='300'>
