### PR TITLE
iOS-3764 Date as an object | Open date object on locked relations

### DIFF
--- a/Anytype/Generated/Strings.swift
+++ b/Anytype/Generated/Strings.swift
@@ -1213,15 +1213,6 @@ internal enum Loc {
         internal static let placeholder = Loc.tr("Localizable", "Relation.Create.Textfield.placeholder", fallback: "Enter name...")
       }
     }
-    internal enum Date {
-      internal enum Locked {
-        internal enum Alert {
-          internal static func title(_ p1: Any) -> String {
-            return Loc.tr("Localizable", "Relation.Date.Locked.Alert.title", String(describing: p1), fallback: "Relation “%@” is locked")
-          }
-        }
-      }
-    }
     internal enum Delete {
       internal enum Alert {
         internal static let description = Loc.tr("Localizable", "Relation.Delete.Alert.Description", fallback: "The option will be permanently removed from your space.")

--- a/Anytype/Resources/Strings/en.lproj/Localizable.strings
+++ b/Anytype/Resources/Strings/en.lproj/Localizable.strings
@@ -84,7 +84,6 @@
 "Relation.View.Create.title" = "Create option";
 "Relation.View.Edit.title" = "Edit option";
 "Relation.Create.Textfield.placeholder" = "Enter name...";
-"Relation.Date.Locked.Alert.title" = "Relation “%@” is locked";
 "Relation.ObjectTypes.Header.title" = "Object types:";
 "Relation.ObjectType.Header.title" = "Object type:";
 

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/View+DragIndicator.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/View+DragIndicator.swift
@@ -1,0 +1,19 @@
+import Foundation
+import SwiftUI
+
+private struct DragIndicatorModifier: ViewModifier {
+    
+    func body(content: Content) -> some View {
+        VStack(spacing: 0) {
+            DragIndicator()
+            content
+        }
+    }
+}
+
+
+extension View {
+    func applyDragIndicator() -> some View {
+        modifier(DragIndicatorModifier())
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Flows/DateCoordinator/DateCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DateCoordinator/DateCoordinatorView.swift
@@ -11,34 +11,28 @@ struct DateCoordinatorView: View {
     
     var body: some View {
         DateView(
-            objectId: model.objectId,
-            spaceId: model.spaceId,
+            date: model.initialData.date,
+            spaceId: model.initialData.spaceId,
             output: model
         )
         .onAppear {
             model.pageNavigation = pageNavigation
         }
         .anytypeSheet(isPresented: $model.showSyncStatusInfo) {
-            SyncStatusInfoView(spaceId: model.spaceId)
+            SyncStatusInfoView(spaceId: model.initialData.spaceId)
         }
         .sheet(item: $model.searchData) { data in
             SimpleSearchListView(items: data.items)
                 .mediumPresentationDetents()
         }
         .sheet(item: $model.calendarData) { data in
-            calendarView(with: data)
-        }
-    }
-    
-    private func calendarView(with data: CalendarData) -> some View {
-        VStack(spacing: 0) {
-            DragIndicator()
             CalendarView(data: data)
+                .applyDragIndicator()
+                .fitPresentationDetents()
         }
-        .fitPresentationDetents()
     }
 }
 
 #Preview {
-    DateCoordinatorView(data: EditorDateObject(objectId: "", spaceId: ""))
+    DateCoordinatorView(data: EditorDateObject(date: Date(), spaceId: ""))
 }

--- a/Anytype/Sources/PresentationLayer/Flows/DateCoordinator/DateCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DateCoordinator/DateCoordinatorViewModel.swift
@@ -3,8 +3,7 @@ import SwiftUI
 @MainActor
 final class DateCoordinatorViewModel: ObservableObject, DateModuleOutput {
     
-    let objectId: String
-    let spaceId: String
+    let initialData: EditorDateObject
     
     @Published var showSyncStatusInfo = false
     @Published var searchData: SimpleSearchData?
@@ -13,8 +12,7 @@ final class DateCoordinatorViewModel: ObservableObject, DateModuleOutput {
     var pageNavigation: PageNavigation?
     
     init(data: EditorDateObject) {
-        self.objectId = data.objectId
-        self.spaceId = data.spaceId
+        self.initialData = data
     }
     
     // MARK: - DateModuleOutput

--- a/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorViewModel.swift
@@ -127,10 +127,7 @@ final class EditorPageCoordinatorViewModel: ObservableObject, EditorPageModuleOu
         relationValueData = relationValueProcessingService.handleRelationValue(
             relation: relation,
             objectDetails: objectDetails,
-            analyticsType: .block,
-            onToastShow: { [weak self] message in
-                self?.toastBarData = ToastBarData(text: message, showSnackBar: true, messageType: .none)
-            }
+            analyticsType: .block
         )
     }
 }

--- a/Anytype/Sources/PresentationLayer/Flows/EditorSetFlow/EditorSetCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorSetFlow/EditorSetCoordinatorViewModel.swift
@@ -153,10 +153,7 @@ final class EditorSetCoordinatorViewModel:
         relationValueData = relationValueProcessingService.handleRelationValue(
             relation: relation,
             objectDetails: objectDetails,
-            analyticsType: .dataview,
-            onToastShow: { [weak self] message in
-                self?.toastBarData = ToastBarData(text: message, showSnackBar: true, messageType: .none)
-            }
+            analyticsType: .dataview
         )
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/Date/DateView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Date/DateView.swift
@@ -5,8 +5,8 @@ struct DateView: View {
     
     @StateObject private var model: DateViewModel
     
-    init(objectId: String, spaceId: String, output: (any DateModuleOutput)?) {
-        self._model = StateObject(wrappedValue: DateViewModel(objectId: objectId, spaceId: spaceId, output: output))
+    init(date: Date?, spaceId: String, output: (any DateModuleOutput)?) {
+        self._model = StateObject(wrappedValue: DateViewModel(date: date, spaceId: spaceId, output: output))
     }
     
     var body: some View {
@@ -15,7 +15,7 @@ struct DateView: View {
             titleView
             content
         }
-        .task(id: model.document.objectId) {
+        .task(id: model.document?.objectId) {
             await model.documentDidChange()
         }
         .task(item: model.state) { state in
@@ -160,5 +160,5 @@ struct DateView: View {
 }
 
 #Preview {
-    DateView(objectId: "", spaceId: "", output: nil)
+    DateView(date: Date(), spaceId: "spaceId", output: nil)
 }

--- a/Anytype/Sources/PresentationLayer/RelationValueFlow/RelationValueCoordinator/RelationValueCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/RelationValueFlow/RelationValueCoordinator/RelationValueCoordinatorViewModel.swift
@@ -15,6 +15,8 @@ final class RelationValueCoordinatorViewModel:
 {
     @Injected(\.objectTypeProvider)
     private var objectTypeProvider: any ObjectTypeProviderProtocol
+    @Injected(\.objectDateByTimestampService)
+    private var objectDateByTimestampService: any ObjectDateByTimestampServiceProtocol
     
     var mediumDetent: Bool = false
     
@@ -36,19 +38,7 @@ final class RelationValueCoordinatorViewModel:
     func relationModule() -> AnyView {
         switch relation {
         case .date(let date):
-            let dateValue = date.value?.date
-            let configuration = RelationModuleConfiguration(
-                title: date.name,
-                isEditable: relation.isEditable,
-                relationKey: date.key,
-                objectId: objectDetails.id,
-                spaceId: objectDetails.spaceId,
-                analyticsType: analyticsType
-            )
-            return DateRelationCalendarView(
-                date: dateValue,
-                configuration: configuration
-            ).eraseToAnyView()
+            return dateModule(date: date)
         case .status(let status):
             let configuration = RelationModuleConfiguration(
                 title: status.name,
@@ -180,6 +170,32 @@ final class RelationValueCoordinatorViewModel:
         case .unknown, .checkbox:
             anytypeAssertionFailure("There is no module for this relation", info: ["relation": relation.name])
             return EmptyView().eraseToAnyView()
+        }
+    }
+    
+    private func dateModule(date: Relation.Date) -> AnyView {
+        if date.isEditable {
+            let dateValue = date.value?.date
+            let configuration = RelationModuleConfiguration(
+                title: date.name,
+                isEditable: relation.isEditable,
+                relationKey: date.key,
+                objectId: objectDetails.id,
+                spaceId: objectDetails.spaceId,
+                analyticsType: analyticsType
+            )
+            return DateRelationCalendarView(
+                date: dateValue,
+                configuration: configuration
+            ).eraseToAnyView()
+        } else {
+            let dateValue = date.value?.date ?? Date()
+            return DateCoordinatorView(
+                data: EditorDateObject(
+                    date: dateValue,
+                    spaceId: objectDetails.spaceId
+                )
+            ).applyDragIndicator().eraseToAnyView()
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/RelationValueFlow/RelationValueCoordinator/RelationValueProcessingService.swift
+++ b/Anytype/Sources/PresentationLayer/RelationValueFlow/RelationValueCoordinator/RelationValueProcessingService.swift
@@ -7,8 +7,7 @@ protocol RelationValueProcessingServiceProtocol {
     func handleRelationValue(
         relation: Relation,
         objectDetails: ObjectDetails,
-        analyticsType: AnalyticsEventsRelationType,
-        onToastShow: (String) -> Void
+        analyticsType: AnalyticsEventsRelationType
     ) -> RelationValueData?
 }
 
@@ -25,14 +24,8 @@ fileprivate final class RelationValueProcessingService: RelationValueProcessingS
     func handleRelationValue(
         relation: Relation,
         objectDetails: ObjectDetails,
-        analyticsType: AnalyticsEventsRelationType,
-        onToastShow: (String) -> Void
+        analyticsType: AnalyticsEventsRelationType
     ) -> RelationValueData? {
-        if case .date = relation, !relation.isEditable {
-            onToastShow(Loc.Relation.Date.Locked.Alert.title(relation.name))
-            return nil
-        }
-        
         switch relation {
         case .status, .tag, .object, .date, .file, .text, .number, .url, .email, .phone:
             return RelationValueData(

--- a/Anytype/Sources/PresentationLayer/TextEditor/Assembly/EditorScreenData+Details.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Assembly/EditorScreenData+Details.swift
@@ -19,7 +19,7 @@ extension EditorScreenData {
                 mode: mode
             ))
         case .date:
-            self = .date(EditorDateObject(objectId: details.id, spaceId: details.spaceId))
+            self = .date(EditorDateObject(date: details.timestamp, spaceId: details.spaceId))
         case .type:
             self = .type(EditorTypeObject(objectId: details.id, spaceId: details.spaceId))
         }
@@ -69,13 +69,11 @@ extension EditorScreenData {
    
     var objectId: String? {
         switch self {
-        case .favorites, .recentEdit, .recentOpen, .sets, .collections, .bin, .allContent:
+        case .favorites, .recentEdit, .recentOpen, .sets, .collections, .bin, .allContent, .date:
             return nil
         case .page(let object):
             return object.objectId
         case .list(let object):
-            return object.objectId
-        case .date(let object):
             return object.objectId
         case .type(let object):
             return object.objectId

--- a/Anytype/Sources/PresentationLayer/TextEditor/Assembly/EditorScreenData.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Assembly/EditorScreenData.swift
@@ -1,4 +1,5 @@
 import Services
+import Foundation
 import AnytypeCore
 
 enum EditorScreenData: Hashable, Codable {
@@ -63,7 +64,7 @@ struct EditorListObject: Hashable, Codable {
 }
 
 struct EditorDateObject: Hashable, Codable {
-    let objectId: String
+    let date: Date?
     let spaceId: String
 }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Coordinator/RelationsListCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Coordinator/RelationsListCoordinatorView.swift
@@ -34,6 +34,5 @@ struct RelationsListCoordinatorView: View {
         .sheet(item: $model.objectTypeData) {
             TypeFieldsView(data: $0)
         }
-        .snackbar(toastBarData: $model.toastBarData)
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Coordinator/RelationsListCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Coordinator/RelationsListCoordinatorViewModel.swift
@@ -16,7 +16,6 @@ final class RelationsListCoordinatorViewModel:
     @Published var relationValueData: RelationValueData?
     @Published var relationsSearchData: RelationsSearchData?
     @Published var objectTypeData: EditorTypeObject?
-    @Published var toastBarData: ToastBarData = .empty
     
     let document: any BaseDocumentProtocol
     
@@ -68,10 +67,7 @@ final class RelationsListCoordinatorViewModel:
         relationValueData = relationValueProcessingService.handleRelationValue(
             relation: relation,
             objectDetails: objectDetails,
-            analyticsType: .menu,
-            onToastShow: { [weak self] message in
-                self?.toastBarData = ToastBarData(text: message, showSnackBar: true, messageType: .none)
-            }
+            analyticsType: .menu
         )
     }
     


### PR DESCRIPTION
Date module init with `date` now, not `objectId`

https://github.com/user-attachments/assets/72f749f4-37e3-4072-ab52-3f3d84fd3ee0

