### PR TITLE
IOS-4737 Do not display hidden relations in the property menu

### DIFF
--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Views/PropertiesLibrary/ObjectPropertiesLibraryViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Views/PropertiesLibrary/ObjectPropertiesLibraryViewModel.swift
@@ -26,7 +26,7 @@ final class ObjectPropertiesLibraryViewModel: ObservableObject, PropertyInfoCoor
     
     func startSubscriptions() async {
         for await rows in propertyDetailsStorage.relationsDetailsPublisher(spaceId: spaceId).values {
-            self.rows = rows
+            self.rows = rows.filter { !$0.isHidden }
         }
     }
     


### PR DESCRIPTION
## Summary
- Filter out hidden relations from the properties library view to prevent them from being displayed to users