### PR TITLE
IOS-4875 Add active color styling to pinned space icon

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCardLabel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCardLabel.swift
@@ -32,7 +32,9 @@ struct SpaceCardLabel: View {
                     Spacer()
                     unreadCounters
                     if FeatureFlags.pinnedSpaces && spaceData.spaceView.isPinned {
-                        Image(asset: .X24.pin).frame(width: 22, height: 22)
+                        Image(asset: .X24.pin)
+                            .foregroundStyle(Color.Control.active)
+                            .frame(width: 22, height: 22)
                     }
                 }
                 Spacer(minLength: 1)

--- a/Modules/Assets/Sources/Assets/Resources/Assets.xcassets/DesignSystem/x24/Pin.imageset/Contents.json
+++ b/Modules/Assets/Sources/Assets/Resources/Assets.xcassets/DesignSystem/x24/Pin.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
## Summary
- Add active color styling to pinned space icon in SpaceCardLabel
- Configure pin icon as template rendering for proper color theming
- 
<img width="460" height="872" alt="image" src="https://github.com/user-attachments/assets/107ffed2-0d79-4862-87c9-ec1da1433842" />
