### PR TITLE
Ios-4125 Primitives | Build relations for templates based on target object id

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/ObjectType/ObjectTypeViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ObjectType/ObjectTypeViewModel.swift
@@ -124,7 +124,7 @@ final class ObjectTypeViewModel: ObservableObject {
             
             if let recommendedLayout = details.recommendedLayoutValue {
                 let isSupportedLayout = recommendedLayout.isEditorLayout
-                let isTemplate = details.uniqueKeyValue == ObjectTypeUniqueKey.template
+                let isTemplate = details.isTemplateType
                 showTemplates = isSupportedLayout && !isTemplate
                 if showTemplates { buildTemplates() }
             } else {

--- a/Anytype/Sources/PresentationLayer/Modules/ObjectType/Views/ObjectsList/ObjectTypeObjectsListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ObjectType/Views/ObjectsList/ObjectTypeObjectsListViewModel.swift
@@ -55,7 +55,7 @@ final class ObjectTypeObjectsListViewModel: ObservableObject {
             }
 
             let isSupportedLayout = layout.isEditorLayout || layout.isList
-            let isTemplate = details.uniqueKeyValue == ObjectTypeUniqueKey.template
+            let isTemplate = details.isTemplateType
             canCreateOjbect = isSupportedLayout && !isTemplate
         }
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -83,7 +83,7 @@ final class EditorSetViewModel: ObservableObject {
         guard let details = setDocument.details else { return false }
         
         let isSupportedLayout = details.recommendedLayoutValue.isEditorLayout
-        let isTemplate = details.uniqueKeyValue == ObjectTypeUniqueKey.template
+        let isTemplate = details.isTemplateType
         return isSupportedLayout && !isTemplate
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/Builders/SetPermissionsBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/Builders/SetPermissionsBuilder.swift
@@ -48,7 +48,7 @@ final class SetPermissionsBuilder: SetPermissionsBuilderProtocol {
             return false
         }
         
-        if queryObject.uniqueKey == ObjectTypeUniqueKey.template {
+        if queryObject.isTemplateType {
             return false
         }
         


### PR DESCRIPTION
Now we use relations from target object id for templates. Before we were using relations from Template type
https://github.com/user-attachments/assets/1a2a645e-3e96-44ad-8c61-8a87e775bf5d

