### PR TITLE
IOS-4730 Fix menu actions visibility to show regardless of loading state

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/NewSpaceCard.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/NewSpaceCard.swift
@@ -27,26 +27,21 @@ struct NewSpaceCard: View, @preconcurrency Equatable {
             )
         }
         .disabled(FeatureFlags.spaceLoadingForScreen ? false : spaceData.spaceView.isLoading)
-        .contextMenu {
-            if !spaceData.spaceView.isLoading {
-                menuItems
-            }
-        }
+        .contextMenu { menuItems }
     }
     
     @ViewBuilder
     private var menuItems: some View {
         if spaceData.spaceView.isLoading {
             copyButton
+            Divider()
         }
-        
-        Divider()
         
         if FeatureFlags.muteSpacePossibility {
             muteButton
+            Divider()
         }
         
-        Divider()
         if spaceData.space.canLeave {
             leaveButton
         }


### PR DESCRIPTION
## Summary
- Fixed context menu actions to be visible regardless of space loading state