### PR TITLE
IOS-4818 Refactor SpaceHub sorting logic

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -130,7 +130,7 @@ final class SpaceHubViewModel: ObservableObject {
     private func subscribeOnSpaces() async {
         for await spaces in await spaceHubSpacesStorage.spacesStream {
             if FeatureFlags.pinnedSpaces {
-                self.spaces = spaces
+                self.spaces = spaces.sorted(by: sortSpacesForPinnedFeature)
                 self.unreadSpaces = []
             } else {
                 self.unreadSpaces = spaces
@@ -141,6 +141,33 @@ final class SpaceHubViewModel: ObservableObject {
                 self.spaces = spaces.filter { $0.preview.unreadCounter == 0 }
             }
             createSpaceAvailable = workspacesStorage.canCreateNewSpace()
+        }
+    }
+    
+    private func sortSpacesForPinnedFeature(_ lhs: ParticipantSpaceViewDataWithPreview, _ rhs: ParticipantSpaceViewDataWithPreview) -> Bool {
+        switch (lhs.spaceView.isPinned, rhs.spaceView.isPinned) {
+        case (true, true):
+            return lhs.spaceView.spaceOrder > rhs.spaceView.spaceOrder
+        case (true, false):
+            return true
+        case (false, true):
+            return false
+        case (false, false):
+            let lhsMessageDate = lhs.preview.lastMessage?.createdAt
+            let rhsMessageDate = rhs.preview.lastMessage?.createdAt
+            
+            switch (lhsMessageDate, rhsMessageDate) {
+            case let (date1?, date2?):
+                return date1 > date2
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            case (nil, nil):
+                let lhsCreatedDate = lhs.spaceView.createdDate ?? .distantFuture
+                let rhsCreatedDate = rhs.spaceView.createdDate ?? .distantFuture
+                return lhsCreatedDate < rhsCreatedDate
+            }
         }
     }
     

--- a/Anytype/Sources/PreviewMocks/Mocks/WorkspacesStorageMock.swift
+++ b/Anytype/Sources/PreviewMocks/Mocks/WorkspacesStorageMock.swift
@@ -29,7 +29,7 @@ final class WorkspacesStorageMock: WorkspacesStorageProtocol, @unchecked Sendabl
                 readersLimit: nil,
                 writersLimit: nil,
                 chatId: "",
-                isPinned: false,
+                spaceOrder: "",
                 uxType: .data,
                 pushNotificationEncryptionKey: "",
                 pushNotificationMode: .all

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
@@ -15,7 +15,7 @@ struct SpaceView: Identifiable, Equatable, Hashable {
     let readersLimit: Int?
     let writersLimit: Int?
     let chatId: String
-    let isPinned: Bool
+    let spaceOrder: String
     let uxType: SpaceUxType
     let pushNotificationEncryptionKey: String
     let pushNotificationMode: SpacePushNotificationsMode
@@ -35,7 +35,7 @@ extension SpaceView: DetailsModel {
         self.readersLimit = details.readersLimit
         self.writersLimit = details.writersLimit
         self.chatId = details.chatId
-        self.isPinned = details.spaceOrder.isNotEmpty
+        self.spaceOrder = details.spaceOrder
         self.uxType = details.spaceUxTypeValue ?? .data
         self.pushNotificationEncryptionKey = details.spacePushNotificationEncryptionKey
         self.pushNotificationMode = details.spacePushNotificationModeValue ?? .all
@@ -66,6 +66,10 @@ extension SpaceView {
     
     var title: String {
         name.withPlaceholder
+    }
+    
+    var isPinned: Bool {
+        spaceOrder.isNotEmpty
     }
     
     var isShared: Bool {

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceViewMock.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceViewMock.swift
@@ -19,7 +19,7 @@ extension SpaceView {
             readersLimit: nil,
             writersLimit: nil,
             chatId: "",
-            isPinned: false,
+            spaceOrder: "",
             uxType: .data,
             pushNotificationEncryptionKey: "",
             pushNotificationMode: .all

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/WorkspacesSubscriptionBuilder.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/WorkspacesSubscriptionBuilder.swift
@@ -22,7 +22,6 @@ final class WorkspacesSubscriptionBuilder: WorkspacesSubscriptionBuilderProtocol
     func build(techSpaceId: String) -> SubscriptionData {
         let sorts: [DataviewSort] = .builder {
             SearchHelper.sort(relation: .spaceOrder, type: .asc, noCollate: true, emptyPlacement: .end)
-            // TODO: lastMessageDate sort
             SearchHelper.sort(relation: .createdDate, type: .desc)
         }
         


### PR DESCRIPTION
## Summary
- Updated SpaceView model to use spaceOrder string instead of isPinned boolean
- Refactored complex sorting logic in SpaceHubViewModel into a clean, readable method
- Improved code maintainability with pattern matching and clear separation of concerns