### PR TITLE
IOS-4550 Filter object types from link to object search

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/ObjectSettingsFlow/ObjectSettingsCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ObjectSettingsFlow/ObjectSettingsCoordinatorViewModel.swift
@@ -65,7 +65,7 @@ final class ObjectSettingsCoordinatorViewModel:
     }
     
     func linkToAction(document: some BaseDocumentProtocol, onSelect: @escaping (String) -> ()) {
-        let excludedLayouts = DetailsLayout.fileAndMediaLayouts + [.set, .participant]
+        let excludedLayouts = DetailsLayout.fileAndMediaLayouts + [.set, .participant, .objectType]
         blockObjectSearchData = BlockObjectSearchData(
             title: Loc.linkTo,
             spaceId: document.spaceId,

--- a/Anytype/Sources/PresentationLayer/TextEditor/Routing/Editor/EditorRouter.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Routing/Editor/EditorRouter.swift
@@ -171,7 +171,7 @@ final class EditorRouter: NSObject, EditorRouterProtocol, ObjectSettingsCoordina
     }
     
     func showMoveTo(onSelect: @escaping (ObjectDetails) -> ()) {
-        let excludedLayouts = DetailsLayout.fileAndMediaLayouts + DetailsLayout.listLayouts
+        let excludedLayouts = DetailsLayout.fileAndMediaLayouts + DetailsLayout.listLayouts + [.participant, .objectType]
         let data = BlockObjectSearchData(
             title: Loc.moveTo,
             spaceId: document.spaceId,


### PR DESCRIPTION
## Summary
- Added objectType to excluded layouts in link to object search functionality
- This prevents object types from appearing in the search results when linking objects