### PR TITLE
IOS-4660 Rename FeaturedRelationsBlockViewModel to FeaturedPropertiesBlockViewModel

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedPropertiesBlockViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedPropertiesBlockViewModel.swift
@@ -3,7 +3,7 @@ import Services
 import Combine
 import SwiftUI
 
-final class FeaturedRelationsBlockViewModel: BlockViewModelProtocol {
+final class FeaturedPropertiesBlockViewModel: BlockViewModelProtocol {
     let infoProvider: BlockModelInfomationProvider
     nonisolated var info: BlockInformation { infoProvider.info }
     nonisolated var hashable: AnyHashable { info.id }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelBuilder.swift
@@ -317,7 +317,7 @@ final class BlockViewModelBuilder {
                 }
             )
         case .featuredRelations:
-            return FeaturedRelationsBlockViewModel(
+            return FeaturedPropertiesBlockViewModel(
                 infoProvider: blockInformationProvider,
                 document: document,
                 collectionController: blockCollectionController


### PR DESCRIPTION
## Summary
- Renamed `FeaturedRelationsBlockViewModel` to `FeaturedPropertiesBlockViewModel`
- Updated usage in `BlockViewModelBuilder.swift`
- Renamed file accordingly

Part of the effort to rename "Relation" to "Property" throughout the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)