### PR TITLE
IOS-4660 Rename FeaturedRelationsView to FeaturedPropertiesView

### DIFF
--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
@@ -55,7 +55,7 @@ struct PropertyInfoView: View {
             NewPropertySectionView(
                 title: Loc.format,
                 contentViewBuilder: {
-                    NewRelationFormatSectionView(model: viewModel.formatModel)
+                    NewPropertyFormatSectionView(model: viewModel.formatModel)
                 },
                 onTap: {
                     UIApplication.shared.hideKeyboard()
@@ -67,7 +67,7 @@ struct PropertyInfoView: View {
             NewPropertySectionView(
                 title: Loc.type,
                 contentViewBuilder: {
-                    NewRelationFormatSectionView(model: viewModel.formatModel)
+                    NewPropertyFormatSectionView(model: viewModel.formatModel)
                 },
                 onTap: nil,
                 isArrowVisible: false

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
@@ -80,7 +80,7 @@ struct PropertyInfoView: View {
             NewPropertySectionView(
                 title: Loc.limitObjectTypes,
                 contentViewBuilder: {
-                    NewRelationRestrictionsSectionView(model: model)
+                    NewPropertyRestrictionsSectionView(model: model)
                 },
                 onTap: {
                     UIApplication.shared.hideKeyboard()

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
@@ -38,7 +38,7 @@ struct PropertyInfoView: View {
     }
     
     private var nameSection: some View {
-        NewRelationSectionView(
+        NewPropertySectionView(
             title: Loc.name,
             contentViewBuilder: {
                 TextField(Loc.untitled, text: $viewModel.name)
@@ -52,7 +52,7 @@ struct PropertyInfoView: View {
     
     private var formatSection: some View {
         if viewModel.mode.canEditRelationType {
-            NewRelationSectionView(
+            NewPropertySectionView(
                 title: Loc.format,
                 contentViewBuilder: {
                     NewRelationFormatSectionView(model: viewModel.formatModel)
@@ -64,7 +64,7 @@ struct PropertyInfoView: View {
                 isArrowVisible: true
             )
         } else {
-            NewRelationSectionView(
+            NewPropertySectionView(
                 title: Loc.type,
                 contentViewBuilder: {
                     NewRelationFormatSectionView(model: viewModel.formatModel)
@@ -77,7 +77,7 @@ struct PropertyInfoView: View {
     
     private var restrictionsSection: some View {
         viewModel.objectTypesRestrictionModel.flatMap { model in
-            NewRelationSectionView(
+            NewPropertySectionView(
                 title: Loc.limitObjectTypes,
                 contentViewBuilder: {
                     NewRelationRestrictionsSectionView(model: model)

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertyFormatSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertyFormatSectionView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct NewRelationFormatSectionView: View {
+struct NewPropertyFormatSectionView: View {
     
     let model: Model
     
@@ -16,7 +16,7 @@ struct NewRelationFormatSectionView: View {
     
 }
 
-extension NewRelationFormatSectionView {
+extension NewPropertyFormatSectionView {
     
     struct Model: Hashable {
         let icon: ImageAsset
@@ -25,10 +25,10 @@ extension NewRelationFormatSectionView {
     
 }
 
-struct NewRelationFormatSectionView_Previews: PreviewProvider {
+struct NewPropertyFormatSectionView_Previews: PreviewProvider {
     static var previews: some View {
-        NewRelationFormatSectionView(
-            model: NewRelationFormatSectionView.Model(icon: .X24.text, title: "Text")
+        NewPropertyFormatSectionView(
+            model: NewPropertyFormatSectionView.Model(icon: .X24.text, title: "Text")
         )
     }
 }

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertyRestrictionsSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertyRestrictionsSectionView.swift
@@ -3,7 +3,7 @@ import Services
 import AnytypeCore
 
 
-struct NewRelationRestrictionsSectionView: View {
+struct NewPropertyRestrictionsSectionView: View {
     
     let model: [ObjectTypeModel]
     
@@ -45,7 +45,7 @@ struct NewRelationRestrictionsSectionView: View {
     }
 }
 
-extension NewRelationRestrictionsSectionView {    
+extension NewPropertyRestrictionsSectionView {    
     struct ObjectTypeModel: Identifiable, Hashable {
         let id: String
         let icon: ObjectIcon
@@ -54,56 +54,56 @@ extension NewRelationRestrictionsSectionView {
     
 }
 
-struct NewRelationRestrictionsSectionView_Previews: PreviewProvider {
+struct NewPropertyRestrictionsSectionView_Previews: PreviewProvider {
     static var previews: some View {
-        NewRelationRestrictionsSectionView(
+        NewPropertyRestrictionsSectionView(
             model: [
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .customIcon(CustomIconData(icon: .man, customColor: .gray)),
                     title: "custom icon title 1"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .customIcon(CustomIconData(icon: .transgender, customColor: .pink)),
                     title: "custom icon title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .customIcon(CustomIconData(icon: .telescope, customColor: .amber)),
                     title: "custom icon title 3"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("📘")!),
                     title: "title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("🐭")!),
                     title: "title 1"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("📘")!),
                     title: "title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("🤡")!),
                     title: "title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("🤡")!),
                     title: "title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("🤡")!),
                     title: "title 2"
                 ),
-                NewRelationRestrictionsSectionView.ObjectTypeModel(
+                NewPropertyRestrictionsSectionView.ObjectTypeModel(
                     id: UUID().uuidString,
                     icon: .emoji(Emoji("🤡")!),
                     title: "title 2"

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertySectionView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/Subviews/NewPropertySectionView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct NewRelationSectionView<Content: View>: View {
+struct NewPropertySectionView<Content: View>: View {
     
     let title: String
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
@@ -6,7 +6,7 @@ import Combine
 @MainActor
 final class PropertyInfoViewModel: ObservableObject {
     
-    var formatModel: NewRelationFormatSectionView.Model {
+    var formatModel: NewPropertyFormatSectionView.Model {
         format.asViewModel
     }
     
@@ -191,8 +191,8 @@ private extension PropertyInfoViewModel {
 
 private extension SupportedPropertyFormat {
     
-    var asViewModel: NewRelationFormatSectionView.Model {
-        NewRelationFormatSectionView.Model(icon: self.iconAsset, title: self.title)
+    var asViewModel: NewPropertyFormatSectionView.Model {
+        NewPropertyFormatSectionView.Model(icon: self.iconAsset, title: self.title)
     }
     
     var asRelationFormat: RelationFormat {

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
@@ -10,7 +10,7 @@ final class PropertyInfoViewModel: ObservableObject {
         format.asViewModel
     }
     
-    var objectTypesRestrictionModel: [NewRelationRestrictionsSectionView.ObjectTypeModel]? {
+    var objectTypesRestrictionModel: [NewPropertyRestrictionsSectionView.ObjectTypeModel]? {
         objectTypes.flatMap { $0.asViewModel }
     }
     
@@ -216,9 +216,9 @@ private extension SupportedPropertyFormat {
 
 private extension Array where Element == ObjectType {
     
-    var asViewModel: [NewRelationRestrictionsSectionView.ObjectTypeModel] {
+    var asViewModel: [NewPropertyRestrictionsSectionView.ObjectTypeModel] {
         map {
-            NewRelationRestrictionsSectionView.ObjectTypeModel(
+            NewPropertyRestrictionsSectionView.ObjectTypeModel(
                 id: $0.id,
                 icon: $0.icon,
                 title: $0.displayName

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Properties/FlowPropertiesView/FlowPropertiesView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Properties/FlowPropertiesView/FlowPropertiesView.swift
@@ -40,7 +40,7 @@ struct FlowPropertiesView: View {
     }
 
     private var featuredPropertiesView: some View {
-        FeaturedRelationsView(
+        FeaturedPropertiesView(
             relations: viewModel.properties,
             view: { property in
                 PropertyValueView(

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Relations/FeaturedRelationsView/EditorFeaturedPropertiesView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Relations/FeaturedRelationsView/EditorFeaturedPropertiesView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct EditorFeaturedRelationsView: View {
+struct EditorFeaturedPropertiesView: View {
     let relations: [Relation]
     let onRelationTap: ((Relation) -> Void)
     

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Relations/FeaturedRelationsView/EditorFeaturedPropertiesView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Relations/FeaturedRelationsView/EditorFeaturedPropertiesView.swift
@@ -16,7 +16,7 @@ struct EditorFeaturedPropertiesView: View {
     }
     
     private var content: some View {
-        FeaturedRelationsView(
+        FeaturedPropertiesView(
             relations: relations,
             view: { relation in
                 PropertyValueView(

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Relations/FeaturedRelationsView/FeaturedPropertiesView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Relations/FeaturedRelationsView/FeaturedPropertiesView.swift
@@ -1,23 +1,23 @@
 import SwiftUI
 import WrappingHStack
 
-enum FeaturedRelationsConstants {
+enum FeaturedPropertiesConstants {
     static let itemSpacing: CGFloat = 6
     static let lineSpacing: CGFloat = 4
 }
 
-struct FeaturedRelationsView<Content>: View where Content: View {
+struct FeaturedPropertiesView<Content>: View where Content: View {
     let relations: [Relation]
     let view: (Relation) -> Content
     
     var body: some View {
         WrappingHStack(
             alignment: .leading,
-            horizontalSpacing: FeaturedRelationsConstants.itemSpacing,
-            verticalSpacing: FeaturedRelationsConstants.lineSpacing
+            horizontalSpacing: FeaturedPropertiesConstants.itemSpacing,
+            verticalSpacing: FeaturedPropertiesConstants.lineSpacing
         ) {
             ForEach(relations) { relation in
-                HStack(spacing: FeaturedRelationsConstants.itemSpacing) {
+                HStack(spacing: FeaturedPropertiesConstants.itemSpacing) {
                     view(relation)
                     
                     if !isLastRelation(relation) {

--- a/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorView.swift
@@ -49,7 +49,7 @@ struct EditorPageCoordinatorView: View {
                 BlockObjectSearchView(data: $0)
             }
             .sheet(item: $model.relationsSearchData) {
-                RelationCreationView(data: $0)
+                PropertyCreationView(data: $0)
             }
             .anytypeSheet(item: $model.undoRedoObjectId) {
                 UndoRedoView(objectId: $0.value)

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedPropertiesBlockViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedPropertiesBlockViewModel.swift
@@ -41,7 +41,7 @@ final class FeaturedPropertiesBlockViewModel: BlockViewModelProtocol {
     
     func makeContentConfiguration(maxWidth _: CGFloat) -> any UIContentConfiguration {
         return UIHostingConfiguration {
-            EditorFeaturedRelationsView(
+            EditorFeaturedPropertiesView(
                 relations: featuredRelations,
                 onRelationTap: onRelationTap
             )

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedPropertiesBlockViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedPropertiesBlockViewModel.swift
@@ -3,7 +3,7 @@ import Services
 import Combine
 import SwiftUI
 
-final class FeaturedRelationsBlockViewModel: BlockViewModelProtocol {
+final class FeaturedPropertiesBlockViewModel: BlockViewModelProtocol {
     let infoProvider: BlockModelInfomationProvider
     nonisolated var info: BlockInformation { infoProvider.info }
     nonisolated var hashable: AnyHashable { info.id }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelBuilder.swift
@@ -317,7 +317,7 @@ final class BlockViewModelBuilder {
                 }
             )
         case .featuredRelations:
-            return FeaturedRelationsBlockViewModel(
+            return FeaturedPropertiesBlockViewModel(
                 infoProvider: blockInformationProvider,
                 document: document,
                 collectionController: blockCollectionController

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Coordinator/PropertiesListCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Coordinator/PropertiesListCoordinatorView.swift
@@ -21,7 +21,7 @@ struct PropertiesListCoordinatorView: View {
             PropertyValueCoordinatorView(data: data, output: model)
         }
         .sheet(item: $model.relationsSearchData) {
-            RelationCreationView(data: $0)
+            PropertyCreationView(data: $0)
         }
         .sheet(item: $model.objectTypeData) {
             TypePropertiesView(data: $0)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/TypePropertiesView/TypePropertiesView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/TypePropertiesView/TypePropertiesView.swift
@@ -21,7 +21,7 @@ struct TypePropertiesView: View {
         content
             .task { await model.setupSubscriptions() }
             .sheet(item: $model.relationsSearchData) { data in
-                RelationCreationView(data: data)
+                PropertyCreationView(data: data)
             }
             .sheet(item: $model.propertyData) {
                 PropertyInfoCoordinatorView(data: $0, output: nil)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Header/SetFullHeader.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Header/SetFullHeader.swift
@@ -178,7 +178,7 @@ extension SetFullHeader {
     }
 
     private var featuredRelationsView: some View {
-        FeaturedRelationsView(
+        FeaturedPropertiesView(
             relations: model.featuredRelations,
             view: { relation in
                 relationContent(for: relation)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/Coordinator/SetPropertiesCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/Coordinator/SetPropertiesCoordinatorView.swift
@@ -16,7 +16,7 @@ struct SetPropertiesCoordinatorView: View {
             output: model
         )
         .sheet(item: $model.relationsSearchData) { data in
-            RelationCreationView(data: data)
+            PropertyCreationView(data: data)
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct RelationCreationView: View {
+struct PropertyCreationView: View {
     @StateObject private var model: RelationCreationViewModel
     @Environment(\.dismiss) private var dismiss
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationView.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
 struct PropertyCreationView: View {
-    @StateObject private var model: RelationCreationViewModel
+    @StateObject private var model: PropertyCreationViewModel
     @Environment(\.dismiss) private var dismiss
     
     init(data: PropertiesSearchData) {
-        _model = StateObject(wrappedValue: RelationCreationViewModel(data: data))
+        _model = StateObject(wrappedValue: PropertyCreationViewModel(data: data))
     }
     
     var body: some View {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationViewModel.swift
@@ -4,7 +4,7 @@ import AnytypeCore
 
 
 @MainActor
-final class RelationCreationViewModel: ObservableObject, PropertyInfoCoordinatorViewOutput {
+final class PropertyCreationViewModel: ObservableObject, PropertyInfoCoordinatorViewOutput {
     
     @Published var rows: [SearchDataSection<PropertySearchData>] = []
     @Published var newPropertyData: PropertyInfoData?


### PR DESCRIPTION
## Summary
- Renamed `FeaturedRelationsView` to `FeaturedPropertiesView`
- Renamed `FeaturedRelationsConstants` to `FeaturedPropertiesConstants`
- Updated 4 usages across multiple view files
- Renamed file accordingly

Part of the effort to rename "Relation" to "Property" throughout the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)