### PR TITLE
iOS-3725 Date as an object | Add limited date range to all date pickers

### DIFF
--- a/Anytype/Sources/FrameworkExtensions/Foundation/DateExtension.swift
+++ b/Anytype/Sources/FrameworkExtensions/Foundation/DateExtension.swift
@@ -20,3 +20,20 @@ extension Date {
         return date
     }
 }
+
+extension ClosedRange where Bound == Date {
+    
+    // MARK: - available date range for all platforms
+    static let anytypeDateRange: ClosedRange<Date> = {
+        let calendar = Calendar.current
+        let startComponents = DateComponents(year: 0, month: 1, day: 1)
+        let endComponents = DateComponents(year: 3000, month: 12, day: 31)
+        
+        guard let startDate = calendar.date(from: startComponents),
+              let endDate = calendar.date(from: endComponents) else {
+            return Date()...Date()
+        }
+        
+        return startDate...endDate
+    }()
+}

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/DateCalendarView/DateCalendarView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/DateCalendarView/DateCalendarView.swift
@@ -33,7 +33,7 @@ struct DateCalendarView: View {
     }
     
     private var calendar: some View {
-        DatePicker("", selection: $date, displayedComponents: .date)
+        DatePicker("", selection: $date, in: ClosedRange.anytypeDateRange, displayedComponents: .date)
             .datePickerStyle(.graphical)
             .accentColor(Color.System.amber125)
             .padding(.horizontal, 16)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/Date/SetFiltersDateRowView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/Date/SetFiltersDateRowView.swift
@@ -35,7 +35,7 @@ struct SetFiltersDateRowView: View {
         Group {
             switch configuration.dateType {
             case .exactDate:
-                DatePicker("", selection: $date, displayedComponents: .date)
+                DatePicker("", selection: $date, in: ClosedRange.anytypeDateRange, displayedComponents: .date)
                     .datePickerStyle(.compact)
                     .frame(height: 24)
                     .accentColor(Color.System.amber100)


### PR DESCRIPTION
`0...3000` years range is available now on all platforms