### PR TITLE
IOS-4660 Rename EditorFeaturedRelationsView to EditorFeaturedPropertiesView

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Relations/FeaturedRelationsView/EditorFeaturedPropertiesView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Relations/FeaturedRelationsView/EditorFeaturedPropertiesView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct EditorFeaturedRelationsView: View {
+struct EditorFeaturedPropertiesView: View {
     let relations: [Relation]
     let onRelationTap: ((Relation) -> Void)
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedPropertiesBlockViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedPropertiesBlockViewModel.swift
@@ -41,7 +41,7 @@ final class FeaturedPropertiesBlockViewModel: BlockViewModelProtocol {
     
     func makeContentConfiguration(maxWidth _: CGFloat) -> any UIContentConfiguration {
         return UIHostingConfiguration {
-            EditorFeaturedRelationsView(
+            EditorFeaturedPropertiesView(
                 relations: featuredRelations,
                 onRelationTap: onRelationTap
             )


### PR DESCRIPTION
## Summary
- Renamed `EditorFeaturedRelationsView` to `EditorFeaturedPropertiesView`
- Updated usage in `FeaturedPropertiesBlockViewModel.swift`
- Renamed file accordingly

Part of the effort to rename "Relation" to "Property" throughout the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)