### PR TITLE
IOS-4660 Rename Relation to Property - Model Layer 1

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Models/Actions/SlashActionProperties.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Models/Actions/SlashActionProperties.swift
@@ -1,6 +1,6 @@
 
 
-enum SlashActionRelations {
+enum SlashActionProperties {
     case newRealtion
     case relation(Relation)
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Models/SlashAction.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Models/SlashAction.swift
@@ -4,7 +4,7 @@ enum SlashAction {
     case style(SlashActionStyle)
     case media(SlashActionMedia)
     case objects(SlashActionObject)
-    case relations(SlashActionRelations)
+    case relations(SlashActionProperties)
     case other(SlashActionOther)
     case actions(BlockAction)
     case color(BlockColor)

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/TableView/RelationCellView/SlashMenuPropertyContentConfiguration.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/TableView/RelationCellView/SlashMenuPropertyContentConfiguration.swift
@@ -1,14 +1,14 @@
 import UIKit
 
-struct SlashMenuRealtionContentConfiguration: UIContentConfiguration, Hashable {
+struct SlashMenuPropertyContentConfiguration: UIContentConfiguration, Hashable {
     var property: PropertyItemModel
     var currentConfigurationState: UICellConfigurationState?
 
     func makeContentView() -> any UIView & UIContentView {
-        return SlashMenuRealtionView(configuration: self)
+        return SlashMenuPropertyView(configuration: self)
     }
 
-    func updated(for state: any UIConfigurationState) -> SlashMenuRealtionContentConfiguration {
+    func updated(for state: any UIConfigurationState) -> SlashMenuPropertyContentConfiguration {
         guard let state = state as? UICellConfigurationState else { return self }
 
         var updatedConfig = self

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/TableView/RelationCellView/SlashMenuPropertyView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/TableView/RelationCellView/SlashMenuPropertyView.swift
@@ -1,15 +1,15 @@
 import UIKit
 import SwiftUI
 
-final class SlashMenuRealtionView: UIView, UIContentView {
+final class SlashMenuPropertyView: UIView, UIContentView {
     private var realtionViewModel: PropertyNameValueViewModel
     private let container = UIView()
 
-    private var currentConfiguration: SlashMenuRealtionContentConfiguration
+    private var currentConfiguration: SlashMenuPropertyContentConfiguration
     var configuration: any UIContentConfiguration {
         get { currentConfiguration }
         set {
-            guard let configuration = newValue as? SlashMenuRealtionContentConfiguration else {
+            guard let configuration = newValue as? SlashMenuPropertyContentConfiguration else {
                 return
             }
             guard configuration != currentConfiguration else {
@@ -21,7 +21,7 @@ final class SlashMenuRealtionView: UIView, UIContentView {
         }
     }
 
-    init(configuration: SlashMenuRealtionContentConfiguration) {
+    init(configuration: SlashMenuPropertyContentConfiguration) {
         self.currentConfiguration = configuration
         self.realtionViewModel = PropertyNameValueViewModel(
             property: configuration.property,
@@ -43,7 +43,7 @@ final class SlashMenuRealtionView: UIView, UIContentView {
     // MARK: - Setup view
 
     func setupSubviews() {
-        let relationsView = EnhancedRelationView(viewModel: realtionViewModel).asUIView()
+        let relationsView = EnhancedPropertyView(viewModel: realtionViewModel).asUIView()
 
         addSubview(container) {
             $0.pinToSuperview(insets: UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20))
@@ -60,7 +60,7 @@ final class SlashMenuRealtionView: UIView, UIContentView {
 
     // MARK: - Apply configuration
 
-    func apply(with configuration: SlashMenuRealtionContentConfiguration) {
+    func apply(with configuration: SlashMenuPropertyContentConfiguration) {
         realtionViewModel.property = configuration.property
         realtionViewModel.isHighlighted = false
 
@@ -70,7 +70,7 @@ final class SlashMenuRealtionView: UIView, UIContentView {
     }
 }
 
-struct EnhancedRelationView: View {
+struct EnhancedPropertyView: View {
     @ObservedObject var viewModel: PropertyNameValueViewModel
 
     var body: some View {

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/TableView/SlashMenuContentConfigurationFactory.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/TableView/SlashMenuContentConfigurationFactory.swift
@@ -23,6 +23,6 @@ final class SlashMenuContentConfigurationFactory {
     }
 
     func configuration(relation: Relation) -> any UIContentConfiguration {
-        SlashMenuRealtionContentConfiguration(property: PropertyItemModel(property: relation))
+        SlashMenuPropertyContentConfiguration(property: PropertyItemModel(property: relation))
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Entities/PropertiesSection.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Entities/PropertiesSection.swift
@@ -9,14 +9,14 @@ struct PropertiesSection: Identifiable {
     let isMissingFields: Bool
     
     var addedToObject: Bool {
-        id != Constants.conflictingRelationsSectionId
+        id != Constants.conflictingPropertiesSectionId 
     }
 }
 
 extension PropertiesSection {
     enum Constants {
-        static let featuredRelationsSectionId = "featuredRelationsSectionId"
-        static let sidebarRelationsSectionId = "sidebarRelationsSectionId"
-        static let conflictingRelationsSectionId = "conflictingRelationsSectionId"
+        static let featuredPropertiesSectionId = "featuredPropertiesSectionId "
+        static let sidebarPropertiesSectionId = "sidebarPropertiesSectionId"
+        static let conflictingPropertiesSectionId = "conflictingPropertiesSectionId"
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Entities/PropertiesSection.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Entities/PropertiesSection.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 
 
-struct RelationsSection: Identifiable {
+struct PropertiesSection: Identifiable {
     let id: String
     let title: String
     let relations: [Relation]
@@ -13,7 +13,7 @@ struct RelationsSection: Identifiable {
     }
 }
 
-extension RelationsSection {
+extension PropertiesSection {
     enum Constants {
         static let featuredRelationsSectionId = "featuredRelationsSectionId"
         static let sidebarRelationsSectionId = "sidebarRelationsSectionId"

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Entities/PropertiesSectionBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Entities/PropertiesSectionBuilder.swift
@@ -3,15 +3,15 @@ import SwiftProtobuf
 import UIKit
 import AnytypeCore
 
-final class RelationsSectionBuilder {
+final class PropertiesSectionBuilder {
     
-    func buildObjectSections(parsedRelations: ParsedRelations) -> [RelationsSection] {
-        var sections: [RelationsSection] = []
+    func buildObjectSections(parsedRelations: ParsedRelations) -> [PropertiesSection] {
+        var sections: [PropertiesSection] = []
         
         if parsedRelations.featuredRelations.isNotEmpty || parsedRelations.sidebarRelations.isNotEmpty {
             sections.append(
-                RelationsSection(
-                    id: RelationsSection.Constants.featuredRelationsSectionId,
+                PropertiesSection(
+                    id: PropertiesSection.Constants.featuredPropertiesSectionId,
                     title: "",
                     relations: parsedRelations.featuredRelations + parsedRelations.sidebarRelations,
                     isMissingFields: false
@@ -21,8 +21,8 @@ final class RelationsSectionBuilder {
         
         if parsedRelations.conflictedRelations.isNotEmpty {
             sections.append(
-                RelationsSection(
-                    id: RelationsSection.Constants.conflictingRelationsSectionId,
+                PropertiesSection(
+                    id: PropertiesSection.Constants.conflictingPropertiesSectionId,
                     title: Loc.Fields.local,
                     relations: parsedRelations.conflictedRelations,
                     isMissingFields: true
@@ -33,7 +33,7 @@ final class RelationsSectionBuilder {
         return sections
     }
 
-    func buildSectionsLegacy(from parsedRelations: ParsedRelations, objectTypeName: String) -> [RelationsSection] {
+    func buildSectionsLegacy(from parsedRelations: ParsedRelations, objectTypeName: String) -> [PropertiesSection] {
         anytypeAssertionFailure("Not supported in a new API")
         return []
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/ObjectFieldsView/ObjectPropertiesView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/ObjectFieldsView/ObjectPropertiesView.swift
@@ -70,7 +70,7 @@ struct ObjectPropertiesView: View {
         }
     }
     
-    private func sectionHeader(section: RelationsSection) -> some View {
+    private func sectionHeader(section: PropertiesSection) -> some View {
         Group {
             if section.isMissingFields {
                 Button {
@@ -87,7 +87,7 @@ struct ObjectPropertiesView: View {
         }
     }
     
-    private func row(with relation: Relation, section: RelationsSection) -> some View {
+    private func row(with relation: Relation, section: PropertiesSection) -> some View {
         HStack {
             rowWithoutActions(with: relation, addedToObject: section.addedToObject)
             if section.isMissingFields {

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/ObjectFieldsView/ObjectPropertiesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/ObjectFieldsView/ObjectPropertiesViewModel.swift
@@ -7,7 +7,7 @@ import Combine
 
 @MainActor
 final class ObjectPropertiesViewModel: ObservableObject {
-    @Published var sections = [RelationsSection]()
+    @Published var sections = [PropertiesSection]()
     @Published var showConflictingInfo = false
     
     var typeId: String? { document.details?.objectType.id }
@@ -15,7 +15,7 @@ final class ObjectPropertiesViewModel: ObservableObject {
     // MARK: - Private variables
     
     private let document: any BaseDocumentProtocol
-    private let sectionsBuilder = RelationsSectionBuilder()
+    private let sectionsBuilder = PropertiesSectionBuilder()
     
     @Injected(\.relationsService)
     private var relationsService: any RelationsServiceProtocol

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/SetDocument.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/SetDocument.swift
@@ -101,7 +101,7 @@ final class SetDocument: SetDocumentProtocol, @unchecked Sendable {
         dataView.views.first { $0.id == id } ?? .empty
     }
     
-    func sortedRelations(for viewId: String) -> [SetRelation] {
+    func sortedRelations(for viewId: String) -> [SetProperty] {
         let view = view(by: viewId)
         return dataBuilder.sortedRelations(dataview: dataView, view: view, spaceId: spaceId)
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/SetDocumentProtocol.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/SetDocumentProtocol.swift
@@ -40,7 +40,7 @@ protocol SetDocumentProtocol: AnyObject, Sendable {
     func filters(for viewId: String) -> [SetFilter]
     
     func view(by id: String) -> DataviewView
-    func sortedRelations(for viewId: String) -> [SetRelation]
+    func sortedRelations(for viewId: String) -> [SetProperty]
     func canStartSubscription() -> Bool
     func viewRelations(viewId: String, excludeRelations: [RelationDetails]) -> [RelationDetails]
     func objectOrderIds(for groupId: String) -> [String]

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetContentViewDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetContentViewDataBuilder.swift
@@ -4,7 +4,7 @@ import AnytypeCore
 import SwiftProtobuf
 
 protocol SetContentViewDataBuilderProtocol: AnyObject {
-    func sortedRelations(dataview: BlockDataview, view: DataviewView, spaceId: String) -> [SetRelation]
+    func sortedRelations(dataview: BlockDataview, view: DataviewView, spaceId: String) -> [SetProperty]
     func activeViewRelations(
         dataViewRelationsDetails: [RelationDetails],
         view: DataviewView,
@@ -30,28 +30,28 @@ final class SetContentViewDataBuilder: SetContentViewDataBuilderProtocol {
     @Injected(\.propertyDetailsStorage)
     private var propertyDetailsStorage: any PropertyDetailsStorageProtocol
     
-    func sortedRelations(dataview: BlockDataview, view: DataviewView, spaceId: String) -> [SetRelation] {
+    func sortedRelations(dataview: BlockDataview, view: DataviewView, spaceId: String) -> [SetProperty] {
         let storageRelationsDetails = propertyDetailsStorage.relationsDetails(keys: dataview.relationLinks.map(\.key), spaceId: spaceId)
             .filter {
                 (!$0.isHidden && !$0.isDeleted) ||
                 (view.canSwitchItemName && $0.key == BundledRelationKey.name.rawValue)
             }
         
-        let relationsPresentInView: [SetRelation] = view.options
+        let relationsPresentInView: [SetProperty] = view.options
             .compactMap { option in
                 let relationsDetails = storageRelationsDetails
                     .first { $0.key == option.key }
                 guard let relationsDetails = relationsDetails else { return nil }
                 
-                return SetRelation(relationDetails: relationsDetails, option: option)
+                return SetProperty(relationDetails: relationsDetails, option: option)
             }
         
-        let relationsNotPresentInView: [SetRelation] = storageRelationsDetails
+        let relationsNotPresentInView: [SetProperty] = storageRelationsDetails
             .filter { !view.options.map(\.key).contains($0.key) }
-            .map { SetRelation(relationDetails: $0, option: DataviewRelationOption(key: $0.key, isVisible: false)) }
+            .map { SetProperty(relationDetails: $0, option: DataviewRelationOption(key: $0.key, isVisible: false)) }
 
         
-        return NSOrderedSet(array: relationsPresentInView + relationsNotPresentInView).array as! [SetRelation]
+        return NSOrderedSet(array: relationsPresentInView + relationsNotPresentInView).array as! [SetProperty]
     }
     
     func activeViewRelations(

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetProperty.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetProperty.swift
@@ -1,7 +1,7 @@
 import Services
 import SwiftUI
 
-struct SetRelation: Identifiable, Hashable {
+struct SetProperty: Identifiable, Hashable {
     let relationDetails: RelationDetails
     let option: DataviewRelationOption
     
@@ -9,7 +9,7 @@ struct SetRelation: Identifiable, Hashable {
 }
 
 extension Array where Element == DataviewRelationOption {
-    func index(of relation: SetRelation) -> Index? {
+    func index(of relation: SetProperty) -> Index? {
         firstIndex(where: { $0.key == relation.relationDetails.key })
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/List/PropertyFilterBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/List/PropertyFilterBuilder.swift
@@ -3,7 +3,7 @@ import Services
 import SwiftProtobuf
 import AnytypeCore
 
-final class RelationFilterBuilder {
+final class PropertyFilterBuilder {
         
     // MARK: - Private variables
     
@@ -100,7 +100,7 @@ final class RelationFilterBuilder {
     }
 }
 
-private extension RelationFilterBuilder {
+private extension PropertyFilterBuilder {
     func objectRelation(
         detailsStorage: ObjectDetailsStorage,
         relationDetails: RelationDetails,

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/List/SetFiltersListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/List/SetFiltersListViewModel.swift
@@ -20,7 +20,7 @@ final class SetFiltersListViewModel: ObservableObject {
     @Injected(\.dataviewService)
     private var dataviewService: any DataviewServiceProtocol
     
-    private let relationFilterBuilder = RelationFilterBuilder()
+    private let relationFilterBuilder = PropertyFilterBuilder()
     private let subscriptionDetailsStorage: ObjectDetailsStorage
     
     private weak var output: (any SetFiltersListCoordinatorOutput)?

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/SetPropertiesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/SetPropertiesViewModel.swift
@@ -141,7 +141,7 @@ final class SetPropertiesViewModel: ObservableObject {
         }
     }
     
-    private func onRelationVisibleChange(_ relation: SetRelation, isVisible: Bool) {
+    private func onRelationVisibleChange(_ relation: SetProperty, isVisible: Bool) {
         Task {
             let newOption = relation.option.updated(isVisible: isVisible).asMiddleware
             try await dataviewService.replaceViewRelation(


### PR DESCRIPTION
## Summary
- Renamed SetRelation to SetProperty
- Renamed RelationsSection to PropertiesSection and RelationsSectionBuilder to PropertiesSectionBuilder  
- Renamed SlashActionRelations to SlashActionProperties
- Renamed RelationFilterBuilder to PropertyFilterBuilder
- Renamed SlashMenuRealtionView to SlashMenuPropertyView

## Test plan
- Build passes with all relation-to-property renames
- No functional changes, only terminology updates

🤖 Generated with [Claude Code](https://claude.ai/code)