### PR TITLE
IOS-4660 Rename NewRelationFormatSectionView to NewPropertyFormatSectionView

### DIFF
--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
@@ -55,7 +55,7 @@ struct PropertyInfoView: View {
             NewPropertySectionView(
                 title: Loc.format,
                 contentViewBuilder: {
-                    NewRelationFormatSectionView(model: viewModel.formatModel)
+                    NewPropertyFormatSectionView(model: viewModel.formatModel)
                 },
                 onTap: {
                     UIApplication.shared.hideKeyboard()
@@ -67,7 +67,7 @@ struct PropertyInfoView: View {
             NewPropertySectionView(
                 title: Loc.type,
                 contentViewBuilder: {
-                    NewRelationFormatSectionView(model: viewModel.formatModel)
+                    NewPropertyFormatSectionView(model: viewModel.formatModel)
                 },
                 onTap: nil,
                 isArrowVisible: false

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertyFormatSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertyFormatSectionView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct NewRelationFormatSectionView: View {
+struct NewPropertyFormatSectionView: View {
     
     let model: Model
     
@@ -16,7 +16,7 @@ struct NewRelationFormatSectionView: View {
     
 }
 
-extension NewRelationFormatSectionView {
+extension NewPropertyFormatSectionView {
     
     struct Model: Hashable {
         let icon: ImageAsset
@@ -25,10 +25,10 @@ extension NewRelationFormatSectionView {
     
 }
 
-struct NewRelationFormatSectionView_Previews: PreviewProvider {
+struct NewPropertyFormatSectionView_Previews: PreviewProvider {
     static var previews: some View {
-        NewRelationFormatSectionView(
-            model: NewRelationFormatSectionView.Model(icon: .X24.text, title: "Text")
+        NewPropertyFormatSectionView(
+            model: NewPropertyFormatSectionView.Model(icon: .X24.text, title: "Text")
         )
     }
 }

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
@@ -6,7 +6,7 @@ import Combine
 @MainActor
 final class PropertyInfoViewModel: ObservableObject {
     
-    var formatModel: NewRelationFormatSectionView.Model {
+    var formatModel: NewPropertyFormatSectionView.Model {
         format.asViewModel
     }
     
@@ -191,8 +191,8 @@ private extension PropertyInfoViewModel {
 
 private extension SupportedPropertyFormat {
     
-    var asViewModel: NewRelationFormatSectionView.Model {
-        NewRelationFormatSectionView.Model(icon: self.iconAsset, title: self.title)
+    var asViewModel: NewPropertyFormatSectionView.Model {
+        NewPropertyFormatSectionView.Model(icon: self.iconAsset, title: self.title)
     }
     
     var asRelationFormat: RelationFormat {


### PR DESCRIPTION
## Summary
- Renamed `NewRelationFormatSectionView` to `NewPropertyFormatSectionView`
- Updated 2 usages in `PropertyInfoView.swift`
- Updated 3 usages in `PropertyInfoViewModel.swift`
- Renamed file accordingly

Part of the effort to rename "Relation" to "Property" throughout the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)