### PR TITLE
IOS-4653 Support toggle for default template state

### DIFF
--- a/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
+++ b/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
@@ -44,6 +44,10 @@ extension BundledRelationsValueProvider {
         return parsedType ?? ObjectTypeProvider.shared.deletedObjectType(id: type)
     }
     
+    var targetObjectTypeValue: ObjectType? {
+        return try? ObjectTypeProvider.shared.objectType(id: targetObjectType)
+    }
+    
     var editorViewType: ScreenType {
         switch resolvedLayoutValue {
         case .basic, .profile, .todo, .note, .space, .UNRECOGNIZED, .relation,

--- a/Anytype/Sources/PresentationLayer/Flows/EditorSetFlow/EditorSetCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorSetFlow/EditorSetCoordinatorViewModel.swift
@@ -306,7 +306,7 @@ final class EditorSetCoordinatorViewModel:
         Task { @MainActor in
             try? await templatesService.setTemplateAsDefaultForType(objectTypeId: objectId, templateId: templateId)
             navigationContext.dismissTopPresented(animated: true, completion: nil)
-            toastPresenter.show(message: Loc.Templates.Popup.default)
+            toastPresenter.show(message: templateId.isEmpty ? Loc.unsetAsDefault : Loc.Templates.Popup.default)
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectAction.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectAction.swift
@@ -2,7 +2,6 @@ import Services
 import AnytypeCore
 
 enum ObjectAction: Hashable, Identifiable {
-    // NOTE: When adding new case here, it case MUST be added in allCasesWith method
     case undoRedo
     case archive(isArchived: Bool)
     case favorite(isFavorite: Bool)
@@ -10,7 +9,7 @@ enum ObjectAction: Hashable, Identifiable {
     case duplicate
     case linkItself
     case makeAsTemplate
-    case templateSetAsDefault
+    case templateToggleDefaultState(isDefault: Bool)
     case delete
     case createWidget
     case copyLink
@@ -42,8 +41,9 @@ enum ObjectAction: Hashable, Identifiable {
                 ObjectAction.makeAsTemplate
             }
             
-            if permissions.canTemplateSetAsDefault {
-                ObjectAction.templateSetAsDefault
+            if permissions.canTemplateSetAsDefault, let targetObjectType = details.targetObjectTypeValue {
+                let isDefault = targetObjectType.defaultTemplateId == details.id
+                ObjectAction.templateToggleDefaultState(isDefault: isDefault)
             }
             
             if permissions.canLinkItself {
@@ -80,8 +80,8 @@ enum ObjectAction: Hashable, Identifiable {
             return "linkItself"
         case .makeAsTemplate:
             return "makeAsTemplate"
-        case .templateSetAsDefault:
-            return "templateSetAsDefault"
+        case .templateToggleDefaultState:
+            return "templateToggleDefaultState"
         case .delete:
             return "delete"
         case .createWidget:

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionRow.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionRow.swift
@@ -63,8 +63,8 @@ private extension ObjectAction {
             return Loc.Actions.linkItself
         case .makeAsTemplate:
             return Loc.Actions.makeAsTemplate
-        case .templateSetAsDefault:
-            return Loc.Actions.templateMakeDefault
+        case .templateToggleDefaultState(let isDefault):
+            return isDefault ? Loc.unsetDefault : Loc.Actions.templateMakeDefault
         case .delete:
             return Loc.delete
         case .createWidget:
@@ -90,7 +90,7 @@ private extension ObjectAction {
             return .X32.linkTo
         case .makeAsTemplate:
             return .makeAsTemplate
-        case .templateSetAsDefault:
+        case .templateToggleDefaultState:
             return .templateMakeDefault
         case .delete:
             return .X32.delete

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionsView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionsView.swift
@@ -30,8 +30,8 @@ struct ObjectActionsView: View {
                             viewModel.linkItselfAction()
                         case .makeAsTemplate:
                             try await viewModel.makeAsTempalte()
-                        case .templateSetAsDefault:
-                            viewModel.makeTemplateAsDefault()
+                        case .templateToggleDefaultState:
+                            try await viewModel.templateToggleDefaultState()
                         case .delete:
                             try await viewModel.deleteAction()
                         case .createWidget:

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionsViewModel.swift
@@ -114,10 +114,14 @@ final class ObjectActionsViewModel: ObservableObject {
         output?.onNewTemplateCreation(templateId: templateId)
     }
     
-    func makeTemplateAsDefault() {
-        guard let details = document.details else { return }
+    func templateToggleDefaultState() async throws {
+        guard let details = document.details,
+        let targetObjectType = details.targetObjectTypeValue else { return }
+
+        let isCurrentlyDefault = targetObjectType.defaultTemplateId == details.id
+        let newTemplateId = isCurrentlyDefault ? "" : details.id
         
-        output?.onTemplateMakeDefault(templateId: details.id)
+        output?.onTemplateMakeDefault(templateId: newTemplateId)
     }
     
     func deleteAction() async throws {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Routing/Editor/EditorRouter.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Routing/Editor/EditorRouter.swift
@@ -443,11 +443,15 @@ extension EditorRouter {
     }
     
     func didTapUseTemplateAsDefault(templateId: String) {
-        guard let objectTypeId = document.details?.objectType.id else { return }
+        guard let details = document.details else { return }
+       
         Task { @MainActor in
-            try? await templateService.setTemplateAsDefaultForType(objectTypeId: objectTypeId, templateId: templateId)
+            try await templateService.setTemplateAsDefaultForType(
+                objectTypeId: details.type,
+                templateId: templateId
+            )
             navigationContext.dismissTopPresented(animated: true, completion: nil)
-            toastPresenter.show(message: Loc.Templates.Popup.default)
+            toastPresenter.show(message: templateId.isEmpty ? Loc.unsetAsDefault : Loc.Templates.Popup.default)
         }
     }
 }

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -441,6 +441,7 @@ public enum Loc {
   public static let unread = Loc.tr("Localizable", "Unread", fallback: "Unread")
   public static let unselectAll = Loc.tr("Localizable", "Unselect all", fallback: "Unselect all")
   public static let unsetAsDefault = Loc.tr("Localizable", "Unset as default", fallback: "Unset as default")
+  public static let unsetDefault = Loc.tr("Localizable", "Unset default", fallback: "Unset default")
   public static let unsplash = Loc.tr("Localizable", "Unsplash", fallback: "Unsplash")
   public static let unsupported = Loc.tr("Localizable", "Unsupported", fallback: "Unsupported")
   public static let unsupportedBlock = Loc.tr("Localizable", "Unsupported block", fallback: "Unsupported block")


### PR DESCRIPTION
## Summary
- Add ability to unset default template in object actions
- Show "Unset default" text when template is already default
- Update toast messages to reflect set/unset actions

## Test plan
- [ ] Open a template object
- [ ] Check object actions menu shows "Set as default" if not default
- [ ] Set template as default and verify toast shows "Set as default"
- [ ] Check object actions menu now shows "Unset default"
- [ ] Unset default and verify toast shows "Unset as default"

🤖 Generated with [Claude Code](https://claude.ai/code)