### PR TITLE
IOS-4779 Fix remote storage segment padding

### DIFF
--- a/Anytype/Sources/PresentationLayer/SpaceSettings/RemoteStorage/RemoteStorageSegmentInfo.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/RemoteStorage/RemoteStorageSegmentInfo.swift
@@ -36,7 +36,7 @@ struct RemoteStorageSegment: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            SegmentLine(items: segmentLineItems).padding(.trailing, 16)
+            SegmentLine(items: segmentLineItems)
             if showLegend {
                 Spacer.fixedHeight(16)
                 SegmentLegend(items: segmentLegendItems)


### PR DESCRIPTION
## Summary
- Remove extra trailing padding from SegmentLine to fix inconsistent horizontal padding in remote storage progress bar