### PR TITLE
IOS-4778 Remove spaceId from BlockActionHandlerProtocol methods

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Handler/SlashMenuActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Handler/SlashMenuActionHandler.swift
@@ -64,7 +64,7 @@ final class SlashMenuActionHandler {
                 try await actionHandler
                     .createPage(
                         targetId: blockInformation.id,
-                        spaceId: spaceId,
+                        spaceId: object.spaceId,
                         typeUniqueKey: object.uniqueKeyValue,
                         templateId: object.defaultTemplateId
                     )
@@ -78,7 +78,7 @@ final class SlashMenuActionHandler {
             case .newRealtion:
                 router.showAddPropertyInfoView(document: document) { [weak self, spaceId = document.spaceId] relation, isNew in
                     Task {
-                        try await self?.actionHandler.addBlock(.relation(key: relation.key), blockId: blockInformation.id, blockText: textView?.attributedText.sendable(), spaceId: spaceId)
+                        try await self?.actionHandler.addBlock(.relation(key: relation.key), blockId: blockInformation.id, blockText: textView?.attributedText.sendable())
                     }
                     AnytypeAnalytics.instance().logAddExistingOrCreateRelation(
                         format: relation.format,
@@ -89,7 +89,7 @@ final class SlashMenuActionHandler {
                     )
                 }
             case .relation(let relation):
-                try await actionHandler.addBlock(.relation(key: relation.key), blockId: blockInformation.id, blockText: textView?.attributedText.sendable(), spaceId: document.spaceId)
+                try await actionHandler.addBlock(.relation(key: relation.key), blockId: blockInformation.id, blockText: textView?.attributedText.sendable())
             }
         case let .other(other):
             switch other {
@@ -98,13 +98,12 @@ final class SlashMenuActionHandler {
                     blockId: blockInformation.id,
                     rowsCount: rowsCount,
                     columnsCount: columnsCount,
-                    blockText: textView?.attributedText.sendable(),
-                    spaceId: document.spaceId
+                    blockText: textView?.attributedText.sendable()
                 ) else { return }
                 
                 cursorManager.blockFocus = BlockFocus(id: blockId, position: .beginning)
             default:
-                try await actionHandler.addBlock(other.blockViewsType, blockId: blockInformation.id, blockText: textView?.attributedText.sendable(), spaceId: document.spaceId)
+                try await actionHandler.addBlock(other.blockViewsType, blockId: blockInformation.id, blockText: textView?.attributedText.sendable())
             }
         case let .color(color):
             actionHandler.setTextColor(color, blockIds: [blockInformation.id])
@@ -214,7 +213,7 @@ final class SlashMenuActionHandler {
         case .delete:
             actionHandler.delete(blockIds: [blockId])
         case .duplicate:
-            actionHandler.duplicate(blockId: blockId, spaceId: document.spaceId)
+            actionHandler.duplicate(blockId: blockId)
         case .moveTo:
             router.showMoveTo { [weak self] details in
                 Task {
@@ -233,7 +232,7 @@ final class SlashMenuActionHandler {
         textView: UITextView?,
         blockInformation: BlockInformation
     ) async throws {
-        let blockId = try await actionHandler.addBlock(media.blockViewsType, blockId: blockInformation.id, blockText: textView?.attributedText.sendable(), spaceId: document.spaceId)
+        let blockId = try await actionHandler.addBlock(media.blockViewsType, blockId: blockInformation.id, blockText: textView?.attributedText.sendable())
         
         switch media {
         case .file:

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/SimpleTable/Block/TextBlock/SimpleTablesTextBlockActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/SimpleTable/Block/TextBlock/SimpleTablesTextBlockActionHandler.swift
@@ -182,7 +182,7 @@ final class SimpleTablesTextBlockActionHandler: TextBlockActionHandlerProtocol {
             case let .addBlock(type, newText):
                 Task { @MainActor in
                     try await setNewText(attributedString: newText.sendable())
-                    try await actionHandler.addBlock(type, blockId: info.id, blockText: newText.sendable(), position: .top, spaceId: document.spaceId)
+                    try await actionHandler.addBlock(type, blockId: info.id, blockText: newText.sendable(), position: .top)
                     resetSubject.send(nil)
                 }
             case let .addStyle(style, currentText, styleRange, focusRange):
@@ -269,7 +269,7 @@ final class SimpleTablesTextBlockActionHandler: TextBlockActionHandlerProtocol {
     }
     
     private func createEmptyBlock() {
-        actionHandler.createEmptyBlock(parentId: info.id, spaceId: document.spaceId)
+        actionHandler.createEmptyBlock(parentId: info.id)
     }
     
     private func handleKeyboardAction(action: CustomTextView.KeyboardAction, textView: UITextView) {

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockActionHandler.swift
@@ -198,7 +198,7 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol {
             case let .addBlock(type, newText):
                 Task { @MainActor in
                     try await setNewText(attributedString: newText.sendable())
-                    try await actionHandler.addBlock(type, blockId: info.id, blockText: newText.sendable(), position: .top, spaceId: document.spaceId)
+                    try await actionHandler.addBlock(type, blockId: info.id, blockText: newText.sendable(), position: .top)
                     resetSubject.send(nil)
                 }
             case let .addStyle(style, currentText, styleRange, focusRange):
@@ -366,7 +366,7 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol {
     }
 
     private func createEmptyBlock() {
-        actionHandler.createEmptyBlock(parentId: info.id, spaceId: document.spaceId)
+        actionHandler.createEmptyBlock(parentId: info.id)
     }
 
     private func handleKeyboardAction(action: CustomTextView.KeyboardAction, textView: UITextView) {

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageBlocksStateManager.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageBlocksStateManager.swift
@@ -431,11 +431,11 @@ final class EditorPageBlocksStateManager: EditorPageBlocksStateManagerProtocol {
         case .addBlockBelow:
             elements.forEach { element in
                 Task {
-                    try await actionHandler.addBlock(.text(.text), blockId: element.blockId, spaceId: document.spaceId)
+                    try await actionHandler.addBlock(.text(.text), blockId: element.blockId)
                 }
             }
         case .duplicate:
-            elements.forEach { actionHandler.duplicate(blockId: $0.blockId, spaceId: document.spaceId) }
+            elements.forEach { actionHandler.duplicate(blockId: $0.blockId) }
         case .turnInto:
             Task {
                 for block in elements {

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
@@ -211,7 +211,7 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
     }
     
     func tapOnEmptyPlace() {
-        actionHandler.createEmptyBlock(parentId: document.objectId, spaceId: document.spaceId)
+        actionHandler.createEmptyBlock(parentId: document.objectId)
     }
     
     private func handleTemplateSubscription(details: [ObjectDetails]) {

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandler.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandler.swift
@@ -100,8 +100,8 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
         service.setBackgroundColor(blockIds: blockIds, color: color)
     }
     
-    func duplicate(blockId: String, spaceId: String) {
-        AnytypeAnalytics.instance().logDuplicateBlock(spaceId: spaceId)
+    func duplicate(blockId: String) {
+        AnytypeAnalytics.instance().logDuplicateBlock(spaceId: document.spaceId)
         service.duplicate(blockId: blockId)
     }
     
@@ -137,10 +137,10 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
     }
 
 
-    func createEmptyBlock(parentId: String, spaceId: String) {
+    func createEmptyBlock(parentId: String) {
         Task {
             let emptyBlock = BlockInformation.emptyText
-            AnytypeAnalytics.instance().logCreateBlock(type: emptyBlock.content.type, spaceId: spaceId)
+            AnytypeAnalytics.instance().logCreateBlock(type: emptyBlock.content.type, spaceId: document.spaceId)
             try await service.addChild(info: emptyBlock, parentId: parentId)
         }
     }
@@ -280,15 +280,14 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
         blockId: String,
         rowsCount: Int,
         columnsCount: Int,
-        blockText: SafeNSAttributedString?,
-        spaceId: String
+        blockText: SafeNSAttributedString?
     ) async throws -> String {
         guard let isTextAndEmpty = blockText?.value.string.isEmpty
                 ?? document.infoContainer.get(id: blockId)?.isTextAndEmpty else { return "" }
         
         let position: BlockPosition = isTextAndEmpty ? .replace : .bottom
 
-        AnytypeAnalytics.instance().logCreateBlock(type: TableBlockType.simpleTableBlock.rawValue, spaceId: spaceId)
+        AnytypeAnalytics.instance().logCreateBlock(type: TableBlockType.simpleTableBlock.rawValue, spaceId: document.spaceId)
         
         return try await blockTableService.createTable(
             contextId: document.objectId,
@@ -300,7 +299,7 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
     }
 
 
-    func addBlock(_ type: BlockContentType, blockId: String, blockText: SafeNSAttributedString?, position: BlockPosition?, spaceId: String) async throws -> String {
+    func addBlock(_ type: BlockContentType, blockId: String, blockText: SafeNSAttributedString?, position: BlockPosition?) async throws -> String {
         guard type != .smartblock(.page) else {
             anytypeAssertionFailure("Use createPage func instead")
             throw CommonError.undefined
@@ -313,7 +312,7 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
         
         let position: BlockPosition = isTextAndEmpty ? .replace : (position ?? .bottom)
         
-        AnytypeAnalytics.instance().logCreateBlock(type: newBlock.content.type, spaceId: spaceId)
+        AnytypeAnalytics.instance().logCreateBlock(type: newBlock.content.type, spaceId: document.spaceId)
         return try await service.add(info: newBlock, targetBlockId: blockId, position: position)
     }
 

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandlerProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandlerProtocol.swift
@@ -12,18 +12,18 @@ protocol BlockActionHandlerProtocol: AnyObject, Sendable {
     
     func setTextColor(_ color: BlockColor, blockIds: [String])
     func setBackgroundColor(_ color: BlockBackgroundColor, blockIds: [String])
-    func duplicate(blockId: String, spaceId: String)
+    func duplicate(blockId: String)
     func fetch(url: AnytypeURL, blockId: String) async throws
     func checkbox(selected: Bool, blockId: String)
     func toggle(blockId: String)
     func setAlignment(_ alignment: LayoutAlignment, blockIds: [String])
     func delete(blockIds: [String])
     func moveToPage(blockIds: [String], pageId: String) async throws
-    func createEmptyBlock(parentId: String, spaceId: String)
+    func createEmptyBlock(parentId: String)
     func addLink(targetDetails: ObjectDetails, blockId: String)
     func changeMarkup(blockIds: [String], markType: MarkupType)
     @discardableResult
-    func addBlock(_ type: BlockContentType, blockId: String, blockText: SafeNSAttributedString?, position: BlockPosition?, spaceId: String) async throws -> String
+    func addBlock(_ type: BlockContentType, blockId: String, blockText: SafeNSAttributedString?, position: BlockPosition?) async throws -> String
     func toggleWholeBlockMarkup(
         _ attributedString: SafeNSAttributedString?,
         markup: MarkupType,
@@ -59,15 +59,14 @@ protocol BlockActionHandlerProtocol: AnyObject, Sendable {
         blockId: String,
         rowsCount: Int,
         columnsCount: Int,
-        blockText: SafeNSAttributedString?,
-        spaceId: String
+        blockText: SafeNSAttributedString?
     ) async throws -> String
     func pasteContent()
 }
 
 extension BlockActionHandlerProtocol {
     @discardableResult
-    func addBlock(_ type: BlockContentType, blockId: String, blockText: SafeNSAttributedString? = nil, spaceId: String) async throws -> String {
-        try await addBlock(type, blockId: blockId, blockText: blockText, position: nil, spaceId: spaceId)
+    func addBlock(_ type: BlockContentType, blockId: String, blockText: SafeNSAttributedString? = nil) async throws -> String {
+        try await addBlock(type, blockId: blockId, blockText: blockText, position: nil)
     }
 }

--- a/AnytypeTests/Markdown/Mocks/BlockActionHandlerMock.swift
+++ b/AnytypeTests/Markdown/Mocks/BlockActionHandlerMock.swift
@@ -35,7 +35,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
     
-    func duplicate(blockId: String, spaceId: String) {
+    func duplicate(blockId: String) {
         assertionFailure()
     }
     
@@ -79,7 +79,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
     
-    func createEmptyBlock(parentId: String, spaceId: String) {
+    func createEmptyBlock(parentId: String) {
         assertionFailure()
     }
     
@@ -95,7 +95,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
     
-    func addBlock(_ type: BlockContentType, blockId: String, blockText: SafeNSAttributedString?, position: BlockPosition?, spaceId: String) async throws -> String {
+    func addBlock(_ type: BlockContentType, blockId: String, blockText: SafeNSAttributedString?, position: BlockPosition?) async throws -> String {
         assertionFailure()
         return ""
     }
@@ -186,7 +186,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
 
-    func createTable(blockId: String, rowsCount: Int, columnsCount: Int, blockText: SafeNSAttributedString?, spaceId: String) async throws -> String {
+    func createTable(blockId: String, rowsCount: Int, columnsCount: Int, blockText: SafeNSAttributedString?) async throws -> String {
         fatalError()
     }
     


### PR DESCRIPTION
## Summary
- Remove spaceId parameter from BlockActionHandlerProtocol methods (createEmptyBlock, addBlock, createPage, createTable)
- Update implementations to use document.spaceId internally instead of accepting spaceId as parameter
- Update all call sites across the codebase to remove spaceId argument
- Fix document scanner integration in slash menu to use proper method call

## Benefits
- Cleaner API that doesn't require callers to pass spaceId
- Consistent with other methods that use document.spaceId internally
- Reduces parameter count and potential for passing incorrect spaceId