### PR TITLE
iOS-3929 Avoid accident tapping on row when scrolling in LegacySearch

### DIFF
--- a/Anytype/Sources/PresentationLayer/Search screen/View/LegacySearchView.swift
+++ b/Anytype/Sources/PresentationLayer/Search screen/View/LegacySearchView.swift
@@ -62,11 +62,11 @@ struct LegacySearchView: View {
     
     private func rowViews(rows: [ListRowConfiguration]) -> some View {
         ForEach(rows) { row in
-            Button {
-                viewModel.didSelectRow(with: row.id)
-            } label: {
-                row.makeView()
-            }
+            row.makeView()
+                .fixTappableArea()
+                .onTapGesture {
+                    viewModel.didSelectRow(with: row.id)
+                }
         }
     }
     


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/07a8a037-1d3e-4796-9035-84678c868c7b

After

https://github.com/user-attachments/assets/61f30c8a-25b4-4914-b70f-ae71afdccf83

