### PR TITLE
IOS-4932 Chat | MessageTextBuilder | remove assert

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageTextBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageTextBuilder.swift
@@ -35,7 +35,6 @@ struct MessageTextBuilder: MessageTextBuilderProtocol, Sendable {
         for mark in content.marks.reversed() {
             let nsRange = NSRange(mark.range)
             guard let range = Range(nsRange, in: message) else {
-                anytypeAssertionFailure("Out of range", info: ["range": nsRange.description, "textLenght": content.text.count.description])
                 continue
             }
             


### PR DESCRIPTION
There is no verification on the middle. 
Some client is incorrect working with mentions. There's no point in sending an assertion, there's nothing we can do about it.

I asked the middle to add a check on their side.