### PR TITLE
IOS-4510 ToastBarData | more SwiftUI way API

### DIFF
--- a/Anytype/Sources/ApplicationLayer/AppCoordinator/ApplicationCoordinatorViewModel.swift
+++ b/Anytype/Sources/ApplicationLayer/AppCoordinator/ApplicationCoordinatorViewModel.swift
@@ -159,6 +159,6 @@ final class ApplicationCoordinatorViewModel: ObservableObject {
     }
 
     private func handleFileLimitReachedError() {
-        toastBarData = ToastBarData(Loc.FileStorage.limitError, type: .none)
+        toastBarData = ToastBarData(Loc.FileStorage.limitError, type: .neutral)
     }
 }

--- a/Anytype/Sources/ApplicationLayer/AppCoordinator/ApplicationCoordinatorViewModel.swift
+++ b/Anytype/Sources/ApplicationLayer/AppCoordinator/ApplicationCoordinatorViewModel.swift
@@ -27,7 +27,7 @@ final class ApplicationCoordinatorViewModel: ObservableObject {
     // MARK: - State
     
     @Published var applicationState: ApplicationState = .initial
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     @Published var migrationData: MigrationModuleData?
     @Published var selectAccountTaskId: String?
     
@@ -159,6 +159,6 @@ final class ApplicationCoordinatorViewModel: ObservableObject {
     }
 
     private func handleFileLimitReachedError() {
-        toastBarData = ToastBarData(text: Loc.FileStorage.limitError, showSnackBar: true, messageType: .none)
+        toastBarData = ToastBarData(Loc.FileStorage.limitError, type: .none)
     }
 }

--- a/Anytype/Sources/ApplicationLayer/AutoWidgetAddedHandler/AutoWidgetAddedModifierModel.swift
+++ b/Anytype/Sources/ApplicationLayer/AutoWidgetAddedHandler/AutoWidgetAddedModifierModel.swift
@@ -4,7 +4,7 @@ import ProtobufMessages
 @MainActor
 final class AutoWidgetAddedModifierModel: ObservableObject {
     
-    @Published var toastBarData = ToastBarData.empty
+    @Published var toastBarData: ToastBarData?
     
     func startSubscription() async {
         for await events in await EventBunchSubscribtion.default.stream() {
@@ -12,11 +12,7 @@ final class AutoWidgetAddedModifierModel: ObservableObject {
                 switch event.value {
                 case let .spaceAutoWidgetAdded(data):
                     AnytypeAnalytics.instance().logAddWidget(context: .auto, createType: .auto)
-                    toastBarData = ToastBarData(
-                        text: Loc.Widgets.autoAddedAlert(data.targetName),
-                        showSnackBar: true,
-                        messageType: .success
-                    )
+                    toastBarData = ToastBarData(Loc.Widgets.autoAddedAlert(data.targetName), type: .success)
                 default:
                     break
                 }

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/RelationInfoViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/RelationInfoViewModel.swift
@@ -41,7 +41,7 @@ final class RelationInfoViewModel: ObservableObject {
     @Published var name: String
     @Published private var format: SupportedRelationFormat
     @Published private var objectTypes: [ObjectType]?
-    @Published var toastData: ToastBarData = .empty
+    @Published var toastData: ToastBarData?
     
     private let target: RelationsModuleTarget
     private let objectId: String
@@ -148,7 +148,7 @@ extension RelationInfoViewModel {
             Loc.Fields.updated(relationDetails.name)
         }
         
-        toastData = ToastBarData(text: text, showSnackBar: true)
+        toastData = ToastBarData(text)
         UINotificationFeedbackGenerator().notificationOccurred(.success)
         output?.didPressConfirm(relationDetails)
     }

--- a/Anytype/Sources/PresentationLayer/Auth/JoinFlow/KeyPhraseView/KeyPhraseViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Auth/JoinFlow/KeyPhraseView/KeyPhraseViewModel.swift
@@ -10,7 +10,7 @@ final class KeyPhraseViewModel: ObservableObject {
         }
     }
     @Published var showMoreInfo = false
-    @Published var snackBar = ToastBarData.empty
+    @Published var snackBar: ToastBarData?
     
     let state: JoinFlowState
     
@@ -61,6 +61,6 @@ final class KeyPhraseViewModel: ObservableObject {
         AnytypeAnalytics.instance().logClickOnboarding(step: .phrase, button: .showAndCopy)
         UISelectionFeedbackGenerator().selectionChanged()
         UIPasteboard.general.string = state.mnemonic
-        snackBar = .init(text: Loc.copied, showSnackBar: true)
+        snackBar = ToastBarData(Loc.copied)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/AsyncThrowsTask.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/AsyncThrowsTask.swift
@@ -4,7 +4,7 @@ import SwiftUI
 fileprivate struct AsyncThrowsTaskModifier: ViewModifier {
     
     let action: @Sendable () async throws -> Void
-    @State private var toast: ToastBarData = .empty
+    @State private var toast: ToastBarData?
     
     func body(content: Content) -> some View {
         content
@@ -12,7 +12,7 @@ fileprivate struct AsyncThrowsTaskModifier: ViewModifier {
                 do {
                     try await action()
                 } catch {
-                    toast = ToastBarData(text: error.localizedDescription, showSnackBar: true, messageType: .failure)
+                    toast = ToastBarData(error.localizedDescription, type: .failure)
                 }
             }
     }
@@ -22,7 +22,7 @@ fileprivate struct AsyncThrowsIdTaskModifier<T: Equatable>: ViewModifier {
     
     let id: T
     let action: @Sendable () async throws -> Void
-    @State private var toast: ToastBarData = .empty
+    @State private var toast: ToastBarData?
     
     func body(content: Content) -> some View {
         content
@@ -30,7 +30,7 @@ fileprivate struct AsyncThrowsIdTaskModifier<T: Equatable>: ViewModifier {
                 do {
                     try await action()
                 } catch {
-                    toast = ToastBarData(text: error.localizedDescription, showSnackBar: true, messageType: .failure)
+                    toast = ToastBarData(error.localizedDescription, type: .failure)
                 }
             }
     }

--- a/Anytype/Sources/PresentationLayer/Debug/Views/MembershipDebugView.swift
+++ b/Anytype/Sources/PresentationLayer/Debug/Views/MembershipDebugView.swift
@@ -19,7 +19,7 @@ struct MembershipDebugView: View {
     
     @State private var tiers: [DebugTierData] = []
     @State private var transactions: [StoreKit.Transaction] = []
-    @State private var toastBarData = ToastBarData.empty
+    @State private var toastBarData: ToastBarData?
     
     @State private var refundId: StoreKit.Transaction.ID?
     @State private var showRefund = false
@@ -142,7 +142,7 @@ struct MembershipDebugView: View {
             }
             StandardButton("Copy to clipboard", style: .secondaryLarge) {
                 UIPasteboard.general.string = transaction.debugDescription
-                toastBarData = ToastBarData(text: "Copied debug info to clipboard", showSnackBar: true)
+                toastBarData = ToastBarData("Copied debug info to clipboard")
             }
             StandardButton("Refund", style: .warningLarge) {
                 refundId = transaction.id

--- a/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorViewModel.swift
@@ -93,7 +93,7 @@ final class EditorPageCoordinatorViewModel: ObservableObject, EditorPageModuleOu
     }
     
     func versionRestored(_ text: String) {
-        toastBarData = ToastBarData(Loc.VersionHistory.Toast.message(text), type: .none)
+        toastBarData = ToastBarData(Loc.VersionHistory.Toast.message(text), type: .neutral)
     }
     
     func showAddRelationInfoView(document: some BaseDocumentProtocol, onSelect: @escaping (RelationDetails, _ isNew: Bool) -> Void) {

--- a/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorViewModel.swift
@@ -15,7 +15,7 @@ final class EditorPageCoordinatorViewModel: ObservableObject, EditorPageModuleOu
     var pageNavigation: PageNavigation?
     @Published var dismiss = false
     @Published var relationValueData: RelationValueData?
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     @Published var codeLanguageData: CodeLanguageListData?
     @Published var covertPickerData: BaseDocumentIdentifiable?
     @Published var linkToObjectData: LinkToObjectSearchModuleData?
@@ -93,7 +93,7 @@ final class EditorPageCoordinatorViewModel: ObservableObject, EditorPageModuleOu
     }
     
     func versionRestored(_ text: String) {
-        toastBarData = ToastBarData(text: Loc.VersionHistory.Toast.message(text), showSnackBar: true, messageType: .none)
+        toastBarData = ToastBarData(Loc.VersionHistory.Toast.message(text), type: .none)
     }
     
     func showAddRelationInfoView(document: some BaseDocumentProtocol, onSelect: @escaping (RelationDetails, _ isNew: Bool) -> Void) {
@@ -112,7 +112,7 @@ final class EditorPageCoordinatorViewModel: ObservableObject, EditorPageModuleOu
     }
     
     func showFailureToast(message: String) {
-        toastBarData = ToastBarData(text: message, showSnackBar: true, messageType: .failure)
+        toastBarData = ToastBarData(message, type: .failure)
     }
     
     func showSyncStatusInfo(spaceId: String) {

--- a/Anytype/Sources/PresentationLayer/Flows/EditorSetFlow/EditorSetCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorSetFlow/EditorSetCoordinatorViewModel.swift
@@ -57,7 +57,7 @@ final class EditorSetCoordinatorViewModel:
     @Published var setQueryData: SetQueryData?
     @Published var relationValueData: RelationValueData?
     @Published var covertPickerData: BaseDocumentIdentifiable?
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     @Published var objectIconPickerData: ObjectIconPickerData?
     @Published var syncStatusSpaceId: StringIdentifiable?
     @Published var setObjectCreationData: SetObjectCreationData?
@@ -224,7 +224,7 @@ final class EditorSetCoordinatorViewModel:
     }
     
     func showFailureToast(message: String) {
-        toastBarData = ToastBarData(text: message, showSnackBar: true, messageType: .failure)
+        toastBarData = ToastBarData(message, type: .failure)
     }
     
     func showSyncStatusInfo(spaceId: String) {
@@ -256,7 +256,7 @@ final class EditorSetCoordinatorViewModel:
     }
     
     func versionRestored(_ text: String) {
-        toastBarData = ToastBarData(text: Loc.VersionHistory.Toast.message(text), showSnackBar: true, messageType: .none)
+        toastBarData = ToastBarData(Loc.VersionHistory.Toast.message(text), type: .none)
     }
     
     // MARK: - SetObjectCreationSettingsOutput

--- a/Anytype/Sources/PresentationLayer/Flows/EditorSetFlow/EditorSetCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorSetFlow/EditorSetCoordinatorViewModel.swift
@@ -256,7 +256,7 @@ final class EditorSetCoordinatorViewModel:
     }
     
     func versionRestored(_ text: String) {
-        toastBarData = ToastBarData(Loc.VersionHistory.Toast.message(text), type: .none)
+        toastBarData = ToastBarData(Loc.VersionHistory.Toast.message(text), type: .neutral)
     }
     
     // MARK: - SetObjectCreationSettingsOutput

--- a/Anytype/Sources/PresentationLayer/Flows/InitialCoordinator/InitialCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/InitialCoordinator/InitialCoordinatorViewModel.swift
@@ -22,7 +22,7 @@ final class InitialCoordinatorViewModel: ObservableObject {
     
     @Published var showWarningAlert: Bool = false
     @Published var showSaveBackupAlert: Bool = false
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     @Published var middlewareShareFile: URL? = nil
     @Published var localStoreURL: URL? = nil
     
@@ -52,7 +52,7 @@ final class InitialCoordinatorViewModel: ObservableObject {
             try await localAuthService.auth(reason: Loc.accessToKeyFromKeychain)
             let phrase = try seedService.obtainSeed()
             UIPasteboard.general.string = phrase
-            toastBarData = ToastBarData(text: Loc.copied, showSnackBar: true)
+            toastBarData = ToastBarData(Loc.copied)
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -242,7 +242,7 @@ final class SpaceHubCoordinatorViewModel: ObservableObject, SpaceHubModuleOutput
             try await document.open()
             guard let details = document.details else { return }
             guard details.isSupportedForOpening || data.isSimpleSet else {
-                toastBarData = ToastBarData(Loc.openTypeError(details.objectType.displayName), type: .none)
+                toastBarData = ToastBarData(Loc.openTypeError(details.objectType.displayName), type: .neutral)
                 return
             }
         }

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -21,7 +21,7 @@ final class SpaceHubCoordinatorViewModel: ObservableObject, SpaceHubModuleOutput
     @Published var spaceJoinData: SpaceJoinModuleData?
     @Published var membershipNameFinalizationData: MembershipTier?
     @Published var showGlobalSearchData: GlobalSearchModuleData?
-    @Published var toastBarData = ToastBarData.empty
+    @Published var toastBarData: ToastBarData?
     @Published var showSpaceShareData: SpaceShareData?
     @Published var showSpaceMembersData: SpaceMembersData?
     @Published var chatProvider = ChatActionProvider()
@@ -242,9 +242,7 @@ final class SpaceHubCoordinatorViewModel: ObservableObject, SpaceHubModuleOutput
             try await document.open()
             guard let details = document.details else { return }
             guard details.isSupportedForOpening || data.isSimpleSet else {
-                toastBarData = ToastBarData(
-                    text: Loc.openTypeError(details.objectType.displayName), showSnackBar: true, messageType: .none
-                )
+                toastBarData = ToastBarData(Loc.openTypeError(details.objectType.displayName), type: .none)
                 return
             }
         }
@@ -390,7 +388,7 @@ final class SpaceHubCoordinatorViewModel: ObservableObject, SpaceHubModuleOutput
             guard accountManager.account.allowMembership else { return }
             membershipTierId = tierId.identifiable
         case .networkConfig:
-            toastBarData = ToastBarData(text: Loc.unsupportedDeeplink, showSnackBar: true)
+            toastBarData = ToastBarData(Loc.unsupportedDeeplink)
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
@@ -105,7 +105,7 @@ final class ChatViewModel: ObservableObject, MessageModuleOutput, ChatActionProv
     
     @Published var deleteMessageConfirmation: MessageViewData?
     @Published var showSendLimitAlert = false
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     
     init(spaceId: String, chatId: String, output: (any ChatModuleOutput)?) {
         self.spaceId = spaceId
@@ -673,7 +673,7 @@ final class ChatViewModel: ObservableObject, MessageModuleOutput, ChatActionProv
     }
     
     private func showFileLimitAlert() {
-        toastBarData = ToastBarData(text: Loc.Chat.AttachmentsLimit.alert(chatMessageLimits.attachmentsLimit), showSnackBar: true, messageType: .failure)
+        toastBarData = ToastBarData(Loc.Chat.AttachmentsLimit.alert(chatMessageLimits.attachmentsLimit), type: .failure)
     }
     
     private func buildObjectSearcData(type: ObjectSearchWithMetaType) -> ObjectSearchWithMetaModuleData {

--- a/Anytype/Sources/PresentationLayer/Modules/DashboardClearCacheAlert/DashboardClearCacheAlertModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/DashboardClearCacheAlert/DashboardClearCacheAlertModel.swift
@@ -14,7 +14,7 @@ final class DashboardClearCacheAlertModel: ObservableObject {
     
     // MARK: - State
     
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     
     func onAppear() {
         AnytypeAnalytics.instance().logScreenFileOffloadWarning()
@@ -26,7 +26,7 @@ final class DashboardClearCacheAlertModel: ObservableObject {
             try await fileActionService.clearCache()
             AnytypeAnalytics.instance().logFileOffload()
             UINotificationFeedbackGenerator().notificationOccurred(.success)
-            self.toastBarData = ToastBarData(text: Loc.ClearCache.success, showSnackBar: true)
+            self.toastBarData = ToastBarData(Loc.ClearCache.success)
         } catch {
             UINotificationFeedbackGenerator().notificationOccurred(.error)
             throw error

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Views/Alerts/DashboardAccountDeletionAlert/DashboardAccountDeletionAlertModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Views/Alerts/DashboardAccountDeletionAlert/DashboardAccountDeletionAlertModel.swift
@@ -11,7 +11,7 @@ final class DashboardAccountDeletionAlertModel: ObservableObject {
     @Injected(\.applicationStateService)
     private var applicationStateService: any ApplicationStateServiceProtocol
     
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     
     func accountDeletionConfirm() async {
         UINotificationFeedbackGenerator().notificationOccurred(.success)
@@ -30,7 +30,7 @@ final class DashboardAccountDeletionAlertModel: ObservableObject {
                 try await logout()
             }
         } catch {
-            toastBarData = ToastBarData(text: error.localizedDescription, showSnackBar: true, messageType: .failure)
+            toastBarData = ToastBarData(error.localizedDescription, type: .failure)
             UINotificationFeedbackGenerator().notificationOccurred(.error)
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Bin/BinWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Bin/BinWidgetViewModel.swift
@@ -21,7 +21,7 @@ final class BinWidgetViewModel: ObservableObject {
     
     // MARK: - State
     
-    @Published var toastData: ToastBarData = .empty
+    @Published var toastData: ToastBarData?
     @Published var binAlertData: BinConfirmationAlertData? = nil
     var dragId: String { data.widgetBlockId }
     
@@ -38,7 +38,7 @@ final class BinWidgetViewModel: ObservableObject {
     func onEmptyBinTap() async throws {
         let binIds = try await searchService.searchArchiveObjectIds(spaceId: data.workspaceInfo.accountSpaceId)
         guard binIds.isNotEmpty else {
-            toastData = ToastBarData(text: Loc.Widgets.Actions.binConfirm(binIds.count), showSnackBar: true)
+            toastData = ToastBarData(Loc.Widgets.Actions.binConfirm(binIds.count))
             return
         }
         binAlertData = BinConfirmationAlertData(ids: binIds)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/BinLink/BinLinkWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/BinLink/BinLinkWidgetViewModel.swift
@@ -16,7 +16,7 @@ final class BinLinkWidgetViewModel: ObservableObject {
     
     // MARK: - State
     
-    @Published var toastData: ToastBarData = .empty
+    @Published var toastData: ToastBarData?
     @Published var binAlertData: BinConfirmationAlertData? = nil
     
     init(spaceId: String, output: (any CommonWidgetModuleOutput)?) {
@@ -32,7 +32,7 @@ final class BinLinkWidgetViewModel: ObservableObject {
     func onEmptyBinTap() async throws {
         let binIds = try await searchService.searchArchiveObjectIds(spaceId: spaceId)
         guard binIds.isNotEmpty else {
-            toastData = ToastBarData(text: Loc.Widgets.Actions.binConfirm(binIds.count), showSnackBar: true)
+            toastData = ToastBarData(Loc.Widgets.Actions.binConfirm(binIds.count))
             return
         }
         binAlertData = BinConfirmationAlertData(ids: binIds)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/BinLink/ConfirmationView/BinConfirmationAlertModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/BinLink/ConfirmationView/BinConfirmationAlertModel.swift
@@ -17,7 +17,7 @@ final class BinConfirmationAlertModel: ObservableObject {
     private let ids: [String]
     
     var count: Int { ids.count }
-    @Published var toastData: ToastBarData = .empty
+    @Published var toastData: ToastBarData?
     
     init(data: BinConfirmationAlertData) {
         self.ids = data.ids
@@ -30,6 +30,6 @@ final class BinConfirmationAlertModel: ObservableObject {
     func onConfirm() async throws {
         AnytypeAnalytics.instance().logDeletion(count: ids.count, route: .bin)
         try await objectActionsService.delete(objectIds: ids)
-        toastData = ToastBarData(text: Loc.Widgets.Actions.binConfirm(ids.count), showSnackBar: true)
+        toastData = ToastBarData(Loc.Widgets.Actions.binConfirm(ids.count))
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Container/WidgetContainerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Container/WidgetContainerViewModel.swift
@@ -30,7 +30,7 @@ final class WidgetContainerViewModel: ObservableObject {
         didSet { expandedDidChange() }
     }
     @Published var homeState: HomeWidgetsState = .readonly
-    @Published var toastData = ToastBarData.empty
+    @Published var toastData: ToastBarData?
     
     init(
         widgetBlockId: String,

--- a/Anytype/Sources/PresentationLayer/Modules/InviteLink/InviteLinkViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/InviteLink/InviteLinkViewModel.swift
@@ -15,7 +15,7 @@ final class InviteLinkViewModel: ObservableObject {
     @Published var canDeleteLink = false
     @Published var canCopyInviteLink = false
     @Published var deleteLinkSpaceId: StringIdentifiable? = nil
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     
     @Injected(\.participantSpacesStorage)
     private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
@@ -94,14 +94,14 @@ final class InviteLinkViewModel: ObservableObject {
             }
             AnytypeAnalytics.instance().logClickShareSpaceCopyLink()
             UIPasteboard.general.string = inviteLink?.absoluteString
-            toastBarData = ToastBarData(text: Loc.copied, showSnackBar: true)
+            toastBarData = ToastBarData(Loc.copied)
         }
     }
     
     func onCopyLink() {
         AnytypeAnalytics.instance().logClickShareSpaceCopyLink()
         UIPasteboard.general.string = shareLink?.absoluteString
-        toastBarData = ToastBarData(text: Loc.copied, showSnackBar: true)
+        toastBarData = ToastBarData(Loc.copied)
     }
     
     func onShareInvite() {

--- a/Anytype/Sources/PresentationLayer/Modules/Membership/TierSelection/OwnershipView/MembershipOwnerInfoSheetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Membership/TierSelection/OwnershipView/MembershipOwnerInfoSheetViewModel.swift
@@ -13,7 +13,7 @@ final class MembershipOwnerInfoSheetViewModel: ObservableObject {
     
     @Published var email: String = ""
     @Published var changeEmail = false
-    @Published var toastData: ToastBarData = .empty
+    @Published var toastData: ToastBarData?
     
     // remove after middleware start to send update membership event
     @Published private var justUpdatedEmail = false
@@ -46,6 +46,6 @@ final class MembershipOwnerInfoSheetViewModel: ObservableObject {
         showEmailVerification = false
         changeEmail = false
         justUpdatedEmail = true
-        toastData = ToastBarData(text: Loc.emailSuccessfullyValidated, showSnackBar: true)
+        toastData = ToastBarData(Loc.emailSuccessfullyValidated)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/ObjectType/ObjectTypeViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ObjectType/ObjectTypeViewModel.swift
@@ -14,7 +14,7 @@ final class ObjectTypeViewModel: ObservableObject {
     @Published var typeName = ""
     @Published var relationsCount: Int = 0
     
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     @Published var showDeleteConfirmation = false
     @Published var showTemplates = false
     
@@ -195,7 +195,7 @@ final class ObjectTypeViewModel: ObservableObject {
             do {
                 let templateId = try await templatesService.createTemplateFromObjectType(objectTypeId: document.objectId, spaceId: document.spaceId)
                 output?.showTemplatesPicker(defaultTemplateId: templateId)
-                toastBarData = ToastBarData(text: Loc.Templates.Popup.WasAddedTo.title(details?.title ?? ""), showSnackBar: true)
+                toastBarData = ToastBarData(Loc.Templates.Popup.WasAddedTo.title(details?.title ?? ""))
             } catch {
                 anytypeAssertionFailure(error.localizedDescription)
             }

--- a/Anytype/Sources/PresentationLayer/Modules/ServerDocumentPicker/ServerDocumentPickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ServerDocumentPicker/ServerDocumentPickerViewModel.swift
@@ -10,7 +10,7 @@ final class ServerDocumentPickerViewModel: ObservableObject {
     
     // MARK: - State
     
-    @Published var toast = ToastBarData.empty
+    @Published var toast: ToastBarData?
     
     func onSelectFile(url: URL) {
         do {
@@ -18,7 +18,7 @@ final class ServerDocumentPickerViewModel: ObservableObject {
             AnytypeAnalytics.instance().logUploadNetworkConfiguration()
             AnytypeAnalytics.instance().logSelectNetwork(type: .selfHost, route: .onboarding)
         } catch {
-            toast = ToastBarData(text: Loc.error, showSnackBar: true, messageType: .failure)
+            toast = ToastBarData(Loc.error, type: .failure)
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceJoin/SpaceJoinViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceJoin/SpaceJoinViewModel.swift
@@ -37,7 +37,7 @@ final class SpaceJoinViewModel: ObservableObject {
     @Published var message: String = Loc.SpaceShare.Join.message("", "") // For Placeholder
     @Published var state: ScreenState = .loading
     @Published var dataState: SpaceJoinDataState = .invite
-    @Published var toast: ToastBarData = .empty
+    @Published var toast: ToastBarData?
     @Published var showSuccessAlert = false
     @Published var dismiss = false
     

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceShare/SpaceShareViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceShare/SpaceShareViewModel.swift
@@ -39,7 +39,7 @@ final class SpaceShareViewModel: ObservableObject {
     var spaceId: String { data.spaceId }
     
     @Published var rows: [SpaceShareParticipantViewModel] = []
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     @Published var requestAlertModel: SpaceRequestAlertData?
     @Published var changeAccessAlertModel: SpaceChangeAccessViewModel?
     @Published var removeParticipantAlertModel: SpaceParticipantRemoveViewModel?
@@ -162,7 +162,7 @@ final class SpaceShareViewModel: ObservableObject {
             return SpaceShareParticipantViewModel.Action(title: Loc.SpaceShare.Action.approve, action: { [weak self] in
                 AnytypeAnalytics.instance().logApproveLeaveRequest()
                 try await self?.workspaceService.leaveApprove(spaceId: participant.spaceId, identity: participant.identity)
-                self?.toastBarData = ToastBarData(text: Loc.SpaceShare.Approve.toast(participant.title), showSnackBar: true)
+                self?.toastBarData = ToastBarData(Loc.SpaceShare.Approve.toast(participant.title))
             })
         case .active:
             return SpaceShareParticipantViewModel.Action(title: nil, action: { [weak self] in
@@ -231,7 +231,7 @@ final class SpaceShareViewModel: ObservableObject {
                     identity: participant.identity,
                     permissions: newPermission
                 )
-                self?.toastBarData = ToastBarData(text: Loc.SpaceShare.accessChanged, showSnackBar: true, messageType: .success)
+                self?.toastBarData = ToastBarData(Loc.SpaceShare.accessChanged, type: .success)
             }
         )
     }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Subviews/StopSharingAlert/StopSharingAlertModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Subviews/StopSharingAlert/StopSharingAlertModel.swift
@@ -10,7 +10,7 @@ final class StopSharingAlertModel: ObservableObject {
     private let spaceId: String
     private let onStopShare: (() -> Void)?
     
-    @Published var toast: ToastBarData = .empty
+    @Published var toast: ToastBarData?
     
     init(spaceId: String, onStopShare: (() -> Void)?) {
         self.spaceId = spaceId
@@ -19,7 +19,7 @@ final class StopSharingAlertModel: ObservableObject {
     
     func onTapStopShare() async throws {
         try await workspaceService.stopSharing(spaceId: spaceId)
-        toast = ToastBarData(text: Loc.SpaceShare.StopSharing.toast, showSnackBar: true, messageType: .success)
+        toast = ToastBarData(Loc.SpaceShare.StopSharing.toast, type: .success)
         AnytypeAnalytics.instance().logStopSpaceShare()
         onStopShare?()
     }

--- a/Anytype/Sources/PresentationLayer/Modules/SpacesManager/Alerts/CancelRequest/SpaceCancelRequestAlertModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpacesManager/Alerts/CancelRequest/SpaceCancelRequestAlertModel.swift
@@ -9,7 +9,7 @@ final class SpaceCancelRequestAlertModel: ObservableObject {
     
     private let spaceId: String
     
-    @Published var toast: ToastBarData = .empty
+    @Published var toast: ToastBarData?
     
     init(spaceId: String) {
         self.spaceId = spaceId
@@ -17,6 +17,6 @@ final class SpaceCancelRequestAlertModel: ObservableObject {
     
     func onTapCancelEquest() async throws {
         try await workspaceService.joinCancel(spaceId: spaceId)
-        toast = ToastBarData(text: Loc.SpaceManager.CancelRequestAlert.toast, showSnackBar: true, messageType: .success)
+        toast = ToastBarData(Loc.SpaceManager.CancelRequestAlert.toast, type: .success)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpacesManager/Subviews/SpacesManagerRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpacesManager/Subviews/SpacesManagerRowView.swift
@@ -10,8 +10,6 @@ struct SpacesManagerRowView: View {
     let onCancelRequest: () async throws -> Void
     let onArchive: () async throws -> Void
     let onStopSharing: () async throws -> Void
-
-    @State private var toast = ToastBarData.empty
     
     var body: some View {
         VStack(spacing: 0) {

--- a/Anytype/Sources/PresentationLayer/Notifications/CommonViews/TopNotificationView.swift
+++ b/Anytype/Sources/PresentationLayer/Notifications/CommonViews/TopNotificationView.swift
@@ -7,7 +7,7 @@ struct TopNotificationView: View {
     var icon: Icon? = nil
     var buttons: [TopNotificationButton]
     
-    @State private var toast: ToastBarData = .empty
+    @State private var toast: ToastBarData?
     
     var body: some View {
         HStack(alignment: .top, spacing: 12) {

--- a/Anytype/Sources/PresentationLayer/Notifications/Specific/RequestToJoin/RequestToJoinNotificationViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Notifications/Specific/RequestToJoin/RequestToJoinNotificationViewModel.swift
@@ -14,7 +14,7 @@ final class RequestToJoinNotificationViewModel: ObservableObject {
     private let onViewRequest: (_ notification: NotificationRequestToJoin) async -> Void
     
     @Published var message: String = ""
-    @Published var toast: ToastBarData = .empty
+    @Published var toast: ToastBarData?
     @Published var dismiss = false
     
     init(

--- a/Anytype/Sources/PresentationLayer/Notifications/Specific/RequestToLeave/RequestToLeaveNotificationViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Notifications/Specific/RequestToLeave/RequestToLeaveNotificationViewModel.swift
@@ -11,7 +11,7 @@ final class RequestToLeaveNotificationViewModel: ObservableObject {
     private var notificationsService: any NotificationsServiceProtocol
     
     @Published var message: String = ""
-    @Published var toast: ToastBarData = .empty
+    @Published var toast: ToastBarData?
     @Published var dismiss = false
     
     init(notification: NotificationRequestToLeave) {
@@ -25,7 +25,7 @@ final class RequestToLeaveNotificationViewModel: ObservableObject {
     func onTapApprove() async throws {
         AnytypeAnalytics.instance().logApproveLeaveRequest()
         try await workspaceService.leaveApprove(spaceId: notification.requestToLeave.spaceID, identity: notification.requestToLeave.identity)
-        toast = ToastBarData(text: Loc.SpaceShare.Approve.toast(notification.requestToLeave.identityName), showSnackBar: true)
+        toast = ToastBarData(Loc.SpaceShare.Approve.toast(notification.requestToLeave.identityName))
         try await notificationsService.reply(ids: [notification.common.id], actionType: .close)
         dismiss.toggle()
     }

--- a/Anytype/Sources/PresentationLayer/ObjectCreationSettings/Views/Selection/SetObjectCreationSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/ObjectCreationSettings/Views/Selection/SetObjectCreationSettingsViewModel.swift
@@ -26,7 +26,7 @@ final class SetObjectCreationSettingsViewModel: ObservableObject {
     @Published var objectTypes = [InstalledObjectTypeViewModel]()
     @Published var templates = [TemplatePreviewViewModel]()
     @Published var canChangeObjectType = false
-    @Published var toastData: ToastBarData = .empty
+    @Published var toastData: ToastBarData?
     
     var isTemplatesEditable = false
     
@@ -105,7 +105,7 @@ final class SetObjectCreationSettingsViewModel: ObservableObject {
                 )
                 let objectDetails = await retrieveObjectDetails(objectId: objectTypeId, spaceId: spaceId)
                 let title = objectDetails?.title.trimmed(numberOfCharacters: 16) ?? ""
-                toastData = ToastBarData(text: Loc.Templates.Popup.WasAddedTo.title(title), showSnackBar: true)
+                toastData = ToastBarData(Loc.Templates.Popup.WasAddedTo.title(title))
             } catch {
                 anytypeAssertionFailure(error.localizedDescription)
             }
@@ -128,7 +128,7 @@ final class SetObjectCreationSettingsViewModel: ObservableObject {
         Task {
             do {
                 try await templatesService.setTemplateAsDefaultForType(objectTypeId: interactor.objectTypeId, templateId: templateId)
-                toastData = ToastBarData(text: Loc.Templates.Popup.default, showSnackBar: true)
+                toastData = ToastBarData(Loc.Templates.Popup.default)
             }
         }
     }
@@ -214,10 +214,10 @@ final class SetObjectCreationSettingsViewModel: ObservableObject {
                 switch option {
                 case .delete:
                     try await templatesService.deleteTemplate(templateId: templateViewModel.id)
-                    toastData = ToastBarData(text: Loc.Templates.Popup.removed, showSnackBar: true)
+                    toastData = ToastBarData(Loc.Templates.Popup.removed)
                 case .duplicate:
                     try await templatesService.cloneTemplate(blockId: templateViewModel.id)
-                    toastData = ToastBarData(text: Loc.Templates.Popup.duplicated, showSnackBar: true)
+                    toastData = ToastBarData(Loc.Templates.Popup.duplicated)
                 case .editTemplate:
                     output?.templateEditingHandler(
                         setting: ObjectCreationSetting(objectTypeId: objectTypeId, spaceId: spaceId, templateId: templateViewModel.id),

--- a/Anytype/Sources/PresentationLayer/ObjectTypeSearch/ObjectTypeSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/ObjectTypeSearch/ObjectTypeSearchViewModel.swift
@@ -13,7 +13,7 @@ final class ObjectTypeSearchViewModel: ObservableObject {
     @Published var searchText = ""
     @Published var showPasteButton = false
     @Published var newTypeInfo: ObjectTypeInfo?
-    @Published var toastData: ToastBarData = .empty
+    @Published var toastData: ToastBarData?
     @Published var participantCanEdit = false
     
     let settings: ObjectTypeSearchViewSettings
@@ -140,7 +140,7 @@ final class ObjectTypeSearchViewModel: ObservableObject {
                 let newTypeDetails = try await workspaceService.installObject(spaceId: spaceId, objectId: type.id)
                 let newType = ObjectType(details: newTypeDetails)
                 
-                toastData = ToastBarData(text: Loc.ObjectType.addedToLibrary(type.displayName), showSnackBar: true)
+                toastData = ToastBarData(Loc.ObjectType.addedToLibrary(type.displayName))
                 
                 onSelect(.objectType(type: newType))
             } else {

--- a/Anytype/Sources/PresentationLayer/RelationValueFlow/RelationValueCoordinator/RelationValueCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/RelationValueFlow/RelationValueCoordinator/RelationValueCoordinatorViewModel.swift
@@ -25,7 +25,7 @@ final class RelationValueCoordinatorViewModel:
     private let analyticsType: AnalyticsEventsRelationType
     private weak var output: (any RelationValueCoordinatorOutput)?
 
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     @Published var safariUrl: URL?
     
     init(data: RelationValueData, output: (any RelationValueCoordinatorOutput)?) {
@@ -247,6 +247,6 @@ final class RelationValueCoordinatorViewModel:
     }
     
     func showActionSuccessMessage(_ text: String) {
-        toastBarData = ToastBarData(text: text, showSnackBar: true, messageType: .success)
+        toastBarData = ToastBarData(text, type: .success)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Settings/About/AboutViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Settings/About/AboutViewModel.swift
@@ -20,7 +20,7 @@ final class AboutViewModel: ObservableObject {
     // MARK: - State
     
     @Published var info: String = ""
-    @Published var snackBarData = ToastBarData.empty
+    @Published var snackBarData: ToastBarData?
     @Published var safariUrl: URL?
     @Published var openUrl: URL?
     
@@ -71,7 +71,7 @@ final class AboutViewModel: ObservableObject {
     func onInfoTap() {
         UISelectionFeedbackGenerator().selectionChanged()
         UIPasteboard.general.string = fullInfo()
-        snackBarData = .init(text: Loc.copiedToClipboard(Loc.About.techInfo), showSnackBar: true)
+        snackBarData = ToastBarData(Loc.copiedToClipboard(Loc.About.techInfo))
     }
     
     func onDebugMenuTap() {

--- a/Anytype/Sources/PresentationLayer/Settings/KeychainPhraseView/KeychainPhraseViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Settings/KeychainPhraseView/KeychainPhraseViewModel.swift
@@ -15,7 +15,7 @@ class KeychainPhraseViewModel: ObservableObject {
     // MARK: - State
     
     @Published private(set) var recoveryPhrase: String? = nil
-    @Published var toastBarData: ToastBarData = .empty
+    @Published var toastBarData: ToastBarData?
     
     init(shownInContext: AnalyticsEventsKeychainContext) {
         self.shownInContext = shownInContext
@@ -49,7 +49,7 @@ class KeychainPhraseViewModel: ObservableObject {
     }
     
     private func showToast() {
-        toastBarData = ToastBarData(text: Loc.Keychain.Key.Copy.Toast.title, showSnackBar: true)
+        toastBarData = ToastBarData(Loc.Keychain.Key.Copy.Toast.title)
         AnytypeAnalytics.instance().logKeychainPhraseCopy(shownInContext)
     }
 }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceProfile/SpaceProfileViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceProfile/SpaceProfileViewModel.swift
@@ -17,7 +17,7 @@ final class SpaceProfileViewModel: ObservableObject {
     @Published var showSpaceLeaveAlert = false
     
     @Published var settingsInfo = [SettingsInfoModel]()
-    @Published var snackBarData = ToastBarData.empty
+    @Published var snackBarData: ToastBarData?
     
     @Published var shareInviteLink: URL?
     @Published var qrInviteLink: URL?
@@ -115,7 +115,7 @@ final class SpaceProfileViewModel: ObservableObject {
     private func updateSettingsInfo() {
         guard let participantSpaceView else { return }
         settingsInfo = spaceSettingsInfoBuilder.build(workspaceInfo: workspaceInfo, details: participantSpaceView.spaceView, owner: owner) { [weak self] in
-            self?.snackBarData = .init(text: Loc.copiedToClipboard($0), showSnackBar: true)
+            self?.snackBarData = ToastBarData(Loc.copiedToClipboard($0))
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Legacy/SpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Legacy/SpaceSettingsViewModel.swift
@@ -41,7 +41,7 @@ final class SpaceSettingsViewModel: ObservableObject {
     @Published var spaceAccessType = ""
     @Published var spaceIcon: Icon?
     @Published var info = [SettingsInfoModel]()
-    @Published var snackBarData = ToastBarData.empty
+    @Published var snackBarData: ToastBarData?
     @Published var showSpaceDeleteAlert = false
     @Published var showSpaceLeaveAlert = false
     @Published var dismiss = false
@@ -167,7 +167,7 @@ final class SpaceSettingsViewModel: ObservableObject {
             info.append(
                 SettingsInfoModel(title: spaceRelationDetails.name, subtitle: details.targetSpaceId, onTap: { [weak self] in
                     UIPasteboard.general.string = details.targetSpaceId
-                    self?.snackBarData = .init(text: Loc.copiedToClipboard(spaceRelationDetails.name), showSnackBar: true)
+                    self?.snackBarData = ToastBarData(Loc.copiedToClipboard(spaceRelationDetails.name))
                 })
             )
         }
@@ -181,7 +181,7 @@ final class SpaceSettingsViewModel: ObservableObject {
                     SettingsInfoModel(title: creatorDetails.name, subtitle: displayName, onTap: { [weak self] in
                         guard let self else { return }
                         UIPasteboard.general.string = displayName
-                        snackBarData = .init(text: Loc.copiedToClipboard(creatorDetails.name), showSnackBar: true)
+                        snackBarData = ToastBarData(Loc.copiedToClipboard(creatorDetails.name))
                     })
                 )
             }
@@ -191,7 +191,7 @@ final class SpaceSettingsViewModel: ObservableObject {
             SettingsInfoModel(title: Loc.SpaceSettings.networkId, subtitle: workspaceInfo.networkId, onTap: { [weak self] in
                 guard let self else { return }
                 UIPasteboard.general.string = workspaceInfo.networkId
-                snackBarData = .init(text: Loc.copiedToClipboard(Loc.SpaceSettings.networkId), showSnackBar: true)
+                snackBarData = ToastBarData(Loc.copiedToClipboard(Loc.SpaceSettings.networkId))
             })
         )
         

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/NewSpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/NewSpaceSettingsViewModel.swift
@@ -45,7 +45,7 @@ final class NewSpaceSettingsViewModel: ObservableObject {
     @Published var spaceIcon: Icon?
     
     @Published var info = [SettingsInfoModel]()
-    @Published var snackBarData = ToastBarData.empty
+    @Published var snackBarData: ToastBarData?
     @Published var showSpaceDeleteAlert = false
     @Published var showSpaceLeaveAlert = false
     @Published var showInfoView = false
@@ -160,7 +160,7 @@ final class NewSpaceSettingsViewModel: ObservableObject {
                 .spaceUxType(isOn ? .chat : .data)
             ])
             
-            snackBarData = ToastBarData(text: isOn ? Loc.Settings.chatEnabled : Loc.Settings.chatDisabled, showSnackBar: true)
+            snackBarData = ToastBarData(isOn ? Loc.Settings.chatEnabled : Loc.Settings.chatDisabled)
         }
     }
     
@@ -259,7 +259,7 @@ final class NewSpaceSettingsViewModel: ObservableObject {
                 ]
             )
             
-            snackBarData = ToastBarData(text: Loc.Settings.updated, showSnackBar: true)
+            snackBarData = ToastBarData(Loc.Settings.updated)
         }
     }
     
@@ -280,7 +280,7 @@ final class NewSpaceSettingsViewModel: ObservableObject {
         }
         
         info = spaceSettingsInfoBuilder.build(workspaceInfo: workspaceInfo, details: spaceView, owner: owner) { [weak self] in
-            self?.snackBarData = .init(text: Loc.copiedToClipboard($0), showSnackBar: true)
+            self?.snackBarData = ToastBarData(Loc.copiedToClipboard($0))
         }
         
         spaceName = spaceView.name

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Views/SpaceLeaveAlert/SpaceLeaveAlertModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Views/SpaceLeaveAlert/SpaceLeaveAlertModel.swift
@@ -12,7 +12,7 @@ final class SpaceLeaveAlertModel: ObservableObject {
     private let spaceId: String
     
     @Published var spaceName: String = ""
-    @Published var toast: ToastBarData = .empty
+    @Published var toast: ToastBarData?
     
     init(spaceId: String) {
         self.spaceId = spaceId
@@ -26,6 +26,6 @@ final class SpaceLeaveAlertModel: ObservableObject {
     func onTapLeave() async throws {
         AnytypeAnalytics.instance().logLeaveSpace()
         try await workspaceService.deleteSpace(spaceId: spaceId)
-        toast = ToastBarData(text: Loc.SpaceSettings.LeaveAlert.toast(spaceName), showSnackBar: true, messageType: .success)
+        toast = ToastBarData(Loc.SpaceSettings.LeaveAlert.toast(spaceName), type: .success)
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionsViewModel.swift
@@ -38,7 +38,7 @@ final class ObjectActionsViewModel: ObservableObject {
     private var workspaceService: any WorkspaceServiceProtocol
     
     @Published var objectActions: [ObjectAction] = []
-    @Published var toastData = ToastBarData.empty
+    @Published var toastData: ToastBarData?
     @Published var dismiss = false
     
     init(objectId: String, spaceId: String, output: (any ObjectActionsOutput)?) {
@@ -160,7 +160,7 @@ final class ObjectActionsViewModel: ObservableObject {
             position: .above(widgetId: first.id)
         )
         AnytypeAnalytics.instance().logAddWidget(context: .object, createType: .manual)
-        toastData = ToastBarData(text: Loc.Actions.CreateWidget.success, showSnackBar: true, messageType: .success)
+        toastData = ToastBarData(Loc.Actions.CreateWidget.success, type: .success)
         dismiss.toggle()
     }
     
@@ -176,7 +176,7 @@ final class ObjectActionsViewModel: ObservableObject {
         }
         
         UIPasteboard.general.string = link?.absoluteString
-        toastData = ToastBarData(text: Loc.copied, showSnackBar: true)
+        toastData = ToastBarData(Loc.copied)
         dismiss.toggle()
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/ObjectType/ObjectTypeTemplatePickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/ObjectType/ObjectTypeTemplatePickerViewModel.swift
@@ -7,7 +7,7 @@ import AnytypeCore
 final class ObjectTypeTemplatePickerViewModel: ObservableObject {
     @Published var templates = [TemplatePreviewViewModel]()
     @Published var templatesCount = 0
-    @Published var toastBarData = ToastBarData.empty
+    @Published var toastBarData: ToastBarData?
     
     private var output: (any EditorSetModuleOutput)?
     private let document: any BaseDocumentProtocol
@@ -43,7 +43,7 @@ final class ObjectTypeTemplatePickerViewModel: ObservableObject {
             do {
                 let templateId = try await templatesService.createTemplateFromObjectType(objectTypeId: document.objectId, spaceId: document.spaceId)
                 output?.onObjectTypeSingleTemplateTap(objectId: document.objectId, spaceId: document.spaceId, defaultTemplateId: templateId)
-                toastBarData = ToastBarData(text: Loc.Templates.Popup.WasAddedTo.title(document.details?.title ?? ""), showSnackBar: true)
+                toastBarData = ToastBarData(Loc.Templates.Popup.WasAddedTo.title(document.details?.title ?? ""))
             } catch {
                 anytypeAssertionFailure(error.localizedDescription)
             }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/LegacyRelationsListSearch/RelationsSearchCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/LegacyRelationsListSearch/RelationsSearchCoordinatorViewModel.swift
@@ -5,7 +5,7 @@ import Services
 final class RelationsSearchCoordinatorViewModel: ObservableObject, RelationInfoCoordinatorViewOutput {
     
     @Published var newRelationData: RelationInfoData?
-    @Published var toastData: ToastBarData = .empty
+    @Published var toastData: ToastBarData?
     @Published var dismiss = false
     
     let data: RelationsSearchData
@@ -26,7 +26,7 @@ final class RelationsSearchCoordinatorViewModel: ObservableObject, RelationInfoC
     
     func onSelectRelation(_ relation: RelationDetails) {
         data.onRelationSelect(relation, false)
-        toastData = ToastBarData(text: Loc.Fields.created(relation.name), showSnackBar: true)
+        toastData = ToastBarData(Loc.Fields.created(relation.name))
         dismiss.toggle()
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/Views/UndoRedo/UndoRedoViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Views/UndoRedo/UndoRedoViewModel.swift
@@ -10,7 +10,7 @@ final class UndoRedoViewModel: ObservableObject {
     
     private let objectId: String
 
-    @Published var toastData: ToastBarData = .empty
+    @Published var toastData: ToastBarData?
     
     init(
         objectId: String
@@ -23,7 +23,7 @@ final class UndoRedoViewModel: ObservableObject {
         do {
             try await objectActionsService.undo(objectId: objectId)
         } catch let error as ObjectActionsServiceError {
-            toastData = ToastBarData(text: error.localizedDescription, showSnackBar: true, messageType: .none)
+            toastData = ToastBarData(error.localizedDescription, type: .none)
         }
     }
 
@@ -32,7 +32,7 @@ final class UndoRedoViewModel: ObservableObject {
             AnytypeAnalytics.instance().logRedo()
             try await objectActionsService.redo(objectId: objectId)
         } catch let error as ObjectActionsServiceError {
-            toastData = ToastBarData(text: error.localizedDescription, showSnackBar: true, messageType: .none)
+            toastData = ToastBarData(error.localizedDescription, type: .none)
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Views/UndoRedo/UndoRedoViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Views/UndoRedo/UndoRedoViewModel.swift
@@ -23,7 +23,7 @@ final class UndoRedoViewModel: ObservableObject {
         do {
             try await objectActionsService.undo(objectId: objectId)
         } catch let error as ObjectActionsServiceError {
-            toastData = ToastBarData(error.localizedDescription, type: .none)
+            toastData = ToastBarData(error.localizedDescription, type: .neutral)
         }
     }
 
@@ -32,7 +32,7 @@ final class UndoRedoViewModel: ObservableObject {
             AnytypeAnalytics.instance().logRedo()
             try await objectActionsService.redo(objectId: objectId)
         } catch let error as ObjectActionsServiceError {
-            toastData = ToastBarData(error.localizedDescription, type: .none)
+            toastData = ToastBarData(error.localizedDescription, type: .neutral)
         }
     }
 }

--- a/Modules/DesignKit/Sources/DesignKit/Components/AsyncButton/AsyncButton.swift
+++ b/Modules/DesignKit/Sources/DesignKit/Components/AsyncButton/AsyncButton.swift
@@ -7,7 +7,7 @@ public struct AsyncButton<Label> : View where Label : View {
     let label: Label
     let role: ButtonRole?
     
-    @State private var toast: ToastBarData = .empty
+    @State private var toast: ToastBarData?
     
     public init(role: ButtonRole? = nil, action: @escaping () async throws -> Void, @ViewBuilder label: () -> Label) {
         self.action = action
@@ -21,7 +21,7 @@ public struct AsyncButton<Label> : View where Label : View {
                 do {
                     try await action()
                 } catch {
-                    toast = ToastBarData(text: error.localizedDescription, showSnackBar: true, messageType: .failure)
+                    toast = ToastBarData(error.localizedDescription, type: .failure)
                 }
             }
         } label: {

--- a/Modules/DesignKit/Sources/DesignKit/Components/AsyncButton/AsyncStandardButton.swift
+++ b/Modules/DesignKit/Sources/DesignKit/Components/AsyncButton/AsyncStandardButton.swift
@@ -8,7 +8,7 @@ public struct AsyncStandardButton: View {
     let action: () async throws -> Void
     
     @State private var inProgress: Bool = false
-    @State private var toast = ToastBarData.empty
+    @State private var toast: ToastBarData?
     @Environment(\.standardButtonGroupDisable) @Binding private var groupDisable
     
     public init(
@@ -32,7 +32,7 @@ public struct AsyncStandardButton: View {
                     try await action()
                 } catch {
                     UINotificationFeedbackGenerator().notificationOccurred(.error)
-                    toast = ToastBarData(text: error.localizedDescription, showSnackBar: true, messageType: .failure)
+                    toast = ToastBarData(error.localizedDescription, type: .failure)
                 }
                 inProgress = false
                 groupDisable = false

--- a/Modules/DesignKit/Sources/DesignKit/Toast/ToastBarData.swift
+++ b/Modules/DesignKit/Sources/DesignKit/Toast/ToastBarData.swift
@@ -1,19 +1,12 @@
 public struct ToastBarData: Equatable {
     public let text: String
-    public let showSnackBar: Bool
-    public let messageType: ToastMessageType
+    public let type: ToastMessageType
     
     public init(
-        text: String,
-        showSnackBar: Bool,
-        messageType: ToastMessageType = .success
+        _ text: String,
+        type: ToastMessageType = .success
     ) {
         self.text = text
-        self.showSnackBar = showSnackBar
-        self.messageType = messageType
-    }
-    
-    public static var empty: ToastBarData {
-        ToastBarData(text: "", showSnackBar: false)
+        self.type = type
     }
 }

--- a/Modules/DesignKit/Sources/DesignKit/Toast/View+Snackbar.swift
+++ b/Modules/DesignKit/Sources/DesignKit/Toast/View+Snackbar.swift
@@ -7,7 +7,7 @@ public extension View {
 }
 
 public enum ToastMessageType {
-    case none
+    case neutral
     case success
     case failure
 }
@@ -25,7 +25,7 @@ private struct ToastModififer: ViewModifier {
                     ToastManager.showSuccessAlert(message: newValue.text)
                 case .failure:
                     ToastManager.showFailureAlert(message: newValue.text)
-                case .none:
+                case .neutral:
                     ToastManager.show(message: newValue.text)
                 }
                 toastBarData = nil

--- a/Modules/DesignKit/Sources/DesignKit/Toast/View+Snackbar.swift
+++ b/Modules/DesignKit/Sources/DesignKit/Toast/View+Snackbar.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 public extension View {
-    func snackbar(toastBarData: Binding<ToastBarData>) -> some View {
+    func snackbar(toastBarData: Binding<ToastBarData?>) -> some View {
         modifier(ToastModififer(toastBarData: toastBarData))
     }
 }
@@ -14,22 +14,21 @@ public enum ToastMessageType {
 
 private struct ToastModififer: ViewModifier {
     
-    @Binding var toastBarData: ToastBarData
+    @Binding var toastBarData: ToastBarData?
     
     func body(content: Content) -> some View {
         content
             .onChange(of: toastBarData) { newValue in
-                if newValue.showSnackBar {
-                    switch newValue.messageType {
-                        case .success:
-                            ToastManager.showSuccessAlert(message: newValue.text)
-                        case .failure:
-                            ToastManager.showFailureAlert(message: newValue.text)
-                        case .none:
-                            ToastManager.show(message: newValue.text)
-                    }
+                guard let newValue else { return }
+                switch newValue.type {
+                case .success:
+                    ToastManager.showSuccessAlert(message: newValue.text)
+                case .failure:
+                    ToastManager.showFailureAlert(message: newValue.text)
+                case .none:
+                    ToastManager.show(message: newValue.text)
                 }
-                toastBarData = .empty
+                toastBarData = nil
             }
     }
 }


### PR DESCRIPTION
1. ToastBarData is optional now. Remove `showSnackBar` field and `empy` value
2. Changed constructor to shorten syntax
Old:
`ToastBarData(text: "Some text", messageType: .someType)`
New
`ToastBarData("Some text", type: .someType)`