### PR TITLE
IOS-4689 Move read-only commands to public settings

### DIFF
--- a/.claude/commands/cpp.md
+++ b/.claude/commands/cpp.md
@@ -1,1 +1,2 @@
 Commit, push, pull request
+If you are doing multistaged work and it was not done in one pull request add progress updates to the corresponding Linear task. Tick checkboxes if you are using them in Linear task. 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,14 @@
       "Bash(ls:*)",
 
       "Bash(make setup-middle:*)",
+      "Bash(make generate-middle:*)",
+      "Bash(make:*)",
       "Bash(xcodebuild:*)",
+      "Bash(open:*)",
+      "Bash(true)",
+
+      "Bash(gh pr view:*)",
+      "Bash(gh issue view:*)",
 
       "mcp__linear__list_my_issues",
       "mcp__linear__list_teams",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ When setting up the project for the first time, run these commands in order:
 - The project uses Swift Package Manager for dependency management
 
 ## Building and Testing
-- **For compilation check**: Use "Build for Testing" (`Cmd+Shift+U`) instead of normal build
+- **For compilation check**: `xcodebuild -scheme Anytype -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 15' build-for-testing`
 - **Normal build**: `xcodebuild -scheme Anytype -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 15' build`
 
 ## Important Guidelines
@@ -214,3 +214,4 @@ Before starting work on any issue, you must identify the task number:
 
 ## Memories
 - Do not add comments if not explicitly asked for
+- If pull request without functional and only like renames or file reuploads add tag "🧠 No brainer" to pr in github.


### PR DESCRIPTION
## Summary
- Moved read-only bash commands from local settings to public settings for everyone to access by default
- Cleaned up local settings to only include write/modify commands that should remain local