### PR TITLE
IOS-4660 Continue Relation to Property rename - files and core types

### DIFF
--- a/Anytype/Sources/Models/Relations/Entities/Property.swift
+++ b/Anytype/Sources/Models/Relations/Entities/Property.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Services
 
-enum Relation: Hashable, Identifiable, Sendable {
+enum Property: Hashable, Identifiable, Sendable {
     case text(Text)
     case number(Text)
     case status(Status)
@@ -18,7 +18,7 @@ enum Relation: Hashable, Identifiable, Sendable {
 
 // MARK: - RelationValueProtocol
 
-extension Relation: PropertyProtocol {
+extension Property: PropertyProtocol {
     
     var id: String {
         switch self {
@@ -177,12 +177,12 @@ extension Relation: PropertyProtocol {
         }
     }
     
-    var editableRelation: Relation? {
+    var editableRelation: Property? {
         switch self {
         case .object(let object):
             var editableObject = object
             editableObject.isEditable = true
-            return Relation.object(editableObject)
+            return Property.object(editableObject)
         default:
             return nil
         }

--- a/Anytype/Sources/PresentationLayer/Modules/Date/DateViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Date/DateViewModel.swift
@@ -14,7 +14,7 @@ final class DateViewModel: ObservableObject {
     @Injected(\.accountManager)
     private var accountManager: any AccountManagerProtocol
     @Injected(\.relationListWithValueService)
-    private var relationListWithValueService: any RelationListWithValueServiceProtocol
+    private var relationListWithValueService: any PropertyListWithValueServiceProtocol
     @Injected(\.propertyDetailsStorage)
     private var propertyDetailsStorage: any PropertyDetailsStorageProtocol
     @Injected(\.dateRelatedObjectsSubscriptionService)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/Property+Set.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/Property+Set.swift
@@ -1,11 +1,11 @@
 import Services
 
-extension Relation {
+extension Property {
     var hasSelectedObjectsRelationType: Bool {
         relationSelectedObjects.isNotEmpty
     }
     
-    var relationSelectedObjects: [Relation.Object.Option] {
+    var relationSelectedObjects: [Property.Object.Option] {
         if case let .object(object) = self {
             return object.selectedObjects.filter { $0.type == Constants.relationType }
         } else {

--- a/Anytype/Sources/ServiceLayer/Extensions/PropertiesServiceProtocolExtensions.swift
+++ b/Anytype/Sources/ServiceLayer/Extensions/PropertiesServiceProtocolExtensions.swift
@@ -3,9 +3,9 @@ import Services
 extension PropertiesServiceProtocol {
     func updateTypeProperties(
         typeId: String,
-        recommendedProperties: [RelationDetails],
-        recommendedFeaturedProperties: [RelationDetails],
-        recommendedHiddenProperties: [RelationDetails]
+        recommendedProperties: [PropertyDetails],
+        recommendedFeaturedProperties: [PropertyDetails],
+        recommendedHiddenProperties: [PropertyDetails]
     ) async throws {
         try await updateTypeProperties(
             typeId: typeId,
@@ -16,11 +16,11 @@ extension PropertiesServiceProtocol {
         )
     }
     
-    func addTypeRecommendedProperty(details: ObjectDetails, property: RelationDetails) async throws {
+    func addTypeRecommendedProperty(details: ObjectDetails, property: PropertyDetails) async throws {
         try await addTypeRecommendedProperty(type: ObjectType(details: details), property: property)
     }
     
-    func addTypeRecommendedProperty(type: ObjectType, property: RelationDetails) async throws {
+    func addTypeRecommendedProperty(type: ObjectType, property: PropertyDetails) async throws {
         var recommendedPropertiesDetails = type.recommendedRelationsDetails
         recommendedPropertiesDetails.insert(property, at: 0)
         try await updateTypeProperties(
@@ -31,11 +31,11 @@ extension PropertiesServiceProtocol {
         )
     }
     
-    func addTypeFeaturedRecommendedProperty(details: ObjectDetails, property: RelationDetails) async throws {
+    func addTypeFeaturedRecommendedProperty(details: ObjectDetails, property: PropertyDetails) async throws {
         try await addTypeFeaturedRecommendedProperty(type: ObjectType(details: details), property: property)
     }
     
-    func addTypeFeaturedRecommendedProperty(type: ObjectType, property: RelationDetails) async throws {
+    func addTypeFeaturedRecommendedProperty(type: ObjectType, property: PropertyDetails) async throws {
         var recommendedFeaturedPropertiesDetails = type.recommendedFeaturedRelationsDetails
         recommendedFeaturedPropertiesDetails.insert(property, at: 0)
         try await updateTypeProperties(

--- a/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorage.swift
@@ -7,7 +7,7 @@ enum PropertyDetailsStorageError: Error {
     case relationNotFound
 }
 
-private struct RelationDetailsKey: Hashable {
+private struct PropertyDetailsKey: Hashable {
     let key: String
     let spaceId: String
 }
@@ -22,11 +22,11 @@ final class PropertyDetailsStorage: PropertyDetailsStorageProtocol, Sendable {
     
     private let subscriptionDataBuilder: any MultispaceSubscriptionDataBuilderProtocol = Container.shared.propertySubscriptionDataBuilder()
     
-    private let multispaceSubscriptionHelper : MultispaceOneActiveSubscriptionHelper<RelationDetails>
+    private let multispaceSubscriptionHelper : MultispaceOneActiveSubscriptionHelper<PropertyDetails>
     
     // MARK: - Private properties
     
-    private let searchDetailsByKey = SynchronizedDictionary<RelationDetailsKey, RelationDetails>()
+    private let searchDetailsByKey = SynchronizedDictionary<PropertyDetailsKey, PropertyDetails>()
     
     private let sync = AtomicPublishedStorage<Void>(())
     var syncPublisher: AnyPublisher<Void, Never> { sync.publisher.eraseToAnyPublisher() }

--- a/Anytype/Sources/ServiceLayer/PropertyStorage/Subscription/PropertySubscriptionDataBuilder.swift
+++ b/Anytype/Sources/ServiceLayer/PropertyStorage/Subscription/PropertySubscriptionDataBuilder.swift
@@ -22,7 +22,7 @@ final class PropertySubscriptionDataBuilder: MultispaceSubscriptionDataBuilderPr
                 filters: filters,
                 limit: 0,
                 offset: 0,
-                keys: RelationDetails.subscriptionKeys.map(\.rawValue),
+                keys: PropertyDetails.subscriptionKeys.map(\.rawValue),
                 noDepSubscription: true
             )
         )

--- a/Modules/Services/Sources/Models/Block/BlockContent/BlockContent.swift
+++ b/Modules/Services/Sources/Models/Block/BlockContent/BlockContent.swift
@@ -9,7 +9,7 @@ public enum BlockContent: Hashable, Sendable {
     case link(BlockLink)
     case layout(BlockLayout)
     case featuredRelations
-    case relation(BlockRelation)
+    case relation(BlockProperty)
     case dataView(BlockDataview)
     case tableOfContents
     case table

--- a/Modules/Services/Sources/Models/Block/BlockContent/Content/BlockProperty.swift
+++ b/Modules/Services/Sources/Models/Block/BlockContent/Content/BlockProperty.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct BlockRelation: Hashable, Sendable {
+public struct BlockProperty: Hashable, Sendable {
     public var key: String
 
     public init(key: String) {

--- a/Modules/Services/Sources/Models/Block/BlockConverters/BlockPropertyConverter.swift
+++ b/Modules/Services/Sources/Models/Block/BlockConverters/BlockPropertyConverter.swift
@@ -3,12 +3,12 @@ import ProtobufMessages
 public extension Anytype_Model_Block.Content.Relation {
     var blockContent: BlockContent {
         .relation(
-            BlockRelation(key: key)
+            BlockProperty(key: key)
         )
     }
 }
 
-public extension BlockRelation {
+public extension BlockProperty {
     var asMiddleware: Anytype_Model_Block.OneOf_Content {
         .relation(.with {
             $0.key = key

--- a/Modules/Services/Sources/Models/Relations/Models/PropertyDetails.swift
+++ b/Modules/Services/Sources/Models/Relations/Models/PropertyDetails.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftProtobuf
 
-public struct RelationDetails: Hashable, Sendable {
+public struct PropertyDetails: Hashable, Sendable {
 
     public let id: String
     public let key: String
@@ -45,7 +45,7 @@ public struct RelationDetails: Hashable, Sendable {
     }
 }
 
-extension RelationDetails: DetailsModel {
+extension PropertyDetails: DetailsModel {
     
     public init(details: ObjectDetails) {
         self.id = details.id
@@ -99,7 +99,7 @@ extension RelationDetails: DetailsModel {
 }
 
 
-public extension RelationDetails {
+public extension PropertyDetails {
     var isMultiSelect: Bool {
         return maxCount == 0
     }

--- a/Modules/Services/Sources/Services/RelationListWithValue/PropertyListWithValueService.swift
+++ b/Modules/Services/Sources/Services/RelationListWithValue/PropertyListWithValueService.swift
@@ -1,11 +1,11 @@
 import Foundation
 import ProtobufMessages
 
-public protocol RelationListWithValueServiceProtocol: AnyObject, Sendable {
+public protocol PropertyListWithValueServiceProtocol: AnyObject, Sendable {
     func relationListWithValue(_ value: String, spaceId: String) async throws -> [String]
 }
 
-final class RelationListWithValueService: RelationListWithValueServiceProtocol, Sendable {
+final class PropertyListWithValueService: PropertyListWithValueServiceProtocol, Sendable {
     func relationListWithValue(_ value: String, spaceId: String) async throws -> [String] {
         let result = try await ClientCommands.relationListWithValue(.with {
             $0.spaceID = spaceId

--- a/Modules/Services/Sources/ServicesDI.swift
+++ b/Modules/Services/Sources/ServicesDI.swift
@@ -138,8 +138,8 @@ public extension Container {
         self { ChatService() }.shared
     }
     
-    var relationListWithValueService: Factory<RelationListWithValueServiceProtocol> {
-        self { RelationListWithValueService() }.shared
+    var relationListWithValueService: Factory<PropertyListWithValueServiceProtocol> {
+        self { PropertyListWithValueService() }.shared
     }
     
     var objectDateByTimestampService: Factory<ObjectDateByTimestampServiceProtocol> {


### PR DESCRIPTION
## Summary
- Renamed remaining files: RelationListWithValueService, BlockRelation, BlockRelationConverter, Relation+Set, RelationDetails
- Renamed enum Relation → Property
- Renamed struct RelationDetails → PropertyDetails  
- Renamed struct BlockRelation → BlockProperty
- Updated protocol and service references
- Updated dependency injection configuration

This continues the Relation → Property rename task from PR #3517.