### PR TITLE
IOS-4660 Rename NewRelationRestrictionsSectionView to NewPropertyRestrictionsSectionView

### DIFF
--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
@@ -80,7 +80,7 @@ struct PropertyInfoView: View {
             NewPropertySectionView(
                 title: Loc.limitObjectTypes,
                 contentViewBuilder: {
-                    NewRelationRestrictionsSectionView(model: model)
+                    NewPropertyRestrictionsSectionView(model: model)
                 },
                 onTap: {
                     UIApplication.shared.hideKeyboard()

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertyRestrictionsSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertyRestrictionsSectionView.swift
@@ -3,7 +3,7 @@ import Services
 import AnytypeCore
 
 
-struct NewRelationRestrictionsSectionView: View {
+struct NewPropertyRestrictionsSectionView: View {
     
     let model: [ObjectTypeModel]
     
@@ -45,7 +45,7 @@ struct NewRelationRestrictionsSectionView: View {
     }
 }
 
-extension NewRelationRestrictionsSectionView {    
+extension NewPropertyRestrictionsSectionView {    
     struct ObjectTypeModel: Identifiable, Hashable {
         let id: String
         let icon: ObjectIcon
@@ -54,56 +54,56 @@ extension NewRelationRestrictionsSectionView {
     
 }
 
-struct NewRelationRestrictionsSectionView_Previews: PreviewProvider {
+struct NewPropertyRestrictionsSectionView_Previews: PreviewProvider {
     static var previews: some View {
-        NewRelationRestrictionsSectionView(
+        NewPropertyRestrictionsSectionView(
             model: [
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .customIcon(CustomIconData(icon: .man, customColor: .gray)),
                     title: "custom icon title 1"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .customIcon(CustomIconData(icon: .transgender, customColor: .pink)),
                     title: "custom icon title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .customIcon(CustomIconData(icon: .telescope, customColor: .amber)),
                     title: "custom icon title 3"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("📘")!),
                     title: "title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("🐭")!),
                     title: "title 1"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("📘")!),
                     title: "title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("🤡")!),
                     title: "title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("🤡")!),
                     title: "title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("🤡")!),
                     title: "title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("🤡")!),
                     title: "title 2"

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
@@ -10,7 +10,7 @@ final class PropertyInfoViewModel: ObservableObject {
         format.asViewModel
     }
     
-    var objectTypesRestrictionModel: [NewRelationRestrictionsSectionView.ObjectTypeModel]? {
+    var objectTypesRestrictionModel: [NewPropertyRestrictionsSectionView.ObjectTypeModel]? {
         objectTypes.flatMap { $0.asViewModel }
     }
     
@@ -216,9 +216,9 @@ private extension SupportedPropertyFormat {
 
 private extension Array where Element == ObjectType {
     
-    var asViewModel: [NewRelationRestrictionsSectionView.ObjectTypeModel] {
+    var asViewModel: [NewPropertyRestrictionsSectionView.ObjectTypeModel] {
         map {
-            NewRelationRestrictionsSectionView.ObjectTypeModel(
+            NewPropertyRestrictionsSectionView.ObjectTypeModel(
                 id: $0.id,
                 icon: $0.icon,
                 title: $0.displayName


### PR DESCRIPTION
## Summary
- Renamed `NewRelationRestrictionsSectionView` to `NewPropertyRestrictionsSectionView` 
- Updated 1 usage in `PropertyInfoView.swift`
- Updated 3 usages in `PropertyInfoViewModel.swift`
- Renamed file accordingly

Part of the effort to rename "Relation" to "Property" throughout the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)