### PR TITLE
IOS-4861 Move read-only Claude permissions to global settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,7 +42,16 @@
       "mcp__linear__get_issue_status",
       "mcp__linear__list_issue_labels",
       "mcp__linear__get_team",
-      "mcp__linear__search_documentation"
+      "mcp__linear__search_documentation",
+      
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(git fetch:*)",
+      "Bash(od:*)",
+      "Bash(awk:*)",
+      "Bash(git stash show:*)",
+      "mcp__figma__get_image",
+      "mcp__figma__get_code"
     ],
     "deny": []
   },


### PR DESCRIPTION
## Summary
- Moved read-only Claude permissions from local to global settings for team consistency
- Added gh pr list/diff, git fetch, od, awk, git stash show, and figma tools to global permissions
- Ensures all team members have the same Claude Code capabilities for read-only operations