### PR TITLE
IOS-4475 Show edit button when there is 1 template

### DIFF
--- a/Anytype/Sources/PresentationLayer/ObjectCreationSettings/Views/Selection/SetObjectCreationSettingsView.swift
+++ b/Anytype/Sources/PresentationLayer/ObjectCreationSettings/Views/Selection/SetObjectCreationSettingsView.swift
@@ -41,7 +41,7 @@ struct SetObjectCreationSettingsView: View {
     
     private var navigationButton: some View {
         HStack(spacing: 0) {
-            if model.templates.count > 2 || model.isEditingState {
+            if model.templates.count > 1 || model.isEditingState {
                 Button {
                     model.isEditingState.toggle()
                 } label: {


### PR DESCRIPTION
## Summary
- Changed template count threshold from >2 to >1 for showing edit button
- Now the edit button appears when there are one or more templates