### PR TITLE
IOS-4753 Hide template tab and properties for template type objects

### DIFF
--- a/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
+++ b/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
@@ -87,6 +87,7 @@ extension BundledRelationsValueProvider {
     }
     
     var isTemplate: Bool { objectType.isTemplateType }
+    var isTemplateType: Bool { uniqueKey == ObjectTypeUniqueKey.template.value }
     
     var canMakeTemplate: Bool {
         resolvedLayoutValue.isEditorLayout && !isTemplate && profileOwnerIdentity.isEmpty && !isObjectType

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -84,8 +84,14 @@ final class EditorSetViewModel: ObservableObject {
         guard let details = setDocument.details else { return false }
         
         let isSupportedLayout = details.recommendedLayoutValue.isEditorLayout
-        let isTemplate = details.isTemplate
+        let isTemplate = details.isTemplateType
         return isSupportedLayout && !isTemplate
+    }
+    
+    var showProperties: Bool {
+        guard let details = setDocument.details else { return false }
+        
+        return !details.isTemplateType
     }
     
     var hasTargetObjectId: Bool {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Header/SetFullHeader.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Header/SetFullHeader.swift
@@ -91,12 +91,14 @@ struct SetFullHeader: View {
                 }.minimumScaleFactor(0.5)
             }
 
-            StandardButton(
-                .textWithBadge(text: Loc.fields, badge: "\(model.relationsCount)"),
-                style: .secondarySmall
-            ) {
-                model.onObjectTypePropertiesTap()
-            }.minimumScaleFactor(0.5)
+            if model.showProperties {
+                StandardButton(
+                    .textWithBadge(text: Loc.fields, badge: "\(model.relationsCount)"),
+                    style: .secondarySmall
+                ) {
+                    model.onObjectTypePropertiesTap()
+                }.minimumScaleFactor(0.5)
+            }
             
             if model.showObjectTypeTemplates {
                 StandardButton(


### PR DESCRIPTION
## Summary
- Hide template tab and properties button for template type objects
- Add isTemplateType computed property to check if object is of template type
- Update SetFullHeader to conditionally show properties button based on template type