### PR TITLE
IOS-4660 Rename NewRelationSectionView to NewPropertySectionView

### DIFF
--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
@@ -38,7 +38,7 @@ struct PropertyInfoView: View {
     }
     
     private var nameSection: some View {
-        NewRelationSectionView(
+        NewPropertySectionView(
             title: Loc.name,
             contentViewBuilder: {
                 TextField(Loc.untitled, text: $viewModel.name)
@@ -52,7 +52,7 @@ struct PropertyInfoView: View {
     
     private var formatSection: some View {
         if viewModel.mode.canEditRelationType {
-            NewRelationSectionView(
+            NewPropertySectionView(
                 title: Loc.format,
                 contentViewBuilder: {
                     NewRelationFormatSectionView(model: viewModel.formatModel)
@@ -64,7 +64,7 @@ struct PropertyInfoView: View {
                 isArrowVisible: true
             )
         } else {
-            NewRelationSectionView(
+            NewPropertySectionView(
                 title: Loc.type,
                 contentViewBuilder: {
                     NewRelationFormatSectionView(model: viewModel.formatModel)
@@ -77,7 +77,7 @@ struct PropertyInfoView: View {
     
     private var restrictionsSection: some View {
         viewModel.objectTypesRestrictionModel.flatMap { model in
-            NewRelationSectionView(
+            NewPropertySectionView(
                 title: Loc.limitObjectTypes,
                 contentViewBuilder: {
                     NewRelationRestrictionsSectionView(model: model)

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertySectionView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertySectionView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct NewRelationSectionView<Content: View>: View {
+struct NewPropertySectionView<Content: View>: View {
     
     let title: String
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Renamed `NewRelationSectionView` to `NewPropertySectionView`
- Updated all 4 usages in `PropertyInfoView.swift`
- Renamed file accordingly

Part of the effort to rename "Relation" to "Property" throughout the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)