### PR TITLE
IOS-4660 Rename RelationsService to PropertiesService

### DIFF
--- a/AnyTypeTests/Helpers/TypePropertiesMoveHandler/TypePropertiesMoveHandlerAdditionalTests.swift
+++ b/AnyTypeTests/Helpers/TypePropertiesMoveHandler/TypePropertiesMoveHandlerAdditionalTests.swift
@@ -5,15 +5,15 @@ import Services
 class TypePropertiesMoveHandlerAdditionalTests: XCTestCase {
     var moveHandler: TypePropertiesMoveHandler!
     var mockDocument: MockBaseDocument!
-    var mockRelationsService: MockRelationsService!
+    var mockPropertiesService: MockPropertiesService!
     
     override func setUp() {
         super.setUp()
-        let mockRelationsService = MockRelationsService()
-        Container.shared.relationsService.register { mockRelationsService }
+        let mockPropertiesService = MockPropertiesService()
+        Container.shared.propertiesService.register { mockPropertiesService }
         let mockPropertyDetailsStorage = MockPropertyDetailsStorage()
         Container.shared.propertyDetailsStorage.register { mockPropertyDetailsStorage }
-        self.mockRelationsService = mockRelationsService
+        self.mockPropertiesService = mockPropertiesService
         mockDocument = MockBaseDocument()
         moveHandler = TypePropertiesMoveHandler()
     }
@@ -41,11 +41,11 @@ class TypePropertiesMoveHandlerAdditionalTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
             []
         )
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
             ["f1"]
         )
     }
@@ -71,11 +71,11 @@ class TypePropertiesMoveHandlerAdditionalTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
             ["h1"]
         )
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
             []
         )
     }
@@ -99,7 +99,7 @@ class TypePropertiesMoveHandlerAdditionalTests: XCTestCase {
             document: mockDocument
         )
         
-        XCTAssertNil(mockRelationsService.lastUpdateRecommendedRelations)
+        XCTAssertNil(mockPropertiesService.lastUpdateRecommendedRelations)
     }
     
     func testMoveWithInvalidRelationId() async throws {
@@ -120,7 +120,7 @@ class TypePropertiesMoveHandlerAdditionalTests: XCTestCase {
             document: mockDocument
         )
         
-        XCTAssertNil(mockRelationsService.lastUpdateRecommendedFeaturedRelations)
+        XCTAssertNil(mockPropertiesService.lastUpdateRecommendedFeaturedRelations)
     }
     
     // MARK: - Concurrent Updates Tests
@@ -144,7 +144,7 @@ class TypePropertiesMoveHandlerAdditionalTests: XCTestCase {
         try await (move1, move2)
         
         // The last update should be applied
-        XCTAssertNotNil(mockRelationsService.lastUpdateRecommendedFeaturedRelations)
+        XCTAssertNotNil(mockPropertiesService.lastUpdateRecommendedFeaturedRelations)
     }
     
     // MARK: - Header Navigation Tests

--- a/AnyTypeTests/Helpers/TypePropertiesMoveHandler/TypePropertiesMoveHandlerGeneralTests.swift
+++ b/AnyTypeTests/Helpers/TypePropertiesMoveHandler/TypePropertiesMoveHandlerGeneralTests.swift
@@ -5,13 +5,13 @@ import Services
 class TypePropertiesMoveHandlerTests: XCTestCase {
     var moveHandler: TypePropertiesMoveHandler!
     var mockDocument: MockBaseDocument!
-    var mockRelationsService: MockRelationsService!
+    var mockPropertiesService: MockPropertiesService!
 
     override func setUp() {
         super.setUp()
-        let mockRelationsService = MockRelationsService()
-        Container.shared.relationsService.register { mockRelationsService }
-        self.mockRelationsService = mockRelationsService
+        let mockPropertiesService = MockPropertiesService()
+        Container.shared.propertiesService.register { mockPropertiesService }
+        self.mockPropertiesService = mockPropertiesService
         mockDocument = MockBaseDocument()
         moveHandler = TypePropertiesMoveHandler()
     }
@@ -68,7 +68,7 @@ class TypePropertiesMoveHandlerTests: XCTestCase {
             document: mockDocument
         )
         // No error should be thrown, and no service calls should be made
-        XCTAssertNil(mockRelationsService.lastUpdateRecommendedFeaturedRelations)
-        XCTAssertNil(mockRelationsService.lastUpdateTypeRelations)
+        XCTAssertNil(mockPropertiesService.lastUpdateRecommendedFeaturedRelations)
+        XCTAssertNil(mockPropertiesService.lastUpdateTypeRelations)
     }
 }

--- a/AnyTypeTests/Helpers/TypePropertiesMoveHandler/TypePropertiesMoveHandlerMoveBetweenSectionTests.swift
+++ b/AnyTypeTests/Helpers/TypePropertiesMoveHandler/TypePropertiesMoveHandlerMoveBetweenSectionTests.swift
@@ -5,13 +5,13 @@ import Services
 class TypePropertiesMoveHandlerMoveBetweenSectionTests: XCTestCase {
     var moveHandler: TypePropertiesMoveHandler!
     var mockDocument: MockBaseDocument!
-    var mockRelationsService: MockRelationsService!
+    var mockPropertiesService: MockPropertiesService!
 
     override func setUp() {
         super.setUp()
-        let mockRelationsService = MockRelationsService()
-        Container.shared.relationsService.register { mockRelationsService }
-        self.mockRelationsService = mockRelationsService
+        let mockPropertiesService = MockPropertiesService()
+        Container.shared.propertiesService.register { mockPropertiesService }
+        self.mockPropertiesService = mockPropertiesService
         mockDocument = MockBaseDocument()
         moveHandler = TypePropertiesMoveHandler()
     }
@@ -31,11 +31,11 @@ class TypePropertiesMoveHandlerMoveBetweenSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
             ["h1", "f1", "f2", "f3"]
         )
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
             ["h2", "h3"]
         )
     }
@@ -55,11 +55,11 @@ class TypePropertiesMoveHandlerMoveBetweenSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
             ["f1", "h1", "f2", "f3"]
         )
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
             ["h2", "h3"]
         )
     }
@@ -79,11 +79,11 @@ class TypePropertiesMoveHandlerMoveBetweenSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
             ["h2", "f1", "f2", "f3"]
         )
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
             ["h1", "h3"]
         )
     }
@@ -103,11 +103,11 @@ class TypePropertiesMoveHandlerMoveBetweenSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
             ["h3", "f1", "f2", "f3"]
         )
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
             ["h1", "h2"]
         )
     }
@@ -127,11 +127,11 @@ class TypePropertiesMoveHandlerMoveBetweenSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedRelations.map(\.id),
             ["f1", "f3"]
         )
         XCTAssertEqual(
-            mockRelationsService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
+            mockPropertiesService.lastUpdateTypeRelations?.recommendedFeaturedRelations.map(\.id),
             ["h1", "h2", "h3", "f2"]
         )
     }

--- a/AnyTypeTests/Helpers/TypePropertiesMoveHandler/TypePropertiesMoveHandlerMoveWithinSectionTests.swift
+++ b/AnyTypeTests/Helpers/TypePropertiesMoveHandler/TypePropertiesMoveHandlerMoveWithinSectionTests.swift
@@ -5,13 +5,13 @@ import Services
 class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
     var moveHandler: TypePropertiesMoveHandler!
     var mockDocument: MockBaseDocument!
-    var mockRelationsService: MockRelationsService!
+    var mockPropertiesService: MockPropertiesService!
 
     override func setUp() {
         super.setUp()
-        let mockRelationsService = MockRelationsService()
-        Container.shared.relationsService.register { mockRelationsService }
-        self.mockRelationsService = mockRelationsService
+        let mockPropertiesService = MockPropertiesService()
+        Container.shared.propertiesService.register { mockPropertiesService }
+        self.mockPropertiesService = mockPropertiesService
         mockDocument = MockBaseDocument()
         moveHandler = TypePropertiesMoveHandler()
     }
@@ -32,7 +32,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
             ["h2", "h3", "h1", "h4"]
         )
     }
@@ -51,7 +51,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
             ["h2", "h3", "h4", "h1"]
         )
     }
@@ -70,7 +70,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
             ["h2", "h1", "h3", "h4"]
         )
     }
@@ -89,7 +89,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
             ["h1", "h3", "h4", "h2"]
         )
     }
@@ -108,7 +108,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
             ["h4", "h1", "h2", "h3"]
         )
     }
@@ -127,7 +127,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedFeaturedRelations?.relations.map(\.id),
             ["h1", "h4", "h2", "h3"]
         )
     }
@@ -147,7 +147,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedRelations?.relations.map(\.id),
             ["f2", "f3", "f1", "f4"]
         )
     }
@@ -166,7 +166,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedRelations?.relations.map(\.id),
             ["f2", "f3", "f4", "f1"]
         )
     }
@@ -185,7 +185,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedRelations?.relations.map(\.id),
             ["f2", "f1", "f3", "f4"]
         )
     }
@@ -204,7 +204,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedRelations?.relations.map(\.id),
             ["f1", "f3", "f4", "f2"]
         )
     }
@@ -223,7 +223,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedRelations?.relations.map(\.id),
             ["f4", "f1", "f2", "f3"]
         )
     }
@@ -242,7 +242,7 @@ class TypePropertiesMoveHandlerMoveWithinSectionTests: XCTestCase {
         )
         
         XCTAssertEqual(
-            mockRelationsService.lastUpdateRecommendedRelations?.relations.map(\.id),
+            mockPropertiesService.lastUpdateRecommendedRelations?.relations.map(\.id),
             ["f1", "f4", "f2", "f3"]
         )
     }

--- a/AnyTypeTests/Markdown/Mocks/MockPropertiesService.swift
+++ b/AnyTypeTests/Markdown/Mocks/MockPropertiesService.swift
@@ -3,7 +3,7 @@ import Services
 import ProtobufMessages
 import SwiftProtobuf
 
-class MockRelationsService: RelationsServiceProtocol {
+class MockPropertiesService: PropertiesServiceProtocol {
     // Last call data storage
     var lastUpdateRelation: (objectId: String, relationKey: String, value: Google_Protobuf_Value)?
     var lastUpdateRelationOption: (id: String, text: String, color: String?)?

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Date/PropertyCalendarViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Date/PropertyCalendarViewModel.swift
@@ -15,8 +15,8 @@ final class PropertyCalendarViewModel: ObservableObject {
     
     let config: PropertyModuleConfiguration
     
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     @Injected(\.propertyDetailsStorage)
     private var propertyDetailsStorage: any PropertyDetailsStorageProtocol
     
@@ -48,7 +48,7 @@ final class PropertyCalendarViewModel: ObservableObject {
     
     private func updateDateRelation(with value: Double) {
         Task {
-            try await relationsService.updateRelation(objectId: config.objectId, relationKey: config.relationKey, value: value.protobufValue)
+            try await propertiesService.updateRelation(objectId: config.objectId, relationKey: config.relationKey, value: value.protobufValue)
             let relationDetails = try propertyDetailsStorage.relationsDetails(key: config.relationKey, spaceId: config.spaceId)
             AnytypeAnalytics.instance().logChangeOrDeleteRelationValue(
                 isEmpty: value.isZero,

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/PropertyOptionSettings/PropertyOptionSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/PropertyOptionSettings/PropertyOptionSettingsViewModel.swift
@@ -11,8 +11,8 @@ final class PropertyOptionSettingsViewModel: ObservableObject {
     let colors: [Color]
     let configuration: PropertyOptionSettingsConfiguration
     
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     
     private let completion: (_ optionParams: RelationOptionParameters) -> Void
     
@@ -42,7 +42,7 @@ final class PropertyOptionSettingsViewModel: ObservableObject {
     
     private func create(with data: PropertyOptionSettingsMode.CreateData) {
         Task {
-            let optionId = try await relationsService.addRelationOption(
+            let optionId = try await propertiesService.addRelationOption(
                 spaceId: data.spaceId,
                 relationKey: data.relationKey,
                 optionText: text,
@@ -63,7 +63,7 @@ final class PropertyOptionSettingsViewModel: ObservableObject {
     
     private func edit() {
         Task {
-            try await relationsService.updateRelationOption(
+            try await propertiesService.updateRelationOption(
                 id: configuration.option.id,
                 text: text,
                 color: selectedColor.middlewareString()

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/PropertySelectedOptions/PropertySelectedOptionsModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/PropertySelectedOptions/PropertySelectedOptionsModel.swift
@@ -20,8 +20,8 @@ final class PropertySelectedOptionsModel: PropertySelectedOptionsModelProtocol {
     
     let config: PropertyModuleConfiguration
     
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     @Injected(\.propertyDetailsStorage)
     private var propertyDetailsStorage: any PropertyDetailsStorageProtocol
     
@@ -32,7 +32,7 @@ final class PropertySelectedOptionsModel: PropertySelectedOptionsModelProtocol {
     
     func onClear() async throws {
         selectedOptionsIds = []
-        try await relationsService.updateRelation(objectId: config.objectId, relationKey: config.relationKey, value: nil)
+        try await propertiesService.updateRelation(objectId: config.objectId, relationKey: config.relationKey, value: nil)
         logChanges()
     }
     
@@ -44,7 +44,7 @@ final class PropertySelectedOptionsModel: PropertySelectedOptionsModelProtocol {
             handleMultiOptionSelected(optionId)
         }
         
-        try await relationsService.updateRelation(
+        try await propertiesService.updateRelation(
             objectId: config.objectId,
             relationKey: config.relationKey,
             value: selectedOptionsIds.protobufValue
@@ -53,14 +53,14 @@ final class PropertySelectedOptionsModel: PropertySelectedOptionsModelProtocol {
     }
     
     func removeRelationOption(_ optionId: String) async throws {
-        try await relationsService.removeRelationOptions(ids: [optionId])
+        try await propertiesService.removeRelationOptions(ids: [optionId])
         try await removeRelationOptionFromSelectedIfNeeded(optionId)
     }
     
     func removeRelationOptionFromSelectedIfNeeded(_ optionId: String) async throws {
         if let index = selectedOptionsIds.firstIndex(of: optionId) {
             selectedOptionsIds.remove(at: index)
-            try await relationsService.updateRelation(
+            try await propertiesService.updateRelation(
                 objectId: config.objectId,
                 relationKey: config.relationKey,
                 value: selectedOptionsIds.protobufValue

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Text/TextPropertyDetailsService/TextPropertyEditingService.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Text/TextPropertyDetailsService/TextPropertyEditingService.swift
@@ -7,7 +7,7 @@ protocol TextPropertyEditingServiceProtocol: AnyObject, Sendable {
 
 final class TextPropertyEditingService: TextPropertyEditingServiceProtocol, Sendable {
 
-    private let service: any RelationsServiceProtocol = Container.shared.relationsService()
+    private let service: any PropertiesServiceProtocol = Container.shared.propertiesService()
     
     private let numberFormatter = NumberFormatter.decimalWithNoSeparator
     

--- a/Anytype/Sources/PresentationLayer/PropertyValueFlow/PropertyValueCoordinator/PropertyValueProcessingService.swift
+++ b/Anytype/Sources/PresentationLayer/PropertyValueFlow/PropertyValueCoordinator/PropertyValueProcessingService.swift
@@ -14,8 +14,8 @@ protocol PropertyValueProcessingServiceProtocol {
 @MainActor
 fileprivate final class PropertyValueProcessingService: PropertyValueProcessingServiceProtocol {
     
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     @Injected(\.propertyDetailsStorage)
     private var propertyDetailsStorage: any PropertyDetailsStorageProtocol
     
@@ -37,7 +37,7 @@ fileprivate final class PropertyValueProcessingService: PropertyValueProcessingS
             guard relation.isEditable else { return nil }
             Task {
                 let newValue = !checkbox.value
-                try await relationsService.updateRelation(objectId: objectDetails.id, relationKey: checkbox.key, value: newValue.protobufValue)
+                try await propertiesService.updateRelation(objectId: objectDetails.id, relationKey: checkbox.key, value: newValue.protobufValue)
                 let relationDetails = try propertyDetailsStorage.relationsDetails(key: relation.key, spaceId: objectDetails.spaceId)
                 AnytypeAnalytics.instance().logChangeOrDeleteRelationValue(
                     isEmpty: !newValue,

--- a/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/PropertiesSearchViewModel/PropertiesInteractor.swift
+++ b/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/PropertiesSearchViewModel/PropertiesInteractor.swift
@@ -16,7 +16,7 @@ protocol PropertiesInteractorProtocol: Sendable {
 
 final class PropertiesInteractor: PropertiesInteractorProtocol, Sendable {
     
-    private let relationsService: any RelationsServiceProtocol = Container.shared.relationsService()
+    private let propertiesService: any PropertiesServiceProtocol = Container.shared.propertiesService()
     private let dataviewService: any DataviewServiceProtocol = Container.shared.dataviewService()
     private let propertyDetailsStorage: any PropertyDetailsStorageProtocol = Container.shared.propertyDetailsStorage()
     
@@ -32,11 +32,11 @@ final class PropertiesInteractor: PropertiesInteractorProtocol, Sendable {
     }
     
     func createProperty(spaceId: String, relation: RelationDetails) async throws -> RelationDetails {
-        try await relationsService.createRelation(spaceId: spaceId, relationDetails: relation)
+        try await propertiesService.createRelation(spaceId: spaceId, relationDetails: relation)
     }
     
     func updateProperty(spaceId: String, relation: RelationDetails) async throws {
-        try await relationsService.updateRelation(objectId: relation.id, fields: relation.fields)
+        try await propertiesService.updateRelation(objectId: relation.id, fields: relation.fields)
     }
     
     func addPropertyToType(relation: RelationDetails, isFeatured: Bool) async throws {
@@ -46,9 +46,9 @@ final class PropertiesInteractor: PropertiesInteractorProtocol, Sendable {
         guard let details = document.details else { return }
         
         if isFeatured {
-            try await relationsService.addTypeFeaturedRecommendedRelation(details: details, relation: relation)
+            try await propertiesService.addTypeFeaturedRecommendedRelation(details: details, relation: relation)
         } else {
-            try await relationsService.addTypeRecommendedRelation(details: details, relation: relation)
+            try await propertiesService.addTypeRecommendedRelation(details: details, relation: relation)
         }
     }
     
@@ -64,10 +64,10 @@ final class PropertiesInteractor: PropertiesInteractorProtocol, Sendable {
     }
     
     private func addPropertyToType(relation: RelationDetails, details: ObjectDetails) async throws {
-        try await relationsService.addTypeRecommendedRelation(details: details, relation: relation)
+        try await propertiesService.addTypeRecommendedRelation(details: details, relation: relation)
     }
     
     func addPropertyToObject(objectId: String, relation: RelationDetails) async throws {
-        try await relationsService.addRelations(objectId: objectId, relationsDetails: [relation])
+        try await propertiesService.addRelations(objectId: objectId, relationsDetails: [relation])
     }
 }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Views/PropertiesLibrary/ObjectPropertiesLibraryViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Views/PropertiesLibrary/ObjectPropertiesLibraryViewModel.swift
@@ -13,8 +13,8 @@ final class ObjectPropertiesLibraryViewModel: ObservableObject, PropertyInfoCoor
     @Injected(\.propertyDetailsStorage)
     private var propertyDetailsStorage: any PropertyDetailsStorageProtocol
     
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     
     @Injected(\.dataviewService)
     private var dataviewService: any DataviewServiceProtocol

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/Model/ObjectSettingsPrimitivesConflictManager.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/Model/ObjectSettingsPrimitivesConflictManager.swift
@@ -10,7 +10,7 @@ protocol ObjectSettingsPrimitivesConflictManagerProtocol: Sendable {
 final class ObjectSettingsPrimitivesConflictManager: ObjectSettingsPrimitivesConflictManagerProtocol {
     private let objectTypeProvider: any ObjectTypeProviderProtocol = Container.shared.objectTypeProvider()
     private let propertyDetailsStorage: any PropertyDetailsStorageProtocol = Container.shared.propertyDetailsStorage()
-    private let relationsService: any RelationsServiceProtocol = Container.shared.relationsService()
+    private let propertiesService: any PropertiesServiceProtocol = Container.shared.propertiesService()
     
     func haveLayoutConflicts(details: ObjectDetails) -> Bool {
         guard !details.isObjectType else { return false }
@@ -39,16 +39,16 @@ final class ObjectSettingsPrimitivesConflictManager: ObjectSettingsPrimitivesCon
     
     func resolveConflicts(details: ObjectDetails) async throws {
         // Remove legacy relations
-        try await relationsService.removeRelation(objectId: details.id, relationKey: BundledRelationKey.layout.rawValue)
-        try await relationsService.removeRelation(objectId: details.id, relationKey: BundledRelationKey.layoutAlign.rawValue)
-        try await relationsService.removeRelation(objectId: details.id, relationKey: BundledRelationKey.layoutWidth.rawValue)
+        try await propertiesService.removeRelation(objectId: details.id, relationKey: BundledRelationKey.layout.rawValue)
+        try await propertiesService.removeRelation(objectId: details.id, relationKey: BundledRelationKey.layoutAlign.rawValue)
+        try await propertiesService.removeRelation(objectId: details.id, relationKey: BundledRelationKey.layoutWidth.rawValue)
         
         // Remove all legacy relations except for description if present (description uses legacy mechanism to preserve its visibility)
         let featuredRelationIds = propertyDetailsStorage
             .relationsDetails(keys: details.featuredRelations, spaceId: details.spaceId)
                 .filter { $0.key == BundledRelationKey.description.rawValue }
                 .map(\.id)
-        try await relationsService.setFeaturedRelation(objectId: details.id, featuredRelationIds: featuredRelationIds)
+        try await propertiesService.setFeaturedRelation(objectId: details.id, featuredRelationIds: featuredRelationIds)
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
@@ -29,8 +29,8 @@ final class ObjectSettingsViewModel: ObservableObject, ObjectActionsOutput {
 
     @Injected(\.openedDocumentProvider)
     private var openDocumentsProvider: any OpenedDocumentsProviderProtocol
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     @Injected(\.objectSettingsBuilder)
     private var settingsBuilder: any ObjectSettingsBuilderProtocol
     @Injected(\.objectSettingsConflictManager)
@@ -88,7 +88,7 @@ final class ObjectSettingsViewModel: ObservableObject, ObjectActionsOutput {
         guard let details = document.details else { return }
         
         let descriptionIsOn = details.featuredRelations.contains(where: { $0 == BundledRelationKey.description.rawValue })
-        try await relationsService.toggleDescription(objectId: document.objectId, isOn: !descriptionIsOn)
+        try await propertiesService.toggleDescription(objectId: document.objectId, isOn: !descriptionIsOn)
     }
     
     func onTapResolveConflict() {

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/ObjectFieldsView/ObjectPropertiesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/ObjectFieldsView/ObjectPropertiesViewModel.swift
@@ -24,8 +24,8 @@ final class ObjectPropertiesViewModel: ObservableObject {
     private let document: any BaseDocumentProtocol
     private let sectionsBuilder = PropertiesSectionBuilder()
     
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     @Injected(\.propertyDetailsStorage)
     private var propertyDetailsStorage: any PropertyDetailsStorageProtocol
     @Injected(\.documentsProvider)
@@ -55,7 +55,7 @@ final class ObjectPropertiesViewModel: ObservableObject {
     
     func removeRelation(_ relation: Relation) {
         Task {
-            try await relationsService.removeRelation(objectId: document.objectId, relationKey: relation.key)
+            try await propertiesService.removeRelation(objectId: document.objectId, relationKey: relation.key)
             let relationDetails = try propertyDetailsStorage.relationsDetails(key: relation.key, spaceId: document.spaceId)
             AnytypeAnalytics.instance().logDeleteRelation(spaceId: document.spaceId, format: relationDetails.format, key: relationDetails.analyticsKey, route: .object)
         }
@@ -72,7 +72,7 @@ final class ObjectPropertiesViewModel: ObservableObject {
         
         Task {
             let relationsDetail = try propertyDetailsStorage.relationsDetails(key: relation.key, spaceId: details.spaceId)
-            try await relationsService.addTypeRecommendedRelation(type: details.objectType, relation: relationsDetail)
+            try await propertiesService.addTypeRecommendedRelation(type: details.objectType, relation: relationsDetail)
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/TypePropertiesView/Model/TypePropertiesMoveHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/TypePropertiesView/Model/TypePropertiesMoveHandler.swift
@@ -15,7 +15,7 @@ protocol TypePropertiesMoveHandlerProtocol: Sendable {
 }
 
 final class TypePropertiesMoveHandler: Sendable {
-    private let relationsService: any RelationsServiceProtocol = Container.shared.relationsService()
+    private let propertiesService: any PropertiesServiceProtocol = Container.shared.propertiesService()
     
     func onMove(from: Int, to: Int, relationRows: [TypePropertiesRow], document: any BaseDocumentProtocol) async throws {
         guard let fromRow = relationRows[safe: from], case let .relation(fromRelation) = fromRow else {
@@ -333,7 +333,7 @@ final class TypePropertiesMoveHandler: Sendable {
     ) async throws {
         AnytypeAnalytics.instance().logReorderRelation(group: from != to ? to.analyticsValue : nil)
         
-        try await relationsService.updateTypeRelations(
+        try await propertiesService.updateTypeRelations(
             typeId: typeId,
             recommendedRelations: recommendedRelationIds,
             recommendedFeaturedRelations: recommendedFeaturedRelationsIds,

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/TypePropertiesView/TypePropertiesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/TypePropertiesView/TypePropertiesViewModel.swift
@@ -24,8 +24,8 @@ final class TypePropertiesViewModel: ObservableObject {
     
     private var parsedRelations = ParsedRelations.empty
     
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     @Injected(\.propertyDetailsStorage)
     private var propertyDetailsStorage: any PropertyDetailsStorageProtocol
     @Injected(\.singleRelationBuilder)
@@ -125,7 +125,7 @@ final class TypePropertiesViewModel: ObservableObject {
         guard let details = document.details else { return }
         
         Task {
-            try await relationsService.removeTypeRelation(details: details, relationId: row.relation.id)
+            try await propertiesService.removeTypeRelation(details: details, relationId: row.relation.id)
             
             guard let format = row.relation.format?.format else {
                 anytypeAssertionFailure("Empty relation format for onRelationRemove")
@@ -140,13 +140,13 @@ final class TypePropertiesViewModel: ObservableObject {
         AnytypeAnalytics.instance().logAddConflictRelation()
         
         Task {
-            try await relationsService.addTypeRecommendedRelation(details: details, relation: relation)    
+            try await propertiesService.addTypeRecommendedRelation(details: details, relation: relation)    
             if let details = document.details { try await updateConflictRelations(details: details) }
         }
     }
     
     private func updateConflictRelations(details: ObjectDetails) async throws {
-        let releationKeys = try await relationsService.getConflictRelationsForType(typeId: document.objectId, spaceId: document.spaceId)
+        let releationKeys = try await propertiesService.getConflictRelationsForType(typeId: document.objectId, spaceId: document.spaceId)
         conflictRelations = propertyDetailsStorage
             .relationsDetails(ids: releationKeys, spaceId: document.spaceId)
             .filter { !$0.isHidden && !$0.isDeleted }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -189,8 +189,8 @@ final class EditorSetViewModel: ObservableObject {
     private var detailsService: any DetailsServiceProtocol
     @Injected(\.objectActionsService)
     private var objectActionsService: any ObjectActionsServiceProtocol
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     @Injected(\.textServiceHandler)
     private var textServiceHandler: any TextServiceProtocol
     @Injected(\.groupsSubscriptionsHandler)
@@ -321,7 +321,7 @@ final class EditorSetViewModel: ObservableObject {
     
     private func subscribeOnRelations() async {
         for await relations in setDocument.document.parsedRelationsPublisherForType.values {
-            let conflictingKeys = (try? await relationsService
+            let conflictingKeys = (try? await propertiesService
                 .getConflictRelationsForType(typeId: setDocument.objectId, spaceId: setDocument.spaceId)) ?? []
             let conflictingRelations = propertyDetailsStorage
                 .relationsDetails(ids: conflictingKeys, spaceId: setDocument.spaceId)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/CreateObject/CreateObjectViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/CreateObject/CreateObjectViewModel.swift
@@ -5,8 +5,8 @@ import AnytypeCore
 final class CreateObjectViewModel: CreateObjectViewModelProtocol {
     let style = CreateObjectView.Style.default
     
-    @Injected(\.relationsService)
-    private var relationService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     @Injected(\.textService)
     private var textServiceHandler: any TextServiceProtocol
     
@@ -62,7 +62,7 @@ final class CreateObjectViewModel: CreateObjectViewModelProtocol {
                 let middlewareString = MiddlewareString(text: text)
                 try await textServiceHandler.setText(contextId: objectId, blockId: blockId, middlewareString: middlewareString)
             case .writeToRelationName:
-                try await relationService.updateRelation(
+                try await propertiesService.updateRelation(
                     objectId: objectId,
                     relationKey: BundledRelationKey.name.rawValue,
                     value: text.protobufValue

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationViewModel.swift
@@ -17,8 +17,8 @@ final class PropertyCreationViewModel: ObservableObject, PropertyInfoCoordinator
     private var workspaceService: any WorkspaceServiceProtocol
     @Injected(\.dataviewService)
     private var dataviewService: any DataviewServiceProtocol
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     @Injected(\.objectActionsService)
     private var objectActionsService: any ObjectActionsServiceProtocol
     
@@ -112,9 +112,9 @@ final class PropertyCreationViewModel: ObservableObject, PropertyInfoCoordinator
     private func addPropertyToType(relation: RelationDetails, typeData: PropertiesModuleTypeData) async throws {
         switch typeData {
         case .recommendedFeaturedRelations(let type):
-            try await relationsService.addTypeFeaturedRecommendedRelation(type: type, relation: relation)
+            try await propertiesService.addTypeFeaturedRecommendedRelation(type: type, relation: relation)
         case .recommendedRelations(let type):
-            try await relationsService.addTypeRecommendedRelation(type: type, relation: relation)
+            try await propertiesService.addTypeRecommendedRelation(type: type, relation: relation)
         }
     }
     
@@ -132,6 +132,6 @@ final class PropertyCreationViewModel: ObservableObject, PropertyInfoCoordinator
     
     
     func addPropertyToObject(objectId: String, relation: RelationDetails) async throws {
-        try await relationsService.addRelations(objectId: objectId, relationsDetails: [relation])
+        try await propertiesService.addRelations(objectId: objectId, relationsDetails: [relation])
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/SetPropertiesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/SetPropertiesViewModel.swift
@@ -15,8 +15,8 @@ final class SetPropertiesViewModel: ObservableObject {
     
     @Injected(\.dataviewService)
     private var dataviewService: any DataviewServiceProtocol
-    @Injected(\.relationsService)
-    private var relationsService: any RelationsServiceProtocol
+    @Injected(\.propertiesService)
+    private var propertiesService: any PropertiesServiceProtocol
     
     private weak var output: (any SetPropertiesCoordinatorOutput)?
     
@@ -44,7 +44,7 @@ final class SetPropertiesViewModel: ObservableObject {
                 guard let details = setDocument.details else { return }
                 
                 if details.isObjectType {
-                    try await relationsService.removeTypeRelation(
+                    try await propertiesService.removeTypeRelation(
                         details: details,
                         relationId: relation.relationDetails.id
                     )
@@ -57,7 +57,7 @@ final class SetPropertiesViewModel: ObservableObject {
                 }
                 
                 if let details = setDocument.details, details.isObjectType {
-                    try await relationsService.removeTypeRelation(details: details, relationId: relation.relationDetails.id)
+                    try await propertiesService.removeTypeRelation(details: details, relationId: relation.relationDetails.id)
                 } else {
                     try await dataviewService.removeViewRelations(
                         objectId: setDocument.objectId,

--- a/Anytype/Sources/ServiceLayer/Extensions/PropertiesServiceProtocolExtensions.swift
+++ b/Anytype/Sources/ServiceLayer/Extensions/PropertiesServiceProtocolExtensions.swift
@@ -1,6 +1,6 @@
 import Services
 
-extension RelationsServiceProtocol {
+extension PropertiesServiceProtocol {
     func updateTypeRelations(
         typeId: String,
         recommendedRelations: [RelationDetails],

--- a/Modules/Services/Sources/Services/Properties/PropertiesService.swift
+++ b/Modules/Services/Sources/Services/Properties/PropertiesService.swift
@@ -2,13 +2,13 @@ import Foundation
 import ProtobufMessages
 import SwiftProtobuf
 
-enum RelationServiceError: Error {
+enum PropertyServiceError: Error {
     case unableToCreateRelationFromObject
 }
 
-final class RelationsService: RelationsServiceProtocol {
+final class PropertiesService: PropertiesServiceProtocol {
     
-    // MARK: - RelationsServiceProtocol
+    // MARK: - PropertiesServiceProtocol
     
     func setFeaturedRelation(objectId: String, featuredRelationIds: [String]) async throws {
         try await ClientCommands.objectSetDetails(.with {
@@ -71,7 +71,7 @@ final class RelationsService: RelationsServiceProtocol {
         }).invoke()
         
         guard let objectDetails = try? ObjectDetails(protobufStruct: result.details) else {
-            throw RelationServiceError.unableToCreateRelationFromObject
+            throw PropertyServiceError.unableToCreateRelationFromObject
         }
               
         return RelationDetails(details: objectDetails)

--- a/Modules/Services/Sources/Services/Properties/PropertiesServiceProtocol.swift
+++ b/Modules/Services/Sources/Services/Properties/PropertiesServiceProtocol.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftProtobuf
 
-public protocol RelationsServiceProtocol: AnyObject, Sendable {
+public protocol PropertiesServiceProtocol: AnyObject, Sendable {
     func setFeaturedRelation(objectId: String, featuredRelationIds: [String]) async throws
     
     func updateRelation(objectId: String, relationKey: String, value: Google_Protobuf_Value) async throws

--- a/Modules/Services/Sources/ServicesDI.swift
+++ b/Modules/Services/Sources/ServicesDI.swift
@@ -86,8 +86,8 @@ public extension Container {
         self { ProcessSubscriptionService() }.shared
     }
     
-    var relationsService: Factory<RelationsServiceProtocol> {
-        self { RelationsService() }.shared
+    var propertiesService: Factory<PropertiesServiceProtocol> {
+        self { PropertiesService() }.shared
     }
     
     var sceneLifecycleStateService: Factory<SceneLifecycleStateServiceProtocol> {


### PR DESCRIPTION
## Summary
- Rename RelationsServiceProtocol to PropertiesServiceProtocol and all associated entities
- Update dependency injection configuration from relationsService to propertiesService
- Rename service implementation files and directories accordingly
- Update all references throughout the codebase for consistency with Properties terminology