### PR TITLE
IOS-4884 Add slash menu route tracking to block action analytics

### DIFF
--- a/Anytype/Sources/Analytics/AnalyticsConstants.swift
+++ b/Anytype/Sources/Analytics/AnalyticsConstants.swift
@@ -71,6 +71,7 @@ enum AnalyticsEventsRouteKind: String {
     case search = "Search"
     case type = "Type"
     case link = "Link"
+    case slashMenu = "SlashMenu"
 }
 
 enum AnalyticsEventsRelationType: String {

--- a/Anytype/Sources/Analytics/AnalyticsConstants.swift
+++ b/Anytype/Sources/Analytics/AnalyticsConstants.swift
@@ -418,3 +418,8 @@ enum UploadMediaRoute: String {
     case scan = "Scan"
     case filePicker = "FilePicker"
 }
+
+enum ScreenSlashMenuRoute: String {
+    case slash = "Slash"
+    case keyboardBar = "KeyboardBar"
+}

--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -261,16 +261,21 @@ extension AnytypeAnalytics {
         isNew: Bool,
         type: AnalyticsEventsRelationType,
         key: AnalyticsRelationKey,
-        spaceId: String
+        spaceId: String,
+        route: AnalyticsEventsRouteKind? = nil
     ) {
+        var properties = [
+            AnalyticsEventsPropertiesKey.format: format.analyticsName,
+            AnalyticsEventsPropertiesKey.type: type.rawValue,
+            AnalyticsEventsPropertiesKey.relationKey: key.value
+        ]
+        if let route = route {
+            properties[AnalyticsEventsPropertiesKey.route] = route.rawValue
+        }
         logEvent(
             isNew ? "CreateRelation" : "AddExistingRelation",
             spaceId: spaceId,
-            withEventProperties: [
-                AnalyticsEventsPropertiesKey.format: format.analyticsName,
-                AnalyticsEventsPropertiesKey.type: type.rawValue,
-                AnalyticsEventsPropertiesKey.relationKey: key.value
-            ]
+            withEventProperties: properties
         )
     }
 
@@ -927,13 +932,15 @@ extension AnytypeAnalytics {
         )
     }
     
-    func logCreateLink(spaceId: String, objectType: AnalyticsObjectType) {
+    func logCreateLink(spaceId: String, objectType: AnalyticsObjectType, route: AnalyticsEventsRouteKind? = nil) {
+        var properties = [AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId]
+        if let route = route {
+            properties[AnalyticsEventsPropertiesKey.route] = route.rawValue
+        }
         logEvent(
             "CreateLink",
             spaceId: spaceId,
-            withEventProperties: [
-                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId
-            ]
+            withEventProperties: properties
         )
     }
     

--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -1212,6 +1212,10 @@ extension AnytypeAnalytics {
         logEvent("ScreenSlashMenu", withEventProperties: [AnalyticsEventsPropertiesKey.route: route.rawValue])
     }
     
+    func logClickSlashMenu(type: SlashMenuItemType) {
+        logEvent("ClickSlashMenu", withEventProperties: [AnalyticsEventsPropertiesKey.type: type.analyticsType])
+    }
+    
     func logKeyboardBarStyleMenu() {
         logEvent("KeyboardBarStyleMenu")
     }

--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -1208,8 +1208,8 @@ extension AnytypeAnalytics {
         logEvent("RelationUrlEditMobile")
     }
     
-    func logKeyboardBarSlashMenu() {
-        logEvent("KeyboardBarSlashMenu")
+    func logScreenSlashMenu(route: ScreenSlashMenuRoute) {
+        logEvent("ScreenSlashMenu", withEventProperties: [AnalyticsEventsPropertiesKey.route: route.rawValue])
     }
     
     func logKeyboardBarStyleMenu() {

--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -48,17 +48,25 @@ extension AnytypeAnalytics {
         )
     }
     
-    func logChangeBlockStyle(_ style: BlockText.Style) {
+    func logChangeBlockStyle(_ style: BlockText.Style, route: AnalyticsEventsRouteKind? = nil) {
+        var properties = [AnalyticsEventsPropertiesKey.blockStyle: style.analyticsValue]
+        if let route = route {
+            properties[AnalyticsEventsPropertiesKey.route] = route.rawValue
+        }
         logEvent(
             "ChangeBlockStyle",
-            withEventProperties: [AnalyticsEventsPropertiesKey.blockStyle: style.analyticsValue]
+            withEventProperties: properties
         )
     }
 
-    func logChangeBlockStyle(_ markupType: MarkupType) {
+    func logChangeBlockStyle(_ markupType: MarkupType, route: AnalyticsEventsRouteKind? = nil) {
+        var properties = [AnalyticsEventsPropertiesKey.type: markupType.analyticsValue]
+        if let route = route {
+            properties[AnalyticsEventsPropertiesKey.route] = route.rawValue
+        }
         logEvent(
             "ChangeBlockStyle",
-            withEventProperties: [AnalyticsEventsPropertiesKey.type: markupType.analyticsValue]
+            withEventProperties: properties
         )
     }
 
@@ -176,13 +184,16 @@ extension AnytypeAnalytics {
                  withEventProperties: [AnalyticsEventsPropertiesKey.layout: layout.rawValue])
     }
 
-    func logSetAlignment(_ alignment: LayoutAlignment, isBlock: Bool) {
+    func logSetAlignment(_ alignment: LayoutAlignment, isBlock: Bool, route: AnalyticsEventsRouteKind? = nil) {
+        var properties = [AnalyticsEventsPropertiesKey.align: alignment.analyticsValue]
+        if let route = route {
+            properties[AnalyticsEventsPropertiesKey.route] = route.rawValue
+        }
+        
         if isBlock {
-            logEvent("ChangeBlockAlign",
-                     withEventProperties: [AnalyticsEventsPropertiesKey.align: alignment.analyticsValue])
+            logEvent("ChangeBlockAlign", withEventProperties: properties)
         } else {
-            logEvent("SetLayoutAlign",
-                     withEventProperties: [AnalyticsEventsPropertiesKey.align: alignment.analyticsValue])
+            logEvent("SetLayoutAlign", withEventProperties: properties)
         }
     }
     
@@ -758,10 +769,12 @@ extension AnytypeAnalytics {
         logEvent("MoveBlock")
     }
     
-    func logChangeBlockBackground(color: MiddlewareColor) {
-        logEvent("ChangeBlockBackground", withEventProperties: [
-            AnalyticsEventsPropertiesKey.color: color.rawValue
-        ])
+    func logChangeBlockBackground(color: MiddlewareColor, route: AnalyticsEventsRouteKind? = nil) {
+        var properties = [AnalyticsEventsPropertiesKey.color: color.rawValue]
+        if let route = route {
+            properties[AnalyticsEventsPropertiesKey.route] = route.rawValue
+        }
+        logEvent("ChangeBlockBackground", withEventProperties: properties)
     }
     
     func logScreenSettingsStorageIndex() {

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewStateManager.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewStateManager.swift
@@ -278,6 +278,7 @@ final class AccessoryViewStateManagerImpl: AccessoryViewStateManager, CursorMode
 
         if textBeforeCaret.hasSuffix(TextTriggerSymbols.slashMenu) && configuration.usecase != .simpleTable {
             showSlashMenuView()
+            AnytypeAnalytics.instance().logScreenSlashMenu(route: .slash)
         } else if textBeforeCaret.hasSuffix(TextTriggerSymbols.mention(prependSpace: prependSpace)) {
             showMentionsView()
         } else {
@@ -449,7 +450,7 @@ extension AccessoryViewStateManagerImpl {
     private func logEvent(for action: CursorModeAccessoryViewAction) {
         switch action {
         case .slashMenu:
-            AnytypeAnalytics.instance().logKeyboardBarSlashMenu()
+            AnytypeAnalytics.instance().logScreenSlashMenu(route: .keyboardBar)
         case .keyboardDismiss:
             AnytypeAnalytics.instance().logKeyboardBarHideKeyboardMenu()
         case .showStyleMenu:

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Handler/SlashMenuActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Handler/SlashMenuActionHandler.swift
@@ -60,7 +60,7 @@ final class SlashMenuActionHandler {
                 }
             case .objectType(let object):
                 let spaceId = document.spaceId
-                AnytypeAnalytics.instance().logCreateLink(spaceId: spaceId, objectType: object.objectType.analyticsType)
+                AnytypeAnalytics.instance().logCreateLink(spaceId: spaceId, objectType: object.objectType.analyticsType, route: .slashMenu)
                 try await actionHandler
                     .createPage(
                         targetId: blockInformation.id,
@@ -69,7 +69,7 @@ final class SlashMenuActionHandler {
                         templateId: object.defaultTemplateId
                     )
                     .flatMap { objectId in
-                        AnytypeAnalytics.instance().logCreateObject(objectType: object.analyticsType, spaceId: object.spaceId, route: .powertool)
+                        AnytypeAnalytics.instance().logCreateObject(objectType: object.analyticsType, spaceId: object.spaceId, route: .slashMenu)
                         router.showEditorScreen(data: .editor(editorScreenData(objectId: objectId, objectDetails: object)))
                     }
             }
@@ -85,7 +85,8 @@ final class SlashMenuActionHandler {
                         isNew: isNew,
                         type: .block,
                         key: relation.analyticsKey,
-                        spaceId: spaceId
+                        spaceId: spaceId,
+                        route: .slashMenu
                     )
                 }
             case .relation(let relation):

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Handler/SlashMenuActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Handler/SlashMenuActionHandler.swift
@@ -109,7 +109,7 @@ final class SlashMenuActionHandler {
         case let .color(color):
             actionHandler.setTextColor(color, blockIds: [blockInformation.id])
         case let .background(color):
-            actionHandler.setBackgroundColor(color, blockIds: [blockInformation.id])
+            actionHandler.setBackgroundColor(color, blockIds: [blockInformation.id], route: .slashMenu)
         }
     }
     
@@ -134,7 +134,7 @@ final class SlashMenuActionHandler {
     }
     
     private func handleAlignment(_ alignment: SlashActionAlignment, blockIds: [String]) {
-        actionHandler.setAlignment(alignment.blockAlignment, blockIds: blockIds)
+        actionHandler.setAlignment(alignment.blockAlignment, blockIds: blockIds, route: .slashMenu)
     }
     
     private func handleStyle(
@@ -145,30 +145,31 @@ final class SlashMenuActionHandler {
     ) async throws {
         switch style {
         case .text:
-            try await actionHandler.turnInto(.text, blockId: blockInformation.id)
+            try await actionHandler.turnInto(.text, blockId: blockInformation.id, route: .slashMenu)
         case .title:
-            try await actionHandler.turnInto(.header, blockId: blockInformation.id)
+            try await actionHandler.turnInto(.header, blockId: blockInformation.id, route: .slashMenu)
         case .heading:
-            try await actionHandler.turnInto(.header2, blockId: blockInformation.id)
+            try await actionHandler.turnInto(.header2, blockId: blockInformation.id, route: .slashMenu)
         case .subheading:
-            try await actionHandler.turnInto(.header3, blockId: blockInformation.id)
+            try await actionHandler.turnInto(.header3, blockId: blockInformation.id, route: .slashMenu)
         case .highlighted:
-            try await actionHandler.turnInto(.quote, blockId: blockInformation.id)
+            try await actionHandler.turnInto(.quote, blockId: blockInformation.id, route: .slashMenu)
         case .callout:
-            try await actionHandler.turnInto(.callout, blockId: blockInformation.id)
+            try await actionHandler.turnInto(.callout, blockId: blockInformation.id, route: .slashMenu)
         case .checkbox:
-            try await actionHandler.turnInto(.checkbox, blockId: blockInformation.id)
+            try await actionHandler.turnInto(.checkbox, blockId: blockInformation.id, route: .slashMenu)
         case .bulleted:
-            try await actionHandler.turnInto(.bulleted, blockId: blockInformation.id)
+            try await actionHandler.turnInto(.bulleted, blockId: blockInformation.id, route: .slashMenu)
         case .numberedList:
-            try await actionHandler.turnInto(.numbered, blockId: blockInformation.id)
+            try await actionHandler.turnInto(.numbered, blockId: blockInformation.id, route: .slashMenu)
         case .toggle:
-            try await actionHandler.turnInto(.toggle, blockId: blockInformation.id)
+            try await actionHandler.turnInto(.toggle, blockId: blockInformation.id, route: .slashMenu)
         case .bold:
             let modifiedAttributedString = try await actionHandler.toggleWholeBlockMarkup(
                 attributedString,
                 markup: .bold,
-                info: blockInformation
+                info: blockInformation,
+                route: .slashMenu
             )
             
             modifiedAttributedString.map(modifiedStringHandler)
@@ -176,7 +177,8 @@ final class SlashMenuActionHandler {
             let modifiedAttributedString = try await actionHandler.toggleWholeBlockMarkup(
                 attributedString,
                 markup: .italic,
-                info: blockInformation
+                info: blockInformation,
+                route: .slashMenu
             )
             
             modifiedAttributedString.map(modifiedStringHandler)
@@ -184,7 +186,8 @@ final class SlashMenuActionHandler {
             let modifiedAttributedString = try await actionHandler.toggleWholeBlockMarkup(
                 attributedString,
                 markup: .strikethrough,
-                info: blockInformation
+                info: blockInformation,
+                route: .slashMenu
             )
             
             modifiedAttributedString.map(modifiedStringHandler)
@@ -192,7 +195,8 @@ final class SlashMenuActionHandler {
             let modifiedAttributedString = try await actionHandler.toggleWholeBlockMarkup(
                 attributedString,
                 markup: .underscored,
-                info: blockInformation
+                info: blockInformation,
+                route: .slashMenu
             )
             
             modifiedAttributedString.map(modifiedStringHandler)
@@ -200,7 +204,8 @@ final class SlashMenuActionHandler {
             let modifiedAttributedString = try await actionHandler.toggleWholeBlockMarkup(
                 attributedString,
                 markup: .keyboard,
-                info: blockInformation
+                info: blockInformation,
+                route: .slashMenu
             )
             
             modifiedAttributedString.map(modifiedStringHandler)

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Models/SlashMenuItemType.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Models/SlashMenuItemType.swift
@@ -74,4 +74,27 @@ enum SlashMenuItemType: Sendable {
     var displayData: SlashMenuItemDisplayData {
         SlashMenuItemDisplayData(iconData: iconName, title: self.title)
     }
+    
+    var analyticsType: String {
+        switch self {
+        case .style:
+            return "Style"
+        case .media:
+            return "Media"
+        case .objects:
+            return "Objects"
+        case .relations:
+            return "Properties"
+        case .other:
+            return "Other"
+        case .actions:
+            return "Actions"
+        case .color:
+            return "Color"
+        case .background:
+            return "Background"
+        case .alignment:
+            return "Alignment"
+        }
+    }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/TableView/SlashMenuViewController+TableView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/TableView/SlashMenuViewController+TableView.swift
@@ -28,6 +28,8 @@ extension SlashMenuViewController: UITableViewDelegate {
         switch cellData[indexPath.row] {
         case let .menu(type, children):
             guard !children.isEmpty else { return }
+            
+            AnytypeAnalytics.instance().logClickSlashMenu(type: type)
 
             let childCellData: [SlashMenuCellData] = children.map { .action($0) }
             

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandler.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandler.swift
@@ -43,7 +43,7 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
         try await service.turnIntoObject(blockId: blockId, spaceId: document.spaceId)
     }
     
-    func turnInto(_ style: BlockText.Style, blockId: String) async throws {
+    func turnInto(_ style: BlockText.Style, blockId: String, route: AnalyticsEventsRouteKind?) async throws {
         switch style {
         case .toggle:
             if let blockInformation = document.infoContainer.get(id: blockId),
@@ -54,7 +54,7 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
         default:
             try await service.turnInto(style, blockId: blockId)
         }
-        AnytypeAnalytics.instance().logChangeBlockStyle(style)
+        AnytypeAnalytics.instance().logChangeBlockStyle(style, route: route)
     }
     
     func upload(blockId: String, filePath: String) async throws {
@@ -95,8 +95,8 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
         }
     }
     
-    func setBackgroundColor(_ color: BlockBackgroundColor, blockIds: [String]) {
-        AnytypeAnalytics.instance().logChangeBlockBackground(color: color.middleware)
+    func setBackgroundColor(_ color: BlockBackgroundColor, blockIds: [String], route: AnalyticsEventsRouteKind?) {
+        AnytypeAnalytics.instance().logChangeBlockBackground(color: color.middleware, route: route)
         service.setBackgroundColor(blockIds: blockIds, color: color)
     }
     
@@ -120,8 +120,8 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
         }
     }
     
-    func setAlignment(_ alignment: LayoutAlignment, blockIds: [String]) {
-        AnytypeAnalytics.instance().logSetAlignment(alignment, isBlock: blockIds.isNotEmpty)
+    func setAlignment(_ alignment: LayoutAlignment, blockIds: [String], route: AnalyticsEventsRouteKind?) {
+        AnytypeAnalytics.instance().logSetAlignment(alignment, isBlock: blockIds.isNotEmpty, route: route)
         Task {
             try await blockService.setAlign(objectId: document.objectId, blockIds: blockIds, alignment: alignment)
         }
@@ -160,9 +160,9 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
         }
     }
     
-    func changeMarkup(blockIds: [String], markType: MarkupType) {
+    func changeMarkup(blockIds: [String], markType: MarkupType, route: AnalyticsEventsRouteKind?) {
         Task {
-            AnytypeAnalytics.instance().logChangeBlockStyle(markType)
+            AnytypeAnalytics.instance().logChangeBlockStyle(markType, route: route)
             try await blockService.changeMarkup(objectId: document.objectId, blockIds: blockIds, markType: markType)
         }
     }
@@ -171,9 +171,12 @@ final class BlockActionHandler: BlockActionHandlerProtocol, Sendable {
     func toggleWholeBlockMarkup(
         _ attributedString: SafeNSAttributedString?,
         markup: MarkupType,
-        info: BlockInformation
+        info: BlockInformation,
+        route: AnalyticsEventsRouteKind?
     ) async throws -> SafeNSAttributedString? {
         guard let textContent = info.textContent, let attributedString else { return nil }
+        AnytypeAnalytics.instance().logChangeBlockStyle(markup, route: route)
+        
         let changedAttributedString = markupChanger.toggleMarkup(
             attributedString.value,
             markup: markup,

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandlerProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionHandlerProtocol.swift
@@ -6,28 +6,29 @@ import UIKit
 
 @MainActor
 protocol BlockActionHandlerProtocol: AnyObject, Sendable {
-    func turnInto(_ style: BlockText.Style, blockId: String) async throws
+    func turnInto(_ style: BlockText.Style, blockId: String, route: AnalyticsEventsRouteKind?) async throws
     @discardableResult
     func turnIntoObject(blockId: String) async throws -> String?
     
     func setTextColor(_ color: BlockColor, blockIds: [String])
-    func setBackgroundColor(_ color: BlockBackgroundColor, blockIds: [String])
+    func setBackgroundColor(_ color: BlockBackgroundColor, blockIds: [String], route: AnalyticsEventsRouteKind?)
     func duplicate(blockId: String)
     func fetch(url: AnytypeURL, blockId: String) async throws
     func checkbox(selected: Bool, blockId: String)
     func toggle(blockId: String)
-    func setAlignment(_ alignment: LayoutAlignment, blockIds: [String])
+    func setAlignment(_ alignment: LayoutAlignment, blockIds: [String], route: AnalyticsEventsRouteKind?)
     func delete(blockIds: [String])
     func moveToPage(blockIds: [String], pageId: String) async throws
     func createEmptyBlock(parentId: String)
     func addLink(targetDetails: ObjectDetails, blockId: String)
-    func changeMarkup(blockIds: [String], markType: MarkupType)
+    func changeMarkup(blockIds: [String], markType: MarkupType, route: AnalyticsEventsRouteKind?)
     @discardableResult
     func addBlock(_ type: BlockContentType, blockId: String, blockText: SafeNSAttributedString?, position: BlockPosition?) async throws -> String
     func toggleWholeBlockMarkup(
         _ attributedString: SafeNSAttributedString?,
         markup: MarkupType,
-        info: BlockInformation
+        info: BlockInformation,
+        route: AnalyticsEventsRouteKind?
     ) async throws -> SafeNSAttributedString?
     func upload(blockId: String, filePath: String) async throws
     func createPage(targetId: String, spaceId: String, typeUniqueKey: ObjectTypeUniqueKey, templateId: String) async throws -> String?
@@ -68,5 +69,29 @@ extension BlockActionHandlerProtocol {
     @discardableResult
     func addBlock(_ type: BlockContentType, blockId: String, blockText: SafeNSAttributedString? = nil) async throws -> String {
         try await addBlock(type, blockId: blockId, blockText: blockText, position: nil)
+    }
+    
+    func turnInto(_ style: BlockText.Style, blockId: String) async throws {
+        try await turnInto(style, blockId: blockId, route: nil)
+    }
+    
+    func setBackgroundColor(_ color: BlockBackgroundColor, blockIds: [String]) {
+        setBackgroundColor(color, blockIds: blockIds, route: nil)
+    }
+    
+    func setAlignment(_ alignment: LayoutAlignment, blockIds: [String]) {
+        setAlignment(alignment, blockIds: blockIds, route: nil)
+    }
+    
+    func changeMarkup(blockIds: [String], markType: MarkupType) {
+        changeMarkup(blockIds: blockIds, markType: markType, route: nil)
+    }
+    
+    func toggleWholeBlockMarkup(
+        _ attributedString: SafeNSAttributedString?,
+        markup: MarkupType,
+        info: BlockInformation
+    ) async throws -> SafeNSAttributedString? {
+        return try await toggleWholeBlockMarkup(attributedString, markup: markup, info: info, route: nil)
     }
 }

--- a/AnytypeTests/Markdown/Mocks/BlockActionHandlerMock.swift
+++ b/AnytypeTests/Markdown/Mocks/BlockActionHandlerMock.swift
@@ -9,7 +9,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
     var turnIntoStub = false
     var turnIntoNumberOfCalls = 0
     var turnIntoStyleFromLastCall: BlockText.Style?
-    func turnInto(_ style: BlockText.Style, blockId: String) {
+    func turnInto(_ style: BlockText.Style, blockId: String, route: AnalyticsEventsRouteKind?) async throws {
         if turnIntoStub {
             turnIntoNumberOfCalls += 1
             turnIntoStyleFromLastCall = style
@@ -22,7 +22,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
     
-    func turnIntoObject(blockId: String) -> String? {
+    func turnIntoObject(blockId: String) async throws -> String? {
         assertionFailure()
         return nil
     }
@@ -31,7 +31,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
 
-    func setBackgroundColor(_ color: BlockBackgroundColor, blockIds: [String]) {
+    func setBackgroundColor(_ color: BlockBackgroundColor, blockIds: [String], route: AnalyticsEventsRouteKind?) {
         assertionFailure()
     }
     
@@ -55,7 +55,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
     
-    func setAlignment(_ alignment: LayoutAlignment, blockIds: [String]) {
+    func setAlignment(_ alignment: LayoutAlignment, blockIds: [String], route: AnalyticsEventsRouteKind?) {
         assertionFailure()
     }
     
@@ -100,12 +100,12 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         return ""
     }
     
-    func toggleWholeBlockMarkup(_ attributedString: SafeNSAttributedString?, markup: MarkupType, info: BlockInformation) -> SafeNSAttributedString? {
+    func toggleWholeBlockMarkup(_ attributedString: SafeNSAttributedString?, markup: MarkupType, info: BlockInformation, route: AnalyticsEventsRouteKind?) async throws -> SafeNSAttributedString? {
         assertionFailure()
         return nil
     }
     
-    func upload(blockId: String, filePath: String) {
+    func upload(blockId: String, filePath: String) async throws {
         assertionFailure()
     }
     
@@ -130,7 +130,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         }
     }
     
-    func changeText(_ text: SafeNSAttributedString, blockId: String) {
+    func changeText(_ text: SafeNSAttributedString, blockId: String) async throws {
         assertionFailure()
     }
     
@@ -174,7 +174,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
 
-    func createAndFetchBookmark(targetID: String, position: BlockPosition, url: AnytypeURL) {
+    func createAndFetchBookmark(targetID: String, position: BlockPosition, url: AnytypeURL) async throws {
         assertionFailure()
     }
 
@@ -194,7 +194,7 @@ final class BlockActionHandlerMock: BlockActionHandlerProtocol {
         assertionFailure()
     }
     
-    func changeMarkup(blockIds: [String], markType: MarkupType) {
+    func changeMarkup(blockIds: [String], markType: MarkupType, route: AnalyticsEventsRouteKind?) {
         assertionFailure()
     }
     


### PR DESCRIPTION
## Summary
- Added `ScreenSlashMenu` analytics event with route tracking ('Slash' vs 'KeyboardBar')
- Added `ClickSlashMenu` analytics event with type parameter for slash menu categories
- Added route parameter to block action analytics events to track origin (SlashMenu route)
- Enhanced analytics tracking throughout the slash menu call chain

## Key Changes
- **Analytics Events**: Added `ScreenSlashMenu` and `ClickSlashMenu` events
- **Route Tracking**: Block actions from slash menu now include `route: .slashMenu`
- **Call Chain**: Updated `BlockActionHandler` methods to accept optional route parameter
- **Backward Compatibility**: Extension methods maintain existing API for other call sites

## Analytics Coverage
- Slash menu opens (keyboard bar vs typing '/')
- Menu category clicks (Style, Media, Objects, Properties, etc.)
- Block style changes from slash menu
- Block background changes from slash menu  
- Block alignment changes from slash menu
- Object creation from slash menu
- Relation creation from slash menu