### PR TITLE
IOS-4417 Properties | Add expandable sections to Properties panel

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Entities/PropertiesSection.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Entities/PropertiesSection.swift
@@ -7,6 +7,7 @@ struct PropertiesSection: Identifiable {
     let title: String
     let relations: [Relation]
     let isMissingFields: Bool
+    let isExpandable: Bool
     
     var addedToObject: Bool {
         id != Constants.conflictingPropertiesSectionId 
@@ -18,5 +19,6 @@ extension PropertiesSection {
         static let featuredPropertiesSectionId = "featuredPropertiesSectionId "
         static let sidebarPropertiesSectionId = "sidebarPropertiesSectionId"
         static let conflictingPropertiesSectionId = "conflictingPropertiesSectionId"
+        static let hiddenPropertiesSectionId = "hiddenPropertiesSectionId"
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Entities/PropertiesSectionBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Entities/PropertiesSectionBuilder.swift
@@ -14,7 +14,20 @@ final class PropertiesSectionBuilder {
                     id: PropertiesSection.Constants.featuredPropertiesSectionId,
                     title: "",
                     relations: parsedRelations.featuredRelations + parsedRelations.sidebarRelations,
-                    isMissingFields: false
+                    isMissingFields: false,
+                    isExpandable: false
+                )
+            )
+        }
+        
+        if parsedRelations.hiddenRelations.isNotEmpty {
+            sections.append(
+                PropertiesSection(
+                    id: PropertiesSection.Constants.hiddenPropertiesSectionId,
+                    title: Loc.hidden,
+                    relations: parsedRelations.hiddenRelations,
+                    isMissingFields: false,
+                    isExpandable: true
                 )
             )
         }
@@ -25,7 +38,8 @@ final class PropertiesSectionBuilder {
                     id: PropertiesSection.Constants.conflictingPropertiesSectionId,
                     title: Loc.Fields.local,
                     relations: parsedRelations.conflictedRelations,
-                    isMissingFields: true
+                    isMissingFields: true,
+                    isExpandable: true
                 )
             )
         }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/ObjectFieldsView/ObjectPropertiesView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/ObjectFieldsView/ObjectPropertiesView.swift
@@ -58,8 +58,10 @@ struct ObjectPropertiesView: View {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(model.sections) { section in
                     Section {
-                        ForEach(section.relations) {
-                            row(with: $0, section: section)
+                        if !section.isExpandable || model.isSectionExpanded(section.id) {
+                            ForEach(section.relations) {
+                                row(with: $0, section: section)
+                            }
                         }
                     } header: {
                         sectionHeader(section: section)
@@ -72,15 +74,35 @@ struct ObjectPropertiesView: View {
     
     private func sectionHeader(section: PropertiesSection) -> some View {
         Group {
-            if section.isMissingFields {
+            if section.isExpandable {
                 Button {
-                    model.onConflictingInfoTap()
+                    model.toggleSectionExpansion(section.id)
                 } label: {
-                    ListSectionHeaderView(title: section.title) {
-                        Image(systemName: "questionmark.circle.fill").foregroundStyle(Color.Control.active)
-                            .frame(width: 18, height: 18)
+                    HStack(spacing: 0) {
+                        Image(asset: .X18.Disclosure.right)
+                            .foregroundColor(.Control.active)
+                            .rotationEffect(.degrees(model.isSectionExpanded(section.id) ? 90 : 0))
+                        
+                        AnytypeText(section.title, style: .uxCalloutMedium)
+                            .foregroundColor(.Text.secondary)
+                            .padding(.leading, 10)
+                        
+                        if section.isMissingFields {
+                            Spacer()
+                            Button {
+                                model.onConflictingInfoTap()
+                            } label: {
+                                Image(systemName: "questionmark.circle.fill")
+                                    .foregroundStyle(Color.Control.active)
+                                    .frame(width: 18, height: 18)
+                            }
+                        } else {
+                            Spacer()
+                        }
                     }
+                    .padding(.vertical, 12)
                 }
+                .padding(.top, 16)
             } else {
                 EmptyView()
             }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/ObjectFieldsView/ObjectPropertiesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/ObjectFieldsView/ObjectPropertiesViewModel.swift
@@ -4,11 +4,13 @@ import SwiftProtobuf
 import UIKit
 import AnytypeCore
 import Combine
+import SwiftUI
 
 @MainActor
 final class ObjectPropertiesViewModel: ObservableObject {
     @Published var sections = [PropertiesSection]()
     @Published var showConflictingInfo = false
+    @Published var expandedSections = Set<String>()
     
     var typeId: String? { document.details?.objectType.id }
     
@@ -72,5 +74,19 @@ final class ObjectPropertiesViewModel: ObservableObject {
     func onConflictingInfoTap() {
         AnytypeAnalytics.instance().logConflictFieldHelp()
         showConflictingInfo.toggle()
+    }
+    
+    func toggleSectionExpansion(_ sectionId: String) {
+        withAnimation(.fastSpring) {
+            if expandedSections.contains(sectionId) {
+                expandedSections.remove(sectionId)
+            } else {
+                expandedSections.insert(sectionId)
+            }
+        }
+    }
+    
+    func isSectionExpanded(_ sectionId: String) -> Bool {
+        expandedSections.contains(sectionId)
     }
 }


### PR DESCRIPTION
## Summary
- Added expandable/collapsible sections for "Hidden" and "Local" properties
- Implemented disclosure indicators that rotate when expanded/collapsed
- Updated section headers with proper spacing and styling

## Demo

https://github.com/user-attachments/assets/3dab60b5-73a4-4623-b4d5-f4ce850ec08b





🤖 Generated with [Claude Code](https://claude.ai/code)