### PR TITLE
IOS-4738 Restrict editing of system properties in the property menu

### DIFF
--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/Coordinator/PropertyInfoData.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/Coordinator/PropertyInfoData.swift
@@ -49,4 +49,5 @@ struct PropertyInfoData: Identifiable {
     let spaceId: String
     let target: PropertiesModuleTarget
     let mode: PropertyInfoViewMode
+    let isReadOnly: Bool
 }

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
@@ -33,7 +33,10 @@ struct PropertyInfoView: View {
                 Spacer.fixedHeight(10)
             }
             Spacer()
-            button
+            
+            if !viewModel.isReadOnly {
+                button
+            }
         }
     }
     
@@ -87,8 +90,9 @@ struct PropertyInfoView: View {
                     UIApplication.shared.hideKeyboard()
                     viewModel.didTapTypesRestrictionSection()
                 },
-                isArrowVisible: true
+                isArrowVisible: !viewModel.isReadOnly
             )
+            .disabled(viewModel.isReadOnly)
         }
     }
     
@@ -97,7 +101,7 @@ struct PropertyInfoView: View {
             viewModel.didTapAddButton()
             dismiss()
         }
-        .disabled(!viewModel.isCreateButtonActive)
+        .disabled(!viewModel.isSaveButtonActive)
         .padding(.vertical, 10)
     }
 }

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/View/PropertyInfoView.swift
@@ -42,8 +42,9 @@ struct PropertyInfoView: View {
             title: Loc.name,
             contentViewBuilder: {
                 TextField(Loc.untitled, text: $viewModel.name)
-                    .foregroundColor(.Text.primary)
+                    .foregroundColor(!viewModel.isReadOnly ? .Text.primary : .Text.secondary)
                     .font(AnytypeFontBuilder.font(anytypeFont: .heading))
+                    .disabled(viewModel.isReadOnly)
             },
             onTap: nil,
             isArrowVisible: false

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
@@ -14,7 +14,7 @@ final class PropertyInfoViewModel: ObservableObject {
         objectTypes.flatMap { $0.asViewModel }
     }
     
-    var isCreateButtonActive: Bool {
+    var isSaveButtonActive: Bool {
         name.isNotEmpty
     }
     

--- a/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/AddNewRelation flow/CreateNewRelation/ViewModel/PropertyInfoViewModel.swift
@@ -37,6 +37,7 @@ final class PropertyInfoViewModel: ObservableObject {
     }
     
     let mode: PropertyInfoViewMode
+    let isReadOnly: Bool
     
     @Published var name: String
     @Published private var format: SupportedPropertyFormat
@@ -65,6 +66,7 @@ final class PropertyInfoViewModel: ObservableObject {
         self.relationsInteractor = relationsInteractor
         self.output = output
         self.mode = data.mode
+        self.isReadOnly = data.isReadOnly
         
         self.name = data.name
         self.format = data.mode.format ?? SupportedPropertyFormat.object

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Views/PropertiesLibrary/ObjectPropertiesLibraryViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Views/PropertiesLibrary/ObjectPropertiesLibraryViewModel.swift
@@ -41,7 +41,8 @@ final class ObjectPropertiesLibraryViewModel: ObservableObject, PropertyInfoCoor
             objectId: nil,
             spaceId: row.spaceId,
             target: .library,
-            mode: .edit(relationId: row.id, format: supportedFormat, limitedObjectTypes: row.objectTypes.isEmpty ? nil : row.objectTypes)
+            mode: .edit(relationId: row.id, format: supportedFormat, limitedObjectTypes: row.objectTypes.isEmpty ? nil : row.objectTypes),
+            isReadOnly: row.isReadOnly
         )
     }
     
@@ -51,7 +52,8 @@ final class ObjectPropertiesLibraryViewModel: ObservableObject, PropertyInfoCoor
             objectId: nil,
             spaceId: spaceId,
             target: .library,
-            mode: .create(format: .text)
+            mode: .create(format: .text),
+            isReadOnly: false
         )
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/TypePropertiesView/TypePropertiesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Relations/Views/TypePropertiesView/TypePropertiesViewModel.swift
@@ -93,7 +93,8 @@ final class TypePropertiesViewModel: ObservableObject {
             objectId: document.objectId,
             spaceId: document.spaceId,
             target: .type(typeData),
-            mode: .edit(relationId: data.relation.id, format: format, limitedObjectTypes: data.relation.limitedObjectTypes)
+            mode: .edit(relationId: data.relation.id, format: format, limitedObjectTypes: data.relation.limitedObjectTypes),
+            isReadOnly: !data.relation.isEditable
         )
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationViewModel.swift
@@ -70,7 +70,8 @@ final class PropertyCreationViewModel: ObservableObject, PropertyInfoCoordinator
                     objectId: data.objectId,
                     spaceId: data.spaceId,
                     target: data.target,
-                    mode: .create(format: format)
+                    mode: .create(format: format),
+                    isReadOnly: false
                 )
             }
         }
@@ -82,7 +83,8 @@ final class PropertyCreationViewModel: ObservableObject, PropertyInfoCoordinator
             objectId: data.objectId,
             spaceId: data.spaceId,
             target: data.target,
-            mode: .create(format: .text)
+            mode: .create(format: .text),
+            isReadOnly: false
         )
     }
     


### PR DESCRIPTION
## Summary
- Add restrictions to prevent changing names for system properties and read-only properties in PropertyInfoCoordinatorView
- System properties and read-only properties now have disabled name editing in the property editor