### PR TITLE
iOS-3827 Date as an object | Update mentions texts if needed

### DIFF
--- a/Anytype/Sources/Models/Documents/Events/DocumentViewModelSetter.swift
+++ b/Anytype/Sources/Models/Documents/Events/DocumentViewModelSetter.swift
@@ -8,6 +8,9 @@ protocol DocumentViewModelSetterProtocol: AnyObject {
 
 final class DocumentViewModelSetter: DocumentViewModelSetterProtocol {
     
+    @Injected(\.mentionTextUpdateHandler)
+    private var mentionTextUpdateHandler: any MentionTextUpdateHandlerProtocol
+    
     private let detailsStorage: ObjectDetailsStorage
     private let relationKeysStorage: any RelationKeysStorageProtocol
     private let restrictionsContainer: ObjectRestrictionsContainer
@@ -53,6 +56,14 @@ final class DocumentViewModelSetter: DocumentViewModelSetterProtocol {
         let restrinctions = MiddlewareObjectRestrictionsConverter.convertObjectRestrictions(middlewareRestrictions: data.restrictions)
         
         restrictionsContainer.restrinctions = restrinctions
+        
+        if FeatureFlags.relativeDates {
+            mentionTextUpdateHandler.updateMentionsTextsIfNeeded(
+                objectId: data.rootID,
+                infoContainer: infoContainer,
+                detailsStorage: detailsStorage
+            )
+        }
     }
     
     // MARK: - Private

--- a/Anytype/Sources/Models/Documents/Events/MentionMarkupEventProvider.swift
+++ b/Anytype/Sources/Models/Documents/Events/MentionMarkupEventProvider.swift
@@ -4,6 +4,9 @@ import ProtobufMessages
 
 final class MentionMarkupEventProvider {
     
+    @Injected(\.mentionTextUpdateHandler)
+    private var mentionTextUpdateHandler: any MentionTextUpdateHandlerProtocol
+    
     private let objectId: String
     private let infoContainer: any InfoContainerProtocol
     private let detailsStorage: ObjectDetailsStorage
@@ -19,99 +22,10 @@ final class MentionMarkupEventProvider {
     }
     
     func updateMentionsEvent() -> [DocumentUpdate] {
-        return infoContainer
-            .recursiveChildren(of: objectId)
-            .compactMap { updateIfNeeded(info: $0) }
-            .map { .block(blockId: $0) }
-    }
-    
-    func updateIfNeeded(info: BlockInformation) -> String? {
-        guard case let .text(content) = info.content else { return nil }
-        guard !content.marks.marks.isEmpty else { return nil }
-        
-        var string = content.text
-        var sortedMarks = content.marks.marks
-            .sorted { $0.range.from < $1.range.from }
-        var needUpdate = false
-        
-        for offset in 0..<sortedMarks.count {
-            let mark = sortedMarks[offset]
-            guard mark.type == .mention && mark.param.isNotEmpty else { continue }
-            
-            guard let mentionRange = mentionRange(in: string, range: mark.range) else { continue }
-            let mentionFrom = mark.range.from
-            let mentionTo = mark.range.to
-            let mentionName = string[mentionRange]
-            
-            let mentionBlockId = mark.param
-            
-            guard
-                let details = detailsStorage.get(id: mentionBlockId)
-            else { return nil }
-            
-            let mentionNameInDetails = details.mentionTitle
-            
-            
-            let previousString = string[mentionRange]
-            if previousString != mentionNameInDetails {
-                needUpdate = true
-            }
-            
-            let countDelta = Int32(mentionName.count - mentionNameInDetails.count)
-
-            string.replaceSubrange(mentionRange, with: mentionNameInDetails)
-            
-            if countDelta != 0 {
-                var mentionMark = mark
-                mentionMark.range.to -= countDelta
-                sortedMarks[offset] = mentionMark
-                
-                for counter in 0..<sortedMarks.count {
-                    var mark = sortedMarks[counter]
-                    if counter == offset || mark.range.to <= mentionFrom {
-                        continue
-                    }
-                    
-                    if mark.range.from >= mentionTo {
-                        mark.range.from -= countDelta
-                    }
-                    mark.range.to -= countDelta
-                    sortedMarks[counter] = mark
-                }
-            }
-        }
-        
-        if needUpdate {
-            update(info: info, string: string, marks: sortedMarks)
-        }
-        
-        return needUpdate ? info.id : nil
-    }
-    
-    private func mentionRange(in string: String, range: Anytype_Model_Range) -> Range<String.Index>? {
-        guard range.from < string.utf16.count, range.to <= string.utf16.count else {
-            anytypeAssertionFailure("Index out of bounds", info: [
-                "range from": "\(range.from)",
-                "range to": "\(range.to)",
-                "string lenght": "\(string.utf16.count)"
-            ])
-            return nil
-        }
-        let from = string.utf16.index(string.utf16.startIndex, offsetBy: Int(range.from))
-        let to = string.utf16.index(string.utf16.startIndex, offsetBy: Int(range.to))
-        return from..<to
-    }
-    
-    private func update(
-        info: BlockInformation,
-        string: String,
-        marks: [Anytype_Model_Block.Content.Text.Mark]) {
-        if case var .text(content) = info.content {
-            content.text = string
-            content.marks = Anytype_Model_Block.Content.Text.Marks.with { $0.marks = marks }
-            infoContainer.add(
-                info.updated(content: .text(content))
-            )
-        }
+        mentionTextUpdateHandler.updateMentionsTextsIfNeeded(
+            objectId: objectId,
+            infoContainer: infoContainer,
+            detailsStorage: detailsStorage
+        ).map { .block(blockId: $0) }
     }
 }

--- a/Anytype/Sources/Models/Documents/MentionTextUpdateHandler/MentionTextUpdateHandler.swift
+++ b/Anytype/Sources/Models/Documents/MentionTextUpdateHandler/MentionTextUpdateHandler.swift
@@ -1,0 +1,121 @@
+import AnytypeCore
+import Services
+import ProtobufMessages
+
+protocol MentionTextUpdateHandlerProtocol {
+    @discardableResult
+    func updateMentionsTextsIfNeeded(
+        objectId: String,
+        infoContainer: some InfoContainerProtocol,
+        detailsStorage: ObjectDetailsStorage
+    ) -> [String]
+}
+
+final class MentionTextUpdateHandler: MentionTextUpdateHandlerProtocol {
+    
+    @discardableResult
+    func updateMentionsTextsIfNeeded(
+        objectId: String,
+        infoContainer: some InfoContainerProtocol,
+        detailsStorage: ObjectDetailsStorage
+    ) -> [String] {
+        let blocks = infoContainer.recursiveChildren(of: objectId)
+        return blocks.compactMap { block in
+            update(infoContainer: infoContainer, info: block, detailsStorage: detailsStorage)
+        }
+    }
+    
+    private func update(infoContainer: some InfoContainerProtocol, info: BlockInformation, detailsStorage: ObjectDetailsStorage) -> String? {
+        guard case let .text(content) = info.content else {
+            return nil
+        }
+        guard !content.marks.marks.isEmpty else {
+            return nil
+        }
+        
+        var string = content.text
+        var sortedMarks = content.marks.marks
+            .sorted { $0.range.from < $1.range.from }
+        var needUpdate = false
+        
+        for offset in 0..<sortedMarks.count {
+            let mark = sortedMarks[offset]
+            guard mark.type == .mention && mark.param.isNotEmpty else { continue }
+            
+            guard let mentionRange = mentionRange(in: string, range: mark.range) else { continue }
+            let mentionFrom = mark.range.from
+            let mentionTo = mark.range.to
+            let mentionName = string[mentionRange]
+            
+            let mentionBlockId = mark.param
+            
+            guard let details = detailsStorage.get(id: mentionBlockId) else { return nil }
+            
+            let mentionNameInDetails = details.mentionTitle
+            
+            
+            let previousString = string[mentionRange]
+            if previousString != mentionNameInDetails {
+                needUpdate = true
+            }
+            
+            let countDelta = Int32(mentionName.count - mentionNameInDetails.count)
+
+            string.replaceSubrange(mentionRange, with: mentionNameInDetails)
+            
+            if countDelta != 0 {
+                var mentionMark = mark
+                mentionMark.range.to -= countDelta
+                sortedMarks[offset] = mentionMark
+                
+                for counter in 0..<sortedMarks.count {
+                    var mark = sortedMarks[counter]
+                    if counter == offset || mark.range.to <= mentionFrom {
+                        continue
+                    }
+                    
+                    if mark.range.from >= mentionTo {
+                        mark.range.from -= countDelta
+                    }
+                    mark.range.to -= countDelta
+                    sortedMarks[counter] = mark
+                }
+            }
+        }
+        
+        if needUpdate {
+            update(infoContainer: infoContainer, info: info, string: string, marks: sortedMarks)
+            return info.id
+        } else {
+            return nil
+        }
+    }
+    
+    private func mentionRange(in string: String, range: Anytype_Model_Range) -> Range<String.Index>? {
+        guard range.from < string.utf16.count, range.to <= string.utf16.count else {
+            anytypeAssertionFailure("Index out of bounds", info: [
+                "range from": "\(range.from)",
+                "range to": "\(range.to)",
+                "string lenght": "\(string.utf16.count)"
+            ])
+            return nil
+        }
+        let from = string.utf16.index(string.utf16.startIndex, offsetBy: Int(range.from))
+        let to = string.utf16.index(string.utf16.startIndex, offsetBy: Int(range.to))
+        return from..<to
+    }
+    
+    private func update(
+        infoContainer: some InfoContainerProtocol,
+        info: BlockInformation,
+        string: String,
+        marks: [Anytype_Model_Block.Content.Text.Mark]) {
+        if case var .text(content) = info.content {
+            content.text = string
+            content.marks = Anytype_Model_Block.Content.Text.Marks.with { $0.marks = marks }
+            infoContainer.add(
+                info.updated(content: .text(content))
+            )
+        }
+    }
+}

--- a/Anytype/Sources/ServiceLayer/ServicesDI.swift
+++ b/Anytype/Sources/ServiceLayer/ServicesDI.swift
@@ -351,4 +351,8 @@ extension Container {
     var setByTypeSubscriptionService: Factory<any SetByTypeSubscriptionServiceProtocol> {
         self { SetByTypeSubscriptionService() }
     }
+    
+    var mentionTextUpdateHandler: Factory<any MentionTextUpdateHandlerProtocol> {
+        self { MentionTextUpdateHandler() }
+    }
 }

--- a/Anytype/Sources/ServiceLayer/Subscriptions/Tree/TreeSubscriptionDataBuilder.swift
+++ b/Anytype/Sources/ServiceLayer/Subscriptions/Tree/TreeSubscriptionDataBuilder.swift
@@ -16,6 +16,7 @@ final class TreeSubscriptionDataBuilder: TreeSubscriptionDataBuilderProtocol {
         let keys: [BundledRelationKey] = .builder {
             BundledRelationKey.objectListKeys
             BundledRelationKey.links
+            BundledRelationKey.timestamp
         }.uniqued()
         
         return .objects(


### PR DESCRIPTION
Just move logic from `MentionMarkupEventProvider` to `MentionTextUpdateHandler` and call it in `DocumentViewModelSetter` to update any mention title on document set (for date as well too)