### PR TITLE
IOS-4861 Analytics | Add route tracking to upload media analytics

### DIFF
--- a/Anytype/Sources/Analytics/AnalyticsConstants.swift
+++ b/Anytype/Sources/Analytics/AnalyticsConstants.swift
@@ -412,3 +412,9 @@ enum SentMessageType: String {
     case attachment = "Attachment"
     case mixed = "Mixed"
 }
+
+enum UploadMediaRoute: String {
+    case camera = "Camera"
+    case scan = "Scan"
+    case filePicker = "FilePicker"
+}

--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -232,11 +232,14 @@ extension AnytypeAnalytics {
         logEvent("DeleteBlock")
     }
     
-    func logUploadMedia(type: FileContentType, spaceId: String) {
+    func logUploadMedia(type: FileContentType, spaceId: String, route: UploadMediaRoute) {
         logEvent(
             "UploadMedia",
             spaceId: spaceId,
-            withEventProperties: [AnalyticsEventsPropertiesKey.type: type.rawValue]
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.type: type.rawValue,
+                AnalyticsEventsPropertiesKey.route: route.rawValue
+            ]
         )
     }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelActions.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelActions.swift
@@ -50,9 +50,9 @@ final class MediaBlockActionsProvider: MediaBlockActionsProviderProtocol {
             
             switch media {
             case let .image(image, type):
-                handler.uploadImage(image: image, type: type, blockId: blockId)
+                handler.uploadImage(image: image, type: type, blockId: blockId, route: .camera)
             case .video(let url):
-                handler.uploadMediaFile(uploadingSource: .path(url.path()), type: .videos, blockId: blockId)
+                handler.uploadMediaFile(uploadingSource: .path(url.path()), type: .videos, blockId: blockId, route: .camera)
             }
         }
     }
@@ -68,11 +68,11 @@ final class MediaBlockActionsProvider: MediaBlockActionsProviderProtocol {
                     for (index, image) in images.enumerated() {
                         if index == 0 {
                             // First image: upload to the provided block ID
-                            self.handler.uploadImage(image: image, type: UTType.png.identifier, blockId: currentBlockId)
+                            self.handler.uploadImage(image: image, type: UTType.png.identifier, blockId: currentBlockId, route: .scan)
                         } else {
                             // Subsequent images: create new block below the previous one
                             currentBlockId = try await self.handler.addBlock(.file(.init(contentType: .image)), blockId: currentBlockId)
-                            self.handler.uploadImage(image: image, type: UTType.png.identifier, blockId: currentBlockId)
+                            self.handler.uploadImage(image: image, type: UTType.png.identifier, blockId: currentBlockId, route: .scan)
                         }
                     }
                 }
@@ -91,7 +91,8 @@ final class MediaBlockActionsProvider: MediaBlockActionsProviderProtocol {
             self?.handler.uploadMediaFile(
                 uploadingSource: .itemProvider(itemProvider),
                 type: type,
-                blockId: blockId
+                blockId: blockId,
+                route: .filePicker
             )
         }
     }
@@ -99,7 +100,7 @@ final class MediaBlockActionsProvider: MediaBlockActionsProviderProtocol {
     private func showFilePicker(blockId: String, types: [UTType]) {
         let model = AnytypePicker.ViewModel(types: types)
         model.$resultInformation.safelyUnwrapOptionals().sink { [weak self] result in
-            self?.handler.uploadFileAt(localPath: result.filePath, blockId: blockId)
+            self?.handler.uploadFileAt(localPath: result.filePath, blockId: blockId, route: .filePicker)
         }.store(in: &subscriptions)
         
         router.showFilePicker(model: model)

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandler.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandler.swift
@@ -220,10 +220,9 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
     }
     
     // MARK: - Public methods
-    func uploadMediaFile(uploadingSource: FileUploadingSource, type: MediaPickerContentType, blockId: String) {
+    func uploadMediaFile(uploadingSource: FileUploadingSource, type: MediaPickerContentType, blockId: String, route: UploadMediaRoute) {
         
         Task {
-            
             await EventsBunch(
                 contextId: document.objectId,
                 localEvents: [.setLoadingState(blockId: blockId)]
@@ -232,10 +231,10 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
             try await fileService.uploadDataAt(source: uploadingSource, contextID: document.objectId, blockID: blockId)
         }
 
-        AnytypeAnalytics.instance().logUploadMedia(type: type.asFileBlockContentType, spaceId: document.spaceId)
+        AnytypeAnalytics.instance().logUploadMedia(type: type.asFileBlockContentType, spaceId: document.spaceId, route: route)
     }
     
-    func uploadImage(image: UIImage, type: String, blockId: String) {
+    func uploadImage(image: UIImage, type: String, blockId: String, route: UploadMediaRoute) {
         Task {
             guard let fileData = try? fileService.createFileData(image: image, type: type) else {
                 return
@@ -249,11 +248,11 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
             try await fileService.uploadDataAt(data: fileData, contextID: document.objectId, blockID: blockId)
         }
 
-        AnytypeAnalytics.instance().logUploadMedia(type: .image, spaceId: document.spaceId)
+        AnytypeAnalytics.instance().logUploadMedia(type: .image, spaceId: document.spaceId, route: route)
     }
     
-    func uploadFileAt(localPath: String, blockId: String) {
-        AnytypeAnalytics.instance().logUploadMedia(type: .file, spaceId: document.spaceId)
+    func uploadFileAt(localPath: String, blockId: String, route: UploadMediaRoute) {
+        AnytypeAnalytics.instance().logUploadMedia(type: .file, spaceId: document.spaceId, route: route)
         
         Task {
             await EventsBunch(

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandlerProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandlerProtocol.swift
@@ -46,9 +46,9 @@ protocol BlockActionHandlerProtocol: AnyObject, Sendable {
         currentText: SafeNSAttributedString,
         contentType: BlockContentType
     ) async throws -> SafeNSAttributedString
-    func uploadMediaFile(uploadingSource: FileUploadingSource, type: MediaPickerContentType, blockId: String)
-    func uploadImage(image: UIImage, type: String, blockId: String)
-    func uploadFileAt(localPath: String, blockId: String)
+    func uploadMediaFile(uploadingSource: FileUploadingSource, type: MediaPickerContentType, blockId: String, route: UploadMediaRoute)
+    func uploadImage(image: UIImage, type: String, blockId: String, route: UploadMediaRoute)
+    func uploadFileAt(localPath: String, blockId: String, route: UploadMediaRoute)
     func createAndFetchBookmark(
         targetID: String,
         position: BlockPosition,

--- a/AnytypeTests/Markdown/Mocks/BlockActionHandlerMock.swift
+++ b/AnytypeTests/Markdown/Mocks/BlockActionHandlerMock.swift
@@ -162,7 +162,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
     
-    func uploadFileAt(localPath: String, blockId: String) {
+    func uploadFileAt(localPath: String, blockId: String, route: UploadMediaRoute) {
         assertionFailure()
     }
     
@@ -190,7 +190,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         fatalError()
     }
     
-    func uploadMediaFile(uploadingSource: FileUploadingSource, type: MediaPickerContentType, blockId: String) {
+    func uploadMediaFile(uploadingSource: FileUploadingSource, type: MediaPickerContentType, blockId: String, route: UploadMediaRoute) {
         assertionFailure()
     }
     
@@ -207,7 +207,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
     
-    func uploadImage(image: UIImage, type: String, blockId: String) {
+    func uploadImage(image: UIImage, type: String, blockId: String, route: UploadMediaRoute) {
         assertionFailure()
     }
     

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,8 @@ git commit -m "IOS-4852 Add limit check for pinned spaces"
 - Brief description of changes (1-3 bullet points)
 ```
 
+**Note**: PRs are for programmers, not testers - no test plan needed
+
 **IMPORTANT**: 
 - **NEVER add AI signatures** like "🤖 Generated with Claude Code" to pull requests
 - **NEVER add AI signatures** to commit messages


### PR DESCRIPTION
## Summary
- Add UploadMediaRoute enum with camera, scan, filePicker routes for detailed analytics tracking
- Update logUploadMedia function to accept route parameter  
- Add route context to all upload function calls in BlockActionHandler
- Update protocols and test mocks to match new signatures