### PR TITLE
IOS-4660 Rename PropertiesService methods from Relation to Property terminology

### DIFF
--- a/AnyTypeTests/Markdown/Mocks/MockPropertiesService.swift
+++ b/AnyTypeTests/Markdown/Mocks/MockPropertiesService.swift
@@ -5,148 +5,128 @@ import SwiftProtobuf
 
 class MockPropertiesService: PropertiesServiceProtocol {
     // Last call data storage
-    var lastUpdateRelation: (objectId: String, relationKey: String, value: Google_Protobuf_Value)?
-    var lastUpdateRelationOption: (id: String, text: String, color: String?)?
-    var lastCreateRelation: (spaceId: String, relationDetails: RelationDetails)?
-    var lastAddRelations: (objectId: String, relations: Any)?
-    var lastRemoveRelation: (objectId: String, relationKey: String)?
-    var lastRemoveRelations: (objectId: String, relationKeys: [String])?
-    var lastAddRelationOption: (spaceId: String, relationKey: String, optionText: String, color: String?)?
-    var lastRemoveRelationOptions: [String]?
+    var lastUpdateProperty: (objectId: String, propertyKey: String, value: Google_Protobuf_Value)?
+    var lastUpdatePropertyOption: (id: String, text: String, color: String?)?
+    var lastCreateProperty: (spaceId: String, propertyDetails: RelationDetails)?
+    var lastAddProperties: (objectId: String, properties: Any)?
+    var lastRemoveProperty: (objectId: String, propertyKey: String)?
+    var lastRemoveProperties: (objectId: String, propertyKeys: [String])?
+    var lastAddPropertyOption: (spaceId: String, propertyKey: String, optionText: String, color: String?)?
+    var lastRemovePropertyOptions: [String]?
     
-    // Type relations last call data
-    var lastUpdateTypeRelations: (typeId: String, recommendedRelations: [RelationDetails], recommendedFeaturedRelations: [RelationDetails], recommendedHiddenRelations: [RelationDetails])?
-    var lastUpdateRecommendedRelations: (typeId: String, relations: [RelationDetails])?
-    var lastUpdateRecommendedFeaturedRelations: (typeId: String, relations: [RelationDetails])?
-    var lastUpdateRecommendedHiddenRelations: (typeId: String, relations: [RelationDetails])?
-    var lastSetFeaturedRelation: (objectId: String, featuredRelationIds: [String])?
+    // Type properties last call data
+    var lastUpdateTypeProperties: (typeId: String, dataviewId: String, recommendedProperties: [RelationDetails], recommendedFeaturedProperties: [RelationDetails], recommendedHiddenProperties: [RelationDetails])?
+    var lastGetConflictPropertiesForType: (typeId: String, spaceId: String)?
+    var lastSetFeaturedProperty: (objectId: String, featuredPropertyIds: [String])?
     var lastToggleDescription: (objectId: String, isOn: Bool)?
 
     // Configurable async result handlers (optional error throwing)
-    var updateRelationError: (any Error)?
-    var updateRelationOptionError: (any Error)?
-    var createRelationError: (any Error)?
-    var addRelationsError: (any Error)?
-    var removeRelationError: (any Error)?
-    var removeRelationsError: (any Error)?
-    var addRelationOptionError: (any Error)?
-    var removeRelationOptionsError: (any Error)?
-    var updateTypeRelationsError: (any Error)?
-    var updateRecommendedRelationsError: (any Error)?
-    var updateRecommendedFeaturedRelationsError: (any Error)?
-    var updateRecommendedHiddenRelationsError: (any Error)?
-    var setFeaturedRelationError: (any Error)?
+    var updatePropertyError: (any Error)?
+    var updatePropertyOptionError: (any Error)?
+    var createPropertyError: (any Error)?
+    var addPropertiesError: (any Error)?
+    var removePropertyError: (any Error)?
+    var removePropertiesError: (any Error)?
+    var addPropertyOptionError: (any Error)?
+    var removePropertyOptionsError: (any Error)?
+    var updateTypePropertiesError: (any Error)?
+    var getConflictPropertiesForTypeError: (any Error)?
+    var setFeaturedPropertyError: (any Error)?
     var toggleDescriptionError: (any Error)?
     
-    func updateRelation(objectId: String, relationKey: String, value: Google_Protobuf_Value) async throws {
-        lastUpdateRelation = (objectId, relationKey, value)
-        if let error = updateRelationError {
+    func updateProperty(objectId: String, propertyKey: String, value: Google_Protobuf_Value) async throws {
+        lastUpdateProperty = (objectId, propertyKey, value)
+        if let error = updatePropertyError {
             throw error
         }
     }
     
-    func updateRelationOption(id: String, text: String, color: String?) async throws {
-        lastUpdateRelationOption = (id, text, color)
-        if let error = updateRelationOptionError {
+    func updatePropertyOption(id: String, text: String, color: String?) async throws {
+        lastUpdatePropertyOption = (id, text, color)
+        if let error = updatePropertyOptionError {
             throw error
         }
     }
     
-    func updateRelation(objectId: String, fields: [String: Google_Protobuf_Value]) async throws {
+    func updateProperty(objectId: String, fields: [String: Google_Protobuf_Value]) async throws {
         // Implementation needed
     }
     
-    func createRelation(spaceId: String, relationDetails: RelationDetails) async throws -> RelationDetails {
-        lastCreateRelation = (spaceId, relationDetails)
-        if let error = createRelationError {
+    func createProperty(spaceId: String, propertyDetails: RelationDetails) async throws -> RelationDetails {
+        lastCreateProperty = (spaceId, propertyDetails)
+        if let error = createPropertyError {
             throw error
         }
-        return relationDetails
+        return propertyDetails
     }
     
-    func addRelations(objectId: String, relationsDetails: [RelationDetails]) async throws {
-        lastAddRelations = (objectId, relationsDetails)
-        if let error = addRelationsError {
-            throw error
-        }
-    }
-    
-    func addRelations(objectId: String, relationKeys: [String]) async throws {
-        lastAddRelations = (objectId, relationKeys)
-        if let error = addRelationsError {
+    func addProperties(objectId: String, propertiesDetails: [RelationDetails]) async throws {
+        lastAddProperties = (objectId, propertiesDetails)
+        if let error = addPropertiesError {
             throw error
         }
     }
     
-    func removeRelation(objectId: String, relationKey: String) async throws {
-        lastRemoveRelation = (objectId, relationKey)
-        if let error = removeRelationError {
+    func addProperties(objectId: String, propertyKeys: [String]) async throws {
+        lastAddProperties = (objectId, propertyKeys)
+        if let error = addPropertiesError {
             throw error
         }
     }
     
-    func removeRelations(objectId: String, relationKeys: [String]) async throws {
-        lastRemoveRelations = (objectId, relationKeys)
-        if let error = removeRelationsError {
+    func removeProperty(objectId: String, propertyKey: String) async throws {
+        lastRemoveProperty = (objectId, propertyKey)
+        if let error = removePropertyError {
             throw error
         }
     }
     
-    func addRelationOption(spaceId: String, relationKey: String, optionText: String, color: String?) async throws -> String? {
-        lastAddRelationOption = (spaceId, relationKey, optionText, color)
-        if let error = addRelationOptionError {
+    func removeProperties(objectId: String, propertyKeys: [String]) async throws {
+        lastRemoveProperties = (objectId, propertyKeys)
+        if let error = removePropertiesError {
+            throw error
+        }
+    }
+    
+    func addPropertyOption(spaceId: String, propertyKey: String, optionText: String, color: String?) async throws -> String? {
+        lastAddPropertyOption = (spaceId, propertyKey, optionText, color)
+        if let error = addPropertyOptionError {
             throw error
         }
         return nil
     }
     
-    func removeRelationOptions(ids: [String]) async throws {
-        lastRemoveRelationOptions = ids
-        if let error = removeRelationOptionsError {
+    func removePropertyOptions(ids: [String]) async throws {
+        lastRemovePropertyOptions = ids
+        if let error = removePropertyOptionsError {
             throw error
         }
     }
     
-    func updateTypeRelations(
+    func updateTypeProperties(
         typeId: String,
-        recommendedRelations: [RelationDetails],
-        recommendedFeaturedRelations: [RelationDetails],
-        recommendedHiddenRelations: [RelationDetails]
+        dataviewId: String,
+        recommendedProperties: [RelationDetails],
+        recommendedFeaturedProperties: [RelationDetails],
+        recommendedHiddenProperties: [RelationDetails]
     ) async throws {
-        lastUpdateTypeRelations = (typeId, recommendedRelations, recommendedFeaturedRelations, recommendedHiddenRelations)
-        if let error = updateTypeRelationsError {
+        lastUpdateTypeProperties = (typeId, dataviewId, recommendedProperties, recommendedFeaturedProperties, recommendedHiddenProperties)
+        if let error = updateTypePropertiesError {
             throw error
         }
     }
     
-    func updateRecommendedRelations(typeId: String, relations: [RelationDetails]) async throws {
-        lastUpdateRecommendedRelations = (typeId, relations)
-        if let error = updateRecommendedRelationsError {
+    func getConflictPropertiesForType(typeId: String, spaceId: String) async throws -> [String] {
+        lastGetConflictPropertiesForType = (typeId, spaceId)
+        if let error = getConflictPropertiesForTypeError {
             throw error
         }
-    }
-    
-    func updateRecommendedFeaturedRelations(typeId: String, relations: [RelationDetails]) async throws {
-        lastUpdateRecommendedFeaturedRelations = (typeId, relations)
-        if let error = updateRecommendedFeaturedRelationsError {
-            throw error
-        }
-    }
-    
-    func updateRecommendedHiddenRelations(typeId: String, relations: [RelationDetails]) async throws {
-        lastUpdateRecommendedHiddenRelations = (typeId, relations)
-        if let error = updateRecommendedHiddenRelationsError {
-            throw error
-        }
-    }
-    
-    func getConflictRelationsForType(typeId: String, spaceId: String) async throws -> [String] {
         return []
     }
     
-    func setFeaturedRelation(objectId: String, featuredRelationIds: [String]) async throws {
-        lastSetFeaturedRelation = (objectId, featuredRelationIds)
-        if let error = setFeaturedRelationError {
+    func setFeaturedProperty(objectId: String, featuredPropertyIds: [String]) async throws {
+        lastSetFeaturedProperty = (objectId, featuredPropertyIds)
+        if let error = setFeaturedPropertyError {
             throw error
         }
     }
@@ -158,25 +138,20 @@ class MockPropertiesService: PropertiesServiceProtocol {
         }
     }
     
-    func updateTypeRelations(typeId: String, dataviewId: String, recommendedRelations: [Services.RelationDetails], recommendedFeaturedRelations: [Services.RelationDetails], recommendedHiddenRelations: [Services.RelationDetails]) async throws {
-        fatalError()
-    }
 
     // Convenience method to reset all last call data
     func reset() {
-        lastUpdateRelation = nil
-        lastUpdateRelationOption = nil
-        lastCreateRelation = nil
-        lastAddRelations = nil
-        lastRemoveRelation = nil
-        lastRemoveRelations = nil
-        lastAddRelationOption = nil
-        lastRemoveRelationOptions = nil
-        lastUpdateTypeRelations = nil
-        lastUpdateRecommendedRelations = nil
-        lastUpdateRecommendedFeaturedRelations = nil
-        lastUpdateRecommendedHiddenRelations = nil
-        lastSetFeaturedRelation = nil
+        lastUpdateProperty = nil
+        lastUpdatePropertyOption = nil
+        lastCreateProperty = nil
+        lastAddProperties = nil
+        lastRemoveProperty = nil
+        lastRemoveProperties = nil
+        lastAddPropertyOption = nil
+        lastRemovePropertyOptions = nil
+        lastUpdateTypeProperties = nil
+        lastGetConflictPropertiesForType = nil
+        lastSetFeaturedProperty = nil
         lastToggleDescription = nil
     }
 }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Date/PropertyCalendarViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Date/PropertyCalendarViewModel.swift
@@ -48,7 +48,7 @@ final class PropertyCalendarViewModel: ObservableObject {
     
     private func updateDateRelation(with value: Double) {
         Task {
-            try await propertiesService.updateRelation(objectId: config.objectId, relationKey: config.relationKey, value: value.protobufValue)
+            try await propertiesService.updateProperty(objectId: config.objectId, propertyKey: config.relationKey, value: value.protobufValue)
             let relationDetails = try propertyDetailsStorage.relationsDetails(key: config.relationKey, spaceId: config.spaceId)
             AnytypeAnalytics.instance().logChangeOrDeleteRelationValue(
                 isEmpty: value.isZero,

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/PropertyOptionSettings/PropertyOptionSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/PropertyOptionSettings/PropertyOptionSettingsViewModel.swift
@@ -42,9 +42,9 @@ final class PropertyOptionSettingsViewModel: ObservableObject {
     
     private func create(with data: PropertyOptionSettingsMode.CreateData) {
         Task {
-            let optionId = try await propertiesService.addRelationOption(
+            let optionId = try await propertiesService.addPropertyOption(
                 spaceId: data.spaceId,
-                relationKey: data.relationKey,
+                propertyKey: data.relationKey,
                 optionText: text,
                 color: selectedColor.middlewareString()
             )
@@ -63,7 +63,7 @@ final class PropertyOptionSettingsViewModel: ObservableObject {
     
     private func edit() {
         Task {
-            try await propertiesService.updateRelationOption(
+            try await propertiesService.updatePropertyOption(
                 id: configuration.option.id,
                 text: text,
                 color: selectedColor.middlewareString()

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/PropertySelectedOptions/PropertySelectedOptionsModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/PropertySelectedOptions/PropertySelectedOptionsModel.swift
@@ -32,7 +32,7 @@ final class PropertySelectedOptionsModel: PropertySelectedOptionsModelProtocol {
     
     func onClear() async throws {
         selectedOptionsIds = []
-        try await propertiesService.updateRelation(objectId: config.objectId, relationKey: config.relationKey, value: nil)
+        try await propertiesService.updateProperty(objectId: config.objectId, propertyKey: config.relationKey, value: [String]().protobufValue)
         logChanges()
     }
     
@@ -44,25 +44,25 @@ final class PropertySelectedOptionsModel: PropertySelectedOptionsModelProtocol {
             handleMultiOptionSelected(optionId)
         }
         
-        try await propertiesService.updateRelation(
+        try await propertiesService.updateProperty(
             objectId: config.objectId,
-            relationKey: config.relationKey,
+            propertyKey: config.relationKey,
             value: selectedOptionsIds.protobufValue
         )
         logChanges()
     }
     
     func removeRelationOption(_ optionId: String) async throws {
-        try await propertiesService.removeRelationOptions(ids: [optionId])
+        try await propertiesService.removePropertyOptions(ids: [optionId])
         try await removeRelationOptionFromSelectedIfNeeded(optionId)
     }
     
     func removeRelationOptionFromSelectedIfNeeded(_ optionId: String) async throws {
         if let index = selectedOptionsIds.firstIndex(of: optionId) {
             selectedOptionsIds.remove(at: index)
-            try await propertiesService.updateRelation(
+            try await propertiesService.updateProperty(
                 objectId: config.objectId,
-                relationKey: config.relationKey,
+                propertyKey: config.relationKey,
                 value: selectedOptionsIds.protobufValue
             )
         }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Text/TextPropertyDetailsService/TextPropertyEditingService.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Text/TextPropertyDetailsService/TextPropertyEditingService.swift
@@ -17,13 +17,13 @@ final class TextPropertyEditingService: TextPropertyEditingServiceProtocol, Send
         Task {
             switch textType {
             case .text:
-                try await service.updateRelation(objectId: objectId, relationKey: key, value: value.protobufValue)
+                try await service.updateProperty(objectId: objectId, propertyKey: key, value: value.protobufValue)
             case .number, .numberOfDays:
                 guard let number = numberFormatter.number(from: value)?.doubleValue else { return }
-                try await service.updateRelation(objectId: objectId, relationKey: key, value: number.protobufValue)
+                try await service.updateProperty(objectId: objectId, propertyKey: key, value: number.protobufValue)
             case .phone, .email, .url:
                 let value = value.replacingOccurrences(of: " ", with: "")
-                try await service.updateRelation(objectId: objectId, relationKey: key, value: value.protobufValue)
+                try await service.updateProperty(objectId: objectId, propertyKey: key, value: value.protobufValue)
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/PropertyValueFlow/PropertyValueCoordinator/PropertyValueProcessingService.swift
+++ b/Anytype/Sources/PresentationLayer/PropertyValueFlow/PropertyValueCoordinator/PropertyValueProcessingService.swift
@@ -37,7 +37,7 @@ fileprivate final class PropertyValueProcessingService: PropertyValueProcessingS
             guard relation.isEditable else { return nil }
             Task {
                 let newValue = !checkbox.value
-                try await propertiesService.updateRelation(objectId: objectDetails.id, relationKey: checkbox.key, value: newValue.protobufValue)
+                try await propertiesService.updateProperty(objectId: objectDetails.id, propertyKey: checkbox.key, value: newValue.protobufValue)
                 let relationDetails = try propertyDetailsStorage.relationsDetails(key: relation.key, spaceId: objectDetails.spaceId)
                 AnytypeAnalytics.instance().logChangeOrDeleteRelationValue(
                     isEmpty: !newValue,

--- a/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/PropertiesSearchViewModel/PropertiesInteractor.swift
+++ b/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/PropertiesSearchViewModel/PropertiesInteractor.swift
@@ -32,11 +32,11 @@ final class PropertiesInteractor: PropertiesInteractorProtocol, Sendable {
     }
     
     func createProperty(spaceId: String, relation: RelationDetails) async throws -> RelationDetails {
-        try await propertiesService.createRelation(spaceId: spaceId, relationDetails: relation)
+        try await propertiesService.createProperty(spaceId: spaceId, propertyDetails: relation)
     }
     
     func updateProperty(spaceId: String, relation: RelationDetails) async throws {
-        try await propertiesService.updateRelation(objectId: relation.id, fields: relation.fields)
+        try await propertiesService.updateProperty(objectId: relation.id, fields: relation.fields)
     }
     
     func addPropertyToType(relation: RelationDetails, isFeatured: Bool) async throws {
@@ -46,9 +46,9 @@ final class PropertiesInteractor: PropertiesInteractorProtocol, Sendable {
         guard let details = document.details else { return }
         
         if isFeatured {
-            try await propertiesService.addTypeFeaturedRecommendedRelation(details: details, relation: relation)
+            try await propertiesService.addTypeFeaturedRecommendedProperty(details: details, property: relation)
         } else {
-            try await propertiesService.addTypeRecommendedRelation(details: details, relation: relation)
+            try await propertiesService.addTypeRecommendedProperty(details: details, property: relation)
         }
     }
     
@@ -64,10 +64,10 @@ final class PropertiesInteractor: PropertiesInteractorProtocol, Sendable {
     }
     
     private func addPropertyToType(relation: RelationDetails, details: ObjectDetails) async throws {
-        try await propertiesService.addTypeRecommendedRelation(details: details, relation: relation)
+        try await propertiesService.addTypeRecommendedProperty(details: details, property: relation)
     }
     
     func addPropertyToObject(objectId: String, relation: RelationDetails) async throws {
-        try await propertiesService.addRelations(objectId: objectId, relationsDetails: [relation])
+        try await propertiesService.addProperties(objectId: objectId, propertiesDetails: [relation])
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/Model/ObjectSettingsPrimitivesConflictManager.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/Model/ObjectSettingsPrimitivesConflictManager.swift
@@ -39,16 +39,16 @@ final class ObjectSettingsPrimitivesConflictManager: ObjectSettingsPrimitivesCon
     
     func resolveConflicts(details: ObjectDetails) async throws {
         // Remove legacy relations
-        try await propertiesService.removeRelation(objectId: details.id, relationKey: BundledRelationKey.layout.rawValue)
-        try await propertiesService.removeRelation(objectId: details.id, relationKey: BundledRelationKey.layoutAlign.rawValue)
-        try await propertiesService.removeRelation(objectId: details.id, relationKey: BundledRelationKey.layoutWidth.rawValue)
+        try await propertiesService.removeProperty(objectId: details.id, propertyKey: BundledRelationKey.layout.rawValue)
+        try await propertiesService.removeProperty(objectId: details.id, propertyKey: BundledRelationKey.layoutAlign.rawValue)
+        try await propertiesService.removeProperty(objectId: details.id, propertyKey: BundledRelationKey.layoutWidth.rawValue)
         
         // Remove all legacy relations except for description if present (description uses legacy mechanism to preserve its visibility)
         let featuredRelationIds = propertyDetailsStorage
             .relationsDetails(keys: details.featuredRelations, spaceId: details.spaceId)
                 .filter { $0.key == BundledRelationKey.description.rawValue }
                 .map(\.id)
-        try await propertiesService.setFeaturedRelation(objectId: details.id, featuredRelationIds: featuredRelationIds)
+        try await propertiesService.setFeaturedProperty(objectId: details.id, featuredPropertyIds: featuredRelationIds)
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/ObjectFieldsView/ObjectPropertiesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/ObjectFieldsView/ObjectPropertiesViewModel.swift
@@ -55,7 +55,7 @@ final class ObjectPropertiesViewModel: ObservableObject {
     
     func removeRelation(_ relation: Relation) {
         Task {
-            try await propertiesService.removeRelation(objectId: document.objectId, relationKey: relation.key)
+            try await propertiesService.removeProperty(objectId: document.objectId, propertyKey: relation.key)
             let relationDetails = try propertyDetailsStorage.relationsDetails(key: relation.key, spaceId: document.spaceId)
             AnytypeAnalytics.instance().logDeleteRelation(spaceId: document.spaceId, format: relationDetails.format, key: relationDetails.analyticsKey, route: .object)
         }
@@ -72,7 +72,7 @@ final class ObjectPropertiesViewModel: ObservableObject {
         
         Task {
             let relationsDetail = try propertyDetailsStorage.relationsDetails(key: relation.key, spaceId: details.spaceId)
-            try await propertiesService.addTypeRecommendedRelation(type: details.objectType, relation: relationsDetail)
+            try await propertiesService.addTypeRecommendedProperty(type: details.objectType, property: relationsDetail)
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/TypePropertiesView/Model/TypePropertiesMoveHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/TypePropertiesView/Model/TypePropertiesMoveHandler.swift
@@ -333,11 +333,11 @@ final class TypePropertiesMoveHandler: Sendable {
     ) async throws {
         AnytypeAnalytics.instance().logReorderRelation(group: from != to ? to.analyticsValue : nil)
         
-        try await propertiesService.updateTypeRelations(
+        try await propertiesService.updateTypeProperties(
             typeId: typeId,
-            recommendedRelations: recommendedRelationIds,
-            recommendedFeaturedRelations: recommendedFeaturedRelationsIds,
-            recommendedHiddenRelations: recommendedHiddenRelationsIds
+            recommendedProperties: recommendedRelationIds,
+            recommendedFeaturedProperties: recommendedFeaturedRelationsIds,
+            recommendedHiddenProperties: recommendedHiddenRelationsIds
         )
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/TypePropertiesView/TypePropertiesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/TypePropertiesView/TypePropertiesViewModel.swift
@@ -125,7 +125,7 @@ final class TypePropertiesViewModel: ObservableObject {
         guard let details = document.details else { return }
         
         Task {
-            try await propertiesService.removeTypeRelation(details: details, relationId: row.relation.id)
+            try await propertiesService.removeTypeProperty(details: details, propertyId: row.relation.id)
             
             guard let format = row.relation.format?.format else {
                 anytypeAssertionFailure("Empty relation format for onRelationRemove")
@@ -140,13 +140,13 @@ final class TypePropertiesViewModel: ObservableObject {
         AnytypeAnalytics.instance().logAddConflictRelation()
         
         Task {
-            try await propertiesService.addTypeRecommendedRelation(details: details, relation: relation)    
+            try await propertiesService.addTypeRecommendedProperty(details: details, property: relation)    
             if let details = document.details { try await updateConflictRelations(details: details) }
         }
     }
     
     private func updateConflictRelations(details: ObjectDetails) async throws {
-        let releationKeys = try await propertiesService.getConflictRelationsForType(typeId: document.objectId, spaceId: document.spaceId)
+        let releationKeys = try await propertiesService.getConflictPropertiesForType(typeId: document.objectId, spaceId: document.spaceId)
         conflictRelations = propertyDetailsStorage
             .relationsDetails(ids: releationKeys, spaceId: document.spaceId)
             .filter { !$0.isHidden && !$0.isDeleted }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -322,7 +322,7 @@ final class EditorSetViewModel: ObservableObject {
     private func subscribeOnRelations() async {
         for await relations in setDocument.document.parsedRelationsPublisherForType.values {
             let conflictingKeys = (try? await propertiesService
-                .getConflictRelationsForType(typeId: setDocument.objectId, spaceId: setDocument.spaceId)) ?? []
+                .getConflictPropertiesForType(typeId: setDocument.objectId, spaceId: setDocument.spaceId)) ?? []
             let conflictingRelations = propertyDetailsStorage
                 .relationsDetails(ids: conflictingKeys, spaceId: setDocument.spaceId)
                 .filter { !$0.isHidden && !$0.isDeleted }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/CreateObject/CreateObjectViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/CreateObject/CreateObjectViewModel.swift
@@ -62,9 +62,9 @@ final class CreateObjectViewModel: CreateObjectViewModelProtocol {
                 let middlewareString = MiddlewareString(text: text)
                 try await textServiceHandler.setText(contextId: objectId, blockId: blockId, middlewareString: middlewareString)
             case .writeToRelationName:
-                try await propertiesService.updateRelation(
+                try await propertiesService.updateProperty(
                     objectId: objectId,
-                    relationKey: BundledRelationKey.name.rawValue,
+                    propertyKey: BundledRelationKey.name.rawValue,
                     value: text.protobufValue
                 )
             case .none:

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/RelationCreation/PropertyCreationViewModel.swift
@@ -112,9 +112,9 @@ final class PropertyCreationViewModel: ObservableObject, PropertyInfoCoordinator
     private func addPropertyToType(relation: RelationDetails, typeData: PropertiesModuleTypeData) async throws {
         switch typeData {
         case .recommendedFeaturedRelations(let type):
-            try await propertiesService.addTypeFeaturedRecommendedRelation(type: type, relation: relation)
+            try await propertiesService.addTypeFeaturedRecommendedProperty(type: type, property: relation)
         case .recommendedRelations(let type):
-            try await propertiesService.addTypeRecommendedRelation(type: type, relation: relation)
+            try await propertiesService.addTypeRecommendedProperty(type: type, property: relation)
         }
     }
     
@@ -132,6 +132,6 @@ final class PropertyCreationViewModel: ObservableObject, PropertyInfoCoordinator
     
     
     func addPropertyToObject(objectId: String, relation: RelationDetails) async throws {
-        try await propertiesService.addRelations(objectId: objectId, relationsDetails: [relation])
+        try await propertiesService.addProperties(objectId: objectId, propertiesDetails: [relation])
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/SetPropertiesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/SetPropertiesViewModel.swift
@@ -44,9 +44,9 @@ final class SetPropertiesViewModel: ObservableObject {
                 guard let details = setDocument.details else { return }
                 
                 if details.isObjectType {
-                    try await propertiesService.removeTypeRelation(
+                    try await propertiesService.removeTypeProperty(
                         details: details,
-                        relationId: relation.relationDetails.id
+                        propertyId: relation.relationDetails.id
                     )
                 } else {
                     try await dataviewService.deleteRelation(
@@ -57,7 +57,7 @@ final class SetPropertiesViewModel: ObservableObject {
                 }
                 
                 if let details = setDocument.details, details.isObjectType {
-                    try await propertiesService.removeTypeRelation(details: details, relationId: relation.relationDetails.id)
+                    try await propertiesService.removeTypeProperty(details: details, propertyId: relation.relationDetails.id)
                 } else {
                     try await dataviewService.removeViewRelations(
                         objectId: setDocument.objectId,

--- a/Anytype/Sources/ServiceLayer/Extensions/PropertiesServiceProtocolExtensions.swift
+++ b/Anytype/Sources/ServiceLayer/Extensions/PropertiesServiceProtocolExtensions.swift
@@ -1,60 +1,60 @@
 import Services
 
 extension PropertiesServiceProtocol {
-    func updateTypeRelations(
+    func updateTypeProperties(
         typeId: String,
-        recommendedRelations: [RelationDetails],
-        recommendedFeaturedRelations: [RelationDetails],
-        recommendedHiddenRelations: [RelationDetails]
+        recommendedProperties: [RelationDetails],
+        recommendedFeaturedProperties: [RelationDetails],
+        recommendedHiddenProperties: [RelationDetails]
     ) async throws {
-        try await updateTypeRelations(
+        try await updateTypeProperties(
             typeId: typeId,
             dataviewId: SetConstants.dataviewBlockId,
-            recommendedRelations: recommendedRelations,
-            recommendedFeaturedRelations: recommendedFeaturedRelations,
-            recommendedHiddenRelations: recommendedHiddenRelations
+            recommendedProperties: recommendedProperties,
+            recommendedFeaturedProperties: recommendedFeaturedProperties,
+            recommendedHiddenProperties: recommendedHiddenProperties
         )
     }
     
-    func addTypeRecommendedRelation(details: ObjectDetails, relation: RelationDetails) async throws {
-        try await addTypeRecommendedRelation(type: ObjectType(details: details), relation: relation)
+    func addTypeRecommendedProperty(details: ObjectDetails, property: RelationDetails) async throws {
+        try await addTypeRecommendedProperty(type: ObjectType(details: details), property: property)
     }
     
-    func addTypeRecommendedRelation(type: ObjectType, relation: RelationDetails) async throws {
-        var recommendedRelationsDetails = type.recommendedRelationsDetails
-        recommendedRelationsDetails.insert(relation, at: 0)
-        try await updateTypeRelations(
+    func addTypeRecommendedProperty(type: ObjectType, property: RelationDetails) async throws {
+        var recommendedPropertiesDetails = type.recommendedRelationsDetails
+        recommendedPropertiesDetails.insert(property, at: 0)
+        try await updateTypeProperties(
             typeId: type.id,
-            recommendedRelations: recommendedRelationsDetails,
-            recommendedFeaturedRelations: type.recommendedFeaturedRelationsDetails,
-            recommendedHiddenRelations: type.recommendedHiddenRelationsDetails
+            recommendedProperties: recommendedPropertiesDetails,
+            recommendedFeaturedProperties: type.recommendedFeaturedRelationsDetails,
+            recommendedHiddenProperties: type.recommendedHiddenRelationsDetails
         )
     }
     
-    func addTypeFeaturedRecommendedRelation(details: ObjectDetails, relation: RelationDetails) async throws {
-        try await addTypeFeaturedRecommendedRelation(type: ObjectType(details: details), relation: relation)
+    func addTypeFeaturedRecommendedProperty(details: ObjectDetails, property: RelationDetails) async throws {
+        try await addTypeFeaturedRecommendedProperty(type: ObjectType(details: details), property: property)
     }
     
-    func addTypeFeaturedRecommendedRelation(type: ObjectType, relation: RelationDetails) async throws {
-        var recommendedFeaturedRelationsDetails = type.recommendedFeaturedRelationsDetails
-        recommendedFeaturedRelationsDetails.insert(relation, at: 0)
-        try await updateTypeRelations(
+    func addTypeFeaturedRecommendedProperty(type: ObjectType, property: RelationDetails) async throws {
+        var recommendedFeaturedPropertiesDetails = type.recommendedFeaturedRelationsDetails
+        recommendedFeaturedPropertiesDetails.insert(property, at: 0)
+        try await updateTypeProperties(
             typeId: type.id,
-            recommendedRelations: type.recommendedRelationsDetails,
-            recommendedFeaturedRelations: recommendedFeaturedRelationsDetails,
-            recommendedHiddenRelations: type.recommendedHiddenRelationsDetails
+            recommendedProperties: type.recommendedRelationsDetails,
+            recommendedFeaturedProperties: recommendedFeaturedPropertiesDetails,
+            recommendedHiddenProperties: type.recommendedHiddenRelationsDetails
         )
     }
         
-    func removeTypeRelation(details: ObjectDetails, relationId: String) async throws {
-        let recommendedRelations = details.recommendedRelationsDetails.filter({ relationId != $0.id })
-        let recommendedFeaturedRelations = details.recommendedFeaturedRelationsDetails.filter({ relationId != $0.id })
-        let recommendedHiddenRelations = details.recommendedHiddenRelationsDetails.filter({ relationId != $0.id })
-        try await updateTypeRelations(
+    func removeTypeProperty(details: ObjectDetails, propertyId: String) async throws {
+        let recommendedProperties = details.recommendedRelationsDetails.filter({ propertyId != $0.id })
+        let recommendedFeaturedProperties = details.recommendedFeaturedRelationsDetails.filter({ propertyId != $0.id })
+        let recommendedHiddenProperties = details.recommendedHiddenRelationsDetails.filter({ propertyId != $0.id })
+        try await updateTypeProperties(
             typeId: details.id,
-            recommendedRelations: recommendedRelations,
-            recommendedFeaturedRelations: recommendedFeaturedRelations,
-            recommendedHiddenRelations: recommendedHiddenRelations
+            recommendedProperties: recommendedProperties,
+            recommendedFeaturedProperties: recommendedFeaturedProperties,
+            recommendedHiddenProperties: recommendedHiddenProperties
         )
     }
 }

--- a/Modules/Services/Sources/Services/Properties/PropertiesService.swift
+++ b/Modules/Services/Sources/Services/Properties/PropertiesService.swift
@@ -10,31 +10,31 @@ final class PropertiesService: PropertiesServiceProtocol {
     
     // MARK: - PropertiesServiceProtocol
     
-    func setFeaturedRelation(objectId: String, featuredRelationIds: [String]) async throws {
+    func setFeaturedProperty(objectId: String, featuredPropertyIds: [String]) async throws {
         try await ClientCommands.objectSetDetails(.with {
             $0.contextID = objectId
             $0.details = [
                 Anytype_Model_Detail.with {
                     $0.key = BundledRelationKey.featuredRelations.rawValue
-                    $0.value = featuredRelationIds.protobufValue
+                    $0.value = featuredPropertyIds.protobufValue
                 }
             ]
         }).invoke()
     }
     
-    public func updateRelation(objectId: String, relationKey: String, value: Google_Protobuf_Value) async throws {
+    public func updateProperty(objectId: String, propertyKey: String, value: Google_Protobuf_Value) async throws {
         try await ClientCommands.objectSetDetails(.with {
             $0.contextID = objectId
             $0.details = [
                 Anytype_Model_Detail.with {
-                    $0.key = relationKey
+                    $0.key = propertyKey
                     $0.value = value
                 }
             ]
         }).invoke()
     }
     
-    func updateRelation(objectId: String, fields: [String: Google_Protobuf_Value]) async throws {
+    func updateProperty(objectId: String, fields: [String: Google_Protobuf_Value]) async throws {
         try await ClientCommands.objectSetDetails(.with {
             $0.contextID = objectId
             $0.details = fields.map { key, value in
@@ -46,7 +46,7 @@ final class PropertiesService: PropertiesServiceProtocol {
         }).invoke()
     }
     
-    public func updateRelationOption(id: String, text: String, color: String?) async throws {
+    public func updatePropertyOption(id: String, text: String, color: String?) async throws {
         try await ClientCommands.objectSetDetails(.with {
             $0.contextID = id
             $0.details = .builder {
@@ -64,9 +64,9 @@ final class PropertiesService: PropertiesServiceProtocol {
         }).invoke()
     }
 
-    public func createRelation(spaceId: String, relationDetails: RelationDetails) async throws -> RelationDetails {
+    public func createProperty(spaceId: String, propertyDetails: RelationDetails) async throws -> RelationDetails {
         let result = try await ClientCommands.objectCreateRelation(.with {
-            $0.details = relationDetails.asMiddleware
+            $0.details = propertyDetails.asMiddleware
             $0.spaceID = spaceId
         }).invoke()
         
@@ -77,35 +77,35 @@ final class PropertiesService: PropertiesServiceProtocol {
         return RelationDetails(details: objectDetails)
     }
 
-    public func addRelations(objectId: String, relationsDetails: [RelationDetails]) async throws {
-        try await addRelations(objectId: objectId, relationKeys: relationsDetails.map(\.key))
+    public func addProperties(objectId: String, propertiesDetails: [RelationDetails]) async throws {
+        try await addProperties(objectId: objectId, propertyKeys: propertiesDetails.map(\.key))
     }
 
-    public func addRelations(objectId: String, relationKeys: [String]) async throws {
+    public func addProperties(objectId: String, propertyKeys: [String]) async throws {
         try await ClientCommands.objectRelationAdd(.with {
             $0.contextID = objectId
-            $0.relationKeys = relationKeys
+            $0.relationKeys = propertyKeys
         }).invoke()
     }
     
-    public func removeRelation(objectId: String, relationKey: String) async throws {
-        try await removeRelations(objectId: objectId, relationKeys: [relationKey])
+    public func removeProperty(objectId: String, propertyKey: String) async throws {
+        try await removeProperties(objectId: objectId, propertyKeys: [propertyKey])
     }
     
-    public func removeRelations(objectId: String, relationKeys: [String]) async throws {
+    public func removeProperties(objectId: String, propertyKeys: [String]) async throws {
         _ = try await ClientCommands.objectRelationDelete(.with {
             $0.contextID = objectId
-            $0.relationKeys = relationKeys
+            $0.relationKeys = propertyKeys
         }).invoke()
     }
     
-    public func addRelationOption(spaceId: String, relationKey: String, optionText: String, color: String?) async throws -> String? {
+    public func addPropertyOption(spaceId: String, propertyKey: String, optionText: String, color: String?) async throws -> String? {
         let color = color ?? MiddlewareColor.allCases.randomElement()?.rawValue ?? MiddlewareColor.default.rawValue
         
         let details = Google_Protobuf_Struct(
             fields: [
                 BundledRelationKey.name.rawValue: optionText.protobufValue,
-                BundledRelationKey.relationKey.rawValue: relationKey.protobufValue,
+                BundledRelationKey.relationKey.rawValue: propertyKey.protobufValue,
                 BundledRelationKey.relationOptionColor.rawValue: color.protobufValue
             ]
         )
@@ -118,7 +118,7 @@ final class PropertiesService: PropertiesServiceProtocol {
         return optionResult?.objectID
     }
     
-    public func removeRelationOptions(ids: [String]) async throws {
+    public func removePropertyOptions(ids: [String]) async throws {
         try await ClientCommands.relationListRemoveOption(.with {
             $0.optionIds = ids
         }).invoke()
@@ -126,32 +126,32 @@ final class PropertiesService: PropertiesServiceProtocol {
     
     // MARK: - New api
     // Updating both relations in type and dataview to preserve integrity between them
-    func updateTypeRelations(
+    func updateTypeProperties(
         typeId: String,
         dataviewId: String,
-        recommendedRelations: [RelationDetails],
-        recommendedFeaturedRelations: [RelationDetails],
-        recommendedHiddenRelations: [RelationDetails]
+        recommendedProperties: [RelationDetails],
+        recommendedFeaturedProperties: [RelationDetails],
+        recommendedHiddenProperties: [RelationDetails]
     ) async throws {
         try await ClientCommands.objectSetDetails(.with {
             $0.contextID = typeId
             $0.details = [
                 Anytype_Model_Detail.with {
                     $0.key = BundledRelationKey.recommendedRelations.rawValue
-                    $0.value = recommendedRelations.map(\.id).protobufValue
+                    $0.value = recommendedProperties.map(\.id).protobufValue
                 },
                 Anytype_Model_Detail.with {
                     $0.key = BundledRelationKey.recommendedFeaturedRelations.rawValue
-                    $0.value = recommendedFeaturedRelations.map(\.id).protobufValue
+                    $0.value = recommendedFeaturedProperties.map(\.id).protobufValue
                 },
                 Anytype_Model_Detail.with {
                     $0.key = BundledRelationKey.recommendedHiddenRelations.rawValue
-                    $0.value = recommendedHiddenRelations.map(\.id).protobufValue
+                    $0.value = recommendedHiddenProperties.map(\.id).protobufValue
                 }
             ]
         }).invoke()
         
-        let compoundRelationsKeys = (recommendedFeaturedRelations + recommendedRelations + recommendedHiddenRelations).map(\.key)
+        let compoundRelationsKeys = (recommendedFeaturedProperties + recommendedProperties + recommendedHiddenProperties).map(\.key)
         let descriptionKey = BundledRelationKey.description.rawValue // Show description in dataview relations list
         let nameKey = BundledRelationKey.name.rawValue // Show name in dataview relations list
         let dataviewKeys = compoundRelationsKeys + [nameKey, descriptionKey]
@@ -164,7 +164,7 @@ final class PropertiesService: PropertiesServiceProtocol {
         }).invoke()
     }
     
-    func getConflictRelationsForType(typeId: String, spaceId: String) async throws -> [String] {
+    func getConflictPropertiesForType(typeId: String, spaceId: String) async throws -> [String] {
         try await ClientCommands.objectTypeListConflictingRelations(.with {
             $0.spaceID = spaceId
             $0.typeObjectID = typeId

--- a/Modules/Services/Sources/Services/Properties/PropertiesServiceProtocol.swift
+++ b/Modules/Services/Sources/Services/Properties/PropertiesServiceProtocol.swift
@@ -2,31 +2,31 @@ import Foundation
 import SwiftProtobuf
 
 public protocol PropertiesServiceProtocol: AnyObject, Sendable {
-    func setFeaturedRelation(objectId: String, featuredRelationIds: [String]) async throws
+    func setFeaturedProperty(objectId: String, featuredPropertyIds: [String]) async throws
     
-    func updateRelation(objectId: String, relationKey: String, value: Google_Protobuf_Value) async throws
-    func updateRelation(objectId: String, fields: [String: Google_Protobuf_Value]) async throws
-    func updateRelationOption(id: String, text: String, color: String?) async throws
+    func updateProperty(objectId: String, propertyKey: String, value: Google_Protobuf_Value) async throws
+    func updateProperty(objectId: String, fields: [String: Google_Protobuf_Value]) async throws
+    func updatePropertyOption(id: String, text: String, color: String?) async throws
 
-    func createRelation(spaceId: String, relationDetails: RelationDetails) async throws -> RelationDetails
-    func addRelations(objectId: String, relationsDetails: [RelationDetails]) async throws
-    func addRelations(objectId: String, relationKeys: [String]) async throws
+    func createProperty(spaceId: String, propertyDetails: RelationDetails) async throws -> RelationDetails
+    func addProperties(objectId: String, propertiesDetails: [RelationDetails]) async throws
+    func addProperties(objectId: String, propertyKeys: [String]) async throws
 
-    func removeRelation(objectId: String, relationKey: String) async throws
-    func removeRelations(objectId: String, relationKeys: [String]) async throws
+    func removeProperty(objectId: String, propertyKey: String) async throws
+    func removeProperties(objectId: String, propertyKeys: [String]) async throws
     
-    func addRelationOption(spaceId: String, relationKey: String, optionText: String, color: String?) async throws -> String?
-    func removeRelationOptions(ids: [String]) async throws
+    func addPropertyOption(spaceId: String, propertyKey: String, optionText: String, color: String?) async throws -> String?
+    func removePropertyOptions(ids: [String]) async throws
     
     // New api
-    func updateTypeRelations(
+    func updateTypeProperties(
         typeId: String,
         dataviewId: String,
-        recommendedRelations: [RelationDetails],
-        recommendedFeaturedRelations: [RelationDetails],
-        recommendedHiddenRelations: [RelationDetails]
+        recommendedProperties: [RelationDetails],
+        recommendedFeaturedProperties: [RelationDetails],
+        recommendedHiddenProperties: [RelationDetails]
     ) async throws
-    func getConflictRelationsForType(typeId: String, spaceId: String) async throws -> [String]
+    func getConflictPropertiesForType(typeId: String, spaceId: String) async throws -> [String]
     
     func toggleDescription(objectId: String, isOn: Bool) async throws
 }


### PR DESCRIPTION
## Summary
- Renamed all method names in PropertiesServiceProtocol from "Relation" to "Property" terminology
- Updated all method implementations and call sites throughout the codebase
- Fixed compilation errors and verified build passes successfully