### PR TITLE
IOS-4660 Rename RelationCreationView to PropertyCreationView

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorView.swift
@@ -49,7 +49,7 @@ struct EditorPageCoordinatorView: View {
                 BlockObjectSearchView(data: $0)
             }
             .sheet(item: $model.relationsSearchData) {
-                RelationCreationView(data: $0)
+                PropertyCreationView(data: $0)
             }
             .anytypeSheet(item: $model.undoRedoObjectId) {
                 UndoRedoView(objectId: $0.value)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Coordinator/PropertiesListCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Coordinator/PropertiesListCoordinatorView.swift
@@ -21,7 +21,7 @@ struct PropertiesListCoordinatorView: View {
             PropertyValueCoordinatorView(data: data, output: model)
         }
         .sheet(item: $model.relationsSearchData) {
-            RelationCreationView(data: $0)
+            PropertyCreationView(data: $0)
         }
         .sheet(item: $model.objectTypeData) {
             TypePropertiesView(data: $0)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/TypePropertiesView/TypePropertiesView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/TypePropertiesView/TypePropertiesView.swift
@@ -21,7 +21,7 @@ struct TypePropertiesView: View {
         content
             .task { await model.setupSubscriptions() }
             .sheet(item: $model.relationsSearchData) { data in
-                RelationCreationView(data: data)
+                PropertyCreationView(data: data)
             }
             .sheet(item: $model.propertyData) {
                 PropertyInfoCoordinatorView(data: $0, output: nil)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/Coordinator/SetPropertiesCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/Coordinator/SetPropertiesCoordinatorView.swift
@@ -16,7 +16,7 @@ struct SetPropertiesCoordinatorView: View {
             output: model
         )
         .sheet(item: $model.relationsSearchData) { data in
-            RelationCreationView(data: data)
+            PropertyCreationView(data: data)
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct RelationCreationView: View {
+struct PropertyCreationView: View {
     @StateObject private var model: RelationCreationViewModel
     @Environment(\.dismiss) private var dismiss
     


### PR DESCRIPTION
## Summary
- Renamed `RelationCreationView` to `PropertyCreationView`
- Updated 5 usages across coordinator and view files
- Renamed file accordingly

Part of the effort to rename "Relation" to "Property" throughout the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)