### PR TITLE
IOS-4898 Add PublishingService for managing object publishing

### DIFF
--- a/Modules/Services/Sources/Services/Publishing/Models/PublishingModels.swift
+++ b/Modules/Services/Sources/Services/Publishing/Models/PublishingModels.swift
@@ -1,0 +1,47 @@
+import Foundation
+import ProtobufMessages
+
+
+public struct PublishState: Sendable {
+    public let spaceId: String
+    public let objectId: String
+    public let uri: String
+    public let status: PublishStatus
+    public let version: String
+    public let timestamp: Date
+    public let size: Int64
+    public let joinSpace: Bool
+    
+    init(from protobuf: Anytype_Rpc.Publishing.PublishState) {
+        self.spaceId = protobuf.spaceID
+        self.objectId = protobuf.objectID
+        self.uri = protobuf.uri
+        self.status = PublishStatus(from: protobuf.status)
+        self.version = protobuf.version
+        self.timestamp = Date(timeIntervalSince1970: TimeInterval(protobuf.timestamp))
+        self.size = protobuf.size
+        self.joinSpace = protobuf.joinSpace
+    }
+}
+
+public enum PublishStatus: Sendable {
+    case created
+    case published
+    case unknown
+    
+    init(from protobuf: Anytype_Rpc.Publishing.PublishStatus) {
+        switch protobuf {
+        case .created:
+            self = .created
+        case .published:
+            self = .published
+        case .UNRECOGNIZED:
+            self = .unknown
+        }
+    }
+}
+
+public enum PublishingServiceError: Error {
+    case invalidUriFormat
+    case publishingFailed(String)
+}

--- a/Modules/Services/Sources/Services/Publishing/PublishingService.swift
+++ b/Modules/Services/Sources/Services/Publishing/PublishingService.swift
@@ -1,0 +1,59 @@
+import ProtobufMessages
+import Foundation
+import AnytypeCore
+
+public protocol PublishingServiceProtocol: Sendable {
+    func create(spaceId: String, objectId: String, uri: String, joinSpace: Bool) async throws -> String
+    func remove(spaceId: String, objectId: String) async throws
+    func list(spaceId: String) async throws -> [PublishState]
+    func resolveUri(uri: String) async throws -> PublishState
+    func getStatus(spaceId: String, objectId: String) async throws -> PublishState
+}
+
+public final class PublishingService: PublishingServiceProtocol {
+    
+    public init() {}
+    
+    public func create(spaceId: String, objectId: String, uri: String, joinSpace: Bool) async throws -> String {
+        let response = try await ClientCommands.publishingCreate(.with {
+            $0.spaceID = spaceId
+            $0.objectID = objectId
+            $0.uri = uri
+            $0.joinSpace = joinSpace
+        }).invoke(ignoreLogErrors: .badInput, .noSuchObject, .noSuchSpace, .limitExceeded, .urlAlreadyTaken)
+        
+        return response.uri
+    }
+    
+    public func remove(spaceId: String, objectId: String) async throws {
+        try await ClientCommands.publishingRemove(.with {
+            $0.spaceID = spaceId
+            $0.objectID = objectId
+        }).invoke(ignoreLogErrors: .badInput, .noSuchObject, .noSuchSpace)
+    }
+    
+    public func list(spaceId: String) async throws -> [PublishState] {
+        let response = try await ClientCommands.publishingList(.with {
+            $0.spaceID = spaceId
+        }).invoke(ignoreLogErrors: .badInput, .noSuchSpace)
+        
+        return response.publishes.map { PublishState(from: $0) }
+    }
+    
+    public func resolveUri(uri: String) async throws -> PublishState {
+        let response = try await ClientCommands.publishingResolveUri(.with {
+            $0.uri = uri
+        }).invoke(ignoreLogErrors: .badInput, .noSuchUri)
+        
+        return PublishState(from: response.publish)
+    }
+    
+    public func getStatus(spaceId: String, objectId: String) async throws -> PublishState {
+        let response = try await ClientCommands.publishingGetStatus(.with {
+            $0.spaceID = spaceId
+            $0.objectID = objectId
+        }).invoke(ignoreLogErrors: .badInput, .noSuchObject, .noSuchSpace)
+        
+        return PublishState(from: response.publish)
+    }
+}

--- a/Modules/Services/Sources/ServicesDI.swift
+++ b/Modules/Services/Sources/ServicesDI.swift
@@ -169,4 +169,8 @@ public extension Container {
     var basicUserInfoStorage: Factory<BasicUserInfoStorageProtocol> {
         self { BasicUserInfoStorage() }.singleton
     }
+    
+    var publishingService: Factory<PublishingServiceProtocol> {
+        self { PublishingService() }.shared
+    }
 }


### PR DESCRIPTION
## Summary
- Added PublishingService with methods for creating, removing, listing, resolving, and getting status of published objects
- Created PublishingModels with PublishState, PublishStatus, and PublishingServiceError types
- Added PublishingService to dependency injection container