### PR TITLE
iOS-4546 Fix empty name file preview

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/UIKit/ImageViewer/ImageViewer/PreviewRemoteItem.swift
+++ b/Anytype/Sources/PresentationLayer/Common/UIKit/ImageViewer/ImageViewer/PreviewRemoteItem.swift
@@ -33,7 +33,7 @@ final class PreviewRemoteItem: NSObject, QLPreviewItem, Identifiable, PreviewMed
         super.init()
         handler.output = self
         
-        let path = FileManager.originalPath(objectId: fileDetails.id, fileName: fileDetails.fileName)
+        let path = FileManager.originalPath(objectId: fileDetails.id, fileName: fileDetails.fileDirectoryName)
         if FileManager.default.fileExists(atPath: path.relativePath) {
             self.previewItemURL = path
         } else {

--- a/Modules/Services/Sources/Models/Details/FileDetails.swift
+++ b/Modules/Services/Sources/Models/Details/FileDetails.swift
@@ -23,13 +23,19 @@ public struct FileDetails: Sendable {
     }
     
     public var fileName: String {
-        return FileDetails.formattedFileName(name, fileExt: fileExt)
+        FileDetails.formattedFileName(name, fileExt: fileExt)
+    }
+    
+    public var fileDirectoryName: String {
+        let fileName = name.isEmpty ? id : name
+        return FileDetails.formattedFileName(fileName, fileExt: fileExt)
     }
     
     static func formattedFileName(_ name: String, fileExt: String) -> String {
         let formattedFileExt = ".\(fileExt)"
         let fileSuffix = fileExt.isNotEmpty && !name.hasSuffix(formattedFileExt) ? formattedFileExt : ""
-        return name + fileSuffix
+        let fileName = name + fileSuffix
+        return fileName
     }
 }
 


### PR DESCRIPTION
`QLPreviewController` can't open image / file with empty name, save it with id name


https://github.com/user-attachments/assets/87742de5-a12a-4677-8002-33f013801dcc

