### PR TITLE
IOS-4852 Add limit check for pinned spaces

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubView.swift
@@ -31,6 +31,7 @@ struct SpaceHubView: View {
                 SpaceDeleteAlert(spaceId: $0.value)
             }
             .homeBottomPanelHidden(true)
+            .snackbar(toastBarData: $model.toastBarData)
     }
     
     var content: some View {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @preconcurrency import Combine
 import AnytypeCore
 import AsyncAlgorithms
+import Loc
 
 @MainActor
 final class SpaceHubViewModel: ObservableObject {
@@ -22,6 +23,7 @@ final class SpaceHubViewModel: ObservableObject {
     @Published var spaceIdToLeave: StringIdentifiable?
     @Published var spaceIdToDelete: StringIdentifiable?
     @Published var spaceMuteData: SpaceMuteData?
+    @Published var toastBarData: ToastBarData?
     
     @Published var profileIcon: Icon?
     
@@ -95,7 +97,15 @@ final class SpaceHubViewModel: ObservableObject {
     
     func pin(spaceView: SpaceView) async throws {
         guard let spaces else { return }
-        var newOrder = spaces.filter { $0.spaceView.id != spaceView.id && $0.spaceView.isPinned }.map(\.spaceView.id)
+        let pinnedSpaces = spaces.filter { $0.spaceView.isPinned }
+        
+        let pinnedSpacesLimit = 6
+        if pinnedSpaces.count >= pinnedSpacesLimit {
+            toastBarData = ToastBarData(Loc.pinLimitReached(pinnedSpacesLimit), type: .failure)
+            return
+        }
+        
+        var newOrder = pinnedSpaces.filter { $0.spaceView.id != spaceView.id }.map(\.spaceView.id)
         newOrder.insert(spaceView.id, at: 0)
         
         try await spaceOrderService.setOrder(spaceViewIdMoved: spaceView.id, newOrder: newOrder)

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -335,6 +335,9 @@ public enum Loc {
   public static let photo = Loc.tr("Localizable", "Photo", fallback: "Photo")
   public static let picture = Loc.tr("Localizable", "Picture", fallback: "Picture")
   public static let pin = Loc.tr("Localizable", "Pin", fallback: "Pin")
+  public static func pinLimitReached(_ p1: Int) -> String {
+    return Loc.tr("Localizable", "Pin limit reached", p1, fallback: "You've reached the limit of %d pinned spaces.")
+  }
   public static let pinOnTop = Loc.tr("Localizable", "Pin on top", fallback: "Pin on top")
   public static let pink = Loc.tr("Localizable", "Pink", fallback: "Pink")
   public static let pinkBackground = Loc.tr("Localizable", "Pink background", fallback: "Pink background")


### PR DESCRIPTION
## Summary
- Added validation to limit pinned spaces to 6
- Show toast message when users try to exceed the limit
- Updated localization strings to support the limit message

## Test plan
- [ ] Try pinning more than 6 spaces
- [ ] Verify toast message appears with "You've reached the limit of 6 pinned spaces."
- [ ] Verify pinning works normally when under the limit
- [ ] Test unpinning and re-pinning spaces