### PR TITLE
IOS-4660 Rename relation to property in block models and services

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Date/DateViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Date/DateViewModel.swift
@@ -14,7 +14,7 @@ final class DateViewModel: ObservableObject {
     @Injected(\.accountManager)
     private var accountManager: any AccountManagerProtocol
     @Injected(\.relationListWithValueService)
-    private var relationListWithValueService: any RelationListWithValueServiceProtocol
+    private var relationListWithValueService: any PropertyListWithValueServiceProtocol
     @Injected(\.propertyDetailsStorage)
     private var propertyDetailsStorage: any PropertyDetailsStorageProtocol
     @Injected(\.dateRelatedObjectsSubscriptionService)

--- a/Modules/Services/Sources/Models/Block/BlockContainer/InfoContainer+ModelHelpers.swift
+++ b/Modules/Services/Sources/Models/Block/BlockContainer/InfoContainer+ModelHelpers.swift
@@ -15,7 +15,7 @@ public extension InfoContainerProtocol {
         }
     }
     
-    func updateRelation(blockId: String, update updateAction: (BlockRelation) -> (BlockRelation)) {
+    func updateRelation(blockId: String, update updateAction: (BlockProperty) -> (BlockProperty)) {
         update(blockId: blockId) { info in
             guard case let .relation(relation) = info.content else {
                 anytypeAssertionFailure("Not a relation", info: ["content": "\(info.content.type)"])

--- a/Modules/Services/Sources/Models/Block/BlockContainer/Models+Events/BlockRelation+Handle.swift
+++ b/Modules/Services/Sources/Models/Block/BlockContainer/Models+Events/BlockRelation+Handle.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ProtobufMessages
 
-extension BlockRelation {
+extension BlockProperty {
     func handleSetRelation(data: Anytype_Event.Block.Set.Relation) -> Self{
         var newData = self
         

--- a/Modules/Services/Sources/Models/Block/BlockContent/BlockContent.swift
+++ b/Modules/Services/Sources/Models/Block/BlockContent/BlockContent.swift
@@ -9,7 +9,7 @@ public enum BlockContent: Hashable, Sendable {
     case link(BlockLink)
     case layout(BlockLayout)
     case featuredRelations
-    case relation(BlockRelation)
+    case relation(BlockProperty)
     case dataView(BlockDataview)
     case tableOfContents
     case table

--- a/Modules/Services/Sources/Models/Block/BlockContent/Content/BlockProperty.swift
+++ b/Modules/Services/Sources/Models/Block/BlockContent/Content/BlockProperty.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct BlockRelation: Hashable, Sendable {
+public struct BlockProperty: Hashable, Sendable {
     public var key: String
 
     public init(key: String) {

--- a/Modules/Services/Sources/Models/Block/BlockConverters/BlockPropertyConverter.swift
+++ b/Modules/Services/Sources/Models/Block/BlockConverters/BlockPropertyConverter.swift
@@ -3,12 +3,12 @@ import ProtobufMessages
 public extension Anytype_Model_Block.Content.Relation {
     var blockContent: BlockContent {
         .relation(
-            BlockRelation(key: key)
+            BlockProperty(key: key)
         )
     }
 }
 
-public extension BlockRelation {
+public extension BlockProperty {
     var asMiddleware: Anytype_Model_Block.OneOf_Content {
         .relation(.with {
             $0.key = key

--- a/Modules/Services/Sources/Services/PropertyListWithValue/PropertyListWithValueService.swift
+++ b/Modules/Services/Sources/Services/PropertyListWithValue/PropertyListWithValueService.swift
@@ -1,11 +1,11 @@
 import Foundation
 import ProtobufMessages
 
-public protocol RelationListWithValueServiceProtocol: AnyObject, Sendable {
+public protocol PropertyListWithValueServiceProtocol: AnyObject, Sendable {
     func relationListWithValue(_ value: String, spaceId: String) async throws -> [String]
 }
 
-final class RelationListWithValueService: RelationListWithValueServiceProtocol, Sendable {
+final class PropertyListWithValueService: PropertyListWithValueServiceProtocol, Sendable {
     func relationListWithValue(_ value: String, spaceId: String) async throws -> [String] {
         let result = try await ClientCommands.relationListWithValue(.with {
             $0.spaceID = spaceId

--- a/Modules/Services/Sources/ServicesDI.swift
+++ b/Modules/Services/Sources/ServicesDI.swift
@@ -138,8 +138,8 @@ public extension Container {
         self { ChatService() }.shared
     }
     
-    var relationListWithValueService: Factory<RelationListWithValueServiceProtocol> {
-        self { RelationListWithValueService() }.shared
+    var relationListWithValueService: Factory<PropertyListWithValueServiceProtocol> {
+        self { PropertyListWithValueService() }.shared
     }
     
     var objectDateByTimestampService: Factory<ObjectDateByTimestampServiceProtocol> {


### PR DESCRIPTION
## Summary
- Rename RelationListWithValueService to PropertyListWithValueService
- Rename BlockRelation to BlockProperty
- Rename BlockRelationConverter to BlockPropertyConverter  
- Update all references throughout codebase