### PR TITLE
IOS-4908 Add long tap context menu to publishing preview

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/PublishToWebCoordinator/PublishToWebCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/PublishToWebCoordinator/PublishToWebCoordinator.swift
@@ -13,5 +13,9 @@ struct PublishToWebCoordinator: View {
             .sheet(isPresented: $model.showMembership) {
                 MembershipCoordinator()
             }
+            .sheet(item: $model.sharedUrl) { url in
+                ActivityView(activityItems: [url])
+            }
+            .safariSheet(url: $model.safariUrl)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Flows/PublishToWebCoordinator/PublishToWebCoordinatorModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/PublishToWebCoordinator/PublishToWebCoordinatorModel.swift
@@ -1,15 +1,20 @@
 import Foundation
 import SwiftUI
+import UIKit
 
 @MainActor
 protocol PublishToWebModuleOutput: AnyObject {
     func onShowMembership()
+    func onSharePreview(url: URL)
+    func onOpenPreview(url: URL)
 }
 
 @MainActor
 final class PublishToWebCoordinatorModel: ObservableObject, PublishToWebModuleOutput {
     
     @Published var showMembership = false
+    @Published var sharedUrl: URL?
+    @Published var safariUrl: URL?
     
     let data: PublishToWebViewData
     
@@ -21,5 +26,13 @@ final class PublishToWebCoordinatorModel: ObservableObject, PublishToWebModuleOu
     
     func onShowMembership() {
         showMembership = true
+    }
+    
+    func onSharePreview(url: URL) {
+        sharedUrl = url
+    }
+    
+    func onOpenPreview(url: URL) {
+        safariUrl = url
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/Builder/PublishedUrlBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/Builder/PublishedUrlBuilder.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Factory
+
+protocol PublishedUrlBuilderProtocol {
+    func buildPublishedUrl(domain: DomainType, customPath: String) -> URL?
+}
+
+struct PublishedUrlBuilder: PublishedUrlBuilderProtocol {
+    
+    func buildPublishedUrl(domain: DomainType, customPath: String) -> URL? {
+        let domainUrl: String
+        switch domain {
+        case .paid(let url):
+            domainUrl = url
+        case .free(let url):
+            domainUrl = url
+        }
+        
+        // Parse the domain URL to separate host and existing path
+        let domainComponents = domainUrl.components(separatedBy: "/")
+        guard let host = domainComponents.first, !host.isEmpty else { return nil }
+        
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        
+        // Build the full path: existing domain path + custom path
+        var pathComponents: [String] = []
+        
+        // Add existing path from domain (everything after the first "/")
+        if domainComponents.count > 1 {
+            pathComponents.append(contentsOf: domainComponents.dropFirst())
+        }
+        
+        // Add custom path if provided
+        if !customPath.isEmpty {
+            let cleanCustomPath = customPath.hasPrefix("/") ? String(customPath.dropFirst()) : customPath
+            if !cleanCustomPath.isEmpty {
+                pathComponents.append(cleanCustomPath)
+            }
+        }
+        
+        // Set the full path
+        if !pathComponents.isEmpty {
+            components.path = "/" + pathComponents.joined(separator: "/")
+        }
+        
+        return components.url
+    }
+}
+
+extension Container {
+    var publishedUrlBuilder: Factory<any PublishedUrlBuilderProtocol> {
+        self { PublishedUrlBuilder() }.shared
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalView.swift
@@ -16,6 +16,7 @@ struct PublishToWebInternalView: View {
             .onChange(of: model.showJoinSpaceButton) { showJoin in
                 model.updatePreviewForJoinButton(showJoin)
             }
+            .snackbar(toastBarData: $model.toastBarData)
     }
     
     var content: some View {
@@ -41,7 +42,7 @@ struct PublishToWebInternalView: View {
             
             Spacer()
             
-            PublishingPreview(data: model.previewData)
+            PublishingPreview(data: model.previewData, isPublished: model.status.isNotNil, output: model)
                 .frame(maxWidth: .infinity)
             
             Spacer.fixedHeight(12)

--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalView.swift
@@ -174,7 +174,6 @@ struct PublishToWebInternalView: View {
                     style: .primaryLarge,
                     action: { try await model.onPublishTap() }
                 )
-                .disabled(!model.canPublish)
             }
             
             Spacer.fixedHeight(16)
@@ -190,7 +189,6 @@ struct PublishToWebInternalView: View {
                 style: .primaryLarge,
                 action: { try await model.onPublishTap() }
             )
-            .disabled(!model.canPublish)
             
             Spacer.fixedHeight(16)
         }

--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalViewModel.swift
@@ -6,7 +6,7 @@ import ProtobufMessages
 
 
 @MainActor
-final class PublishToWebInternalViewModel: ObservableObject {
+final class PublishToWebInternalViewModel: ObservableObject, PublishingPreviewOutput {
     
     @Published var customPath: String = ""
     @Published var showJoinSpaceButton: Bool = true
@@ -14,6 +14,7 @@ final class PublishToWebInternalViewModel: ObservableObject {
     
     @Published var error: String?
     @Published var previewData: PublishingPreviewData = .empty
+    @Published var toastBarData: ToastBarData?
     
     let domain: DomainType
     
@@ -23,6 +24,8 @@ final class PublishToWebInternalViewModel: ObservableObject {
     private var publishingService: any PublishingServiceProtocol
     @Injected(\.publishingPreviewBuilder)
     private var previewBuilder: any PublishingPreviewBuilderProtocol
+    @Injected(\.publishedUrlBuilder)
+    private var urlBuilder: any PublishedUrlBuilderProtocol
     
     private let spaceId: String
     private let objectId: String
@@ -67,5 +70,26 @@ final class PublishToWebInternalViewModel: ObservableObject {
         )
     }
     
+    // MARK: - PublishingPreviewOutput
+    
+    func onPreviewTap() {
+        guard let publishedUrl = urlBuilder.buildPublishedUrl(domain: domain, customPath: customPath) else { return }
+        output?.onOpenPreview(url: publishedUrl)
+    }
+    
+    func onPreviewOpenWebPage() {
+        guard let publishedUrl = urlBuilder.buildPublishedUrl(domain: domain, customPath: customPath) else { return }
+        output?.onOpenPreview(url: publishedUrl)
+    }
+    
+    func onPreviewShareLink() {
+        guard let publishedUrl = urlBuilder.buildPublishedUrl(domain: domain, customPath: customPath) else { return }
+        output?.onSharePreview(url: publishedUrl)
+    }
+    
+    func onPreviewCopyLink() {
+        guard let publishedUrl = urlBuilder.buildPublishedUrl(domain: domain, customPath: customPath) else { return }
+        UIPasteboard.general.string = publishedUrl.absoluteString
+        toastBarData = ToastBarData(Loc.copiedToClipboard(Loc.link))
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalViewModel.swift
@@ -10,7 +10,6 @@ final class PublishToWebInternalViewModel: ObservableObject {
     
     @Published var customPath: String = ""
     @Published var showJoinSpaceButton: Bool = true
-    @Published var canPublish: Bool = true
     @Published var status: PublishState?
     
     @Published var error: String?
@@ -43,8 +42,6 @@ final class PublishToWebInternalViewModel: ObservableObject {
             spaceName: data.spaceName,
             showJoinButton: showJoinSpaceButton
         )
-        
-        setupBindings()
     }
     
     func onPublishTap() async throws {
@@ -70,9 +67,5 @@ final class PublishToWebInternalViewModel: ObservableObject {
         )
     }
     
-    private func setupBindings() {
-        $customPath
-            .map { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-            .assign(to: &$canPublish)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/View/PublishingPreview.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/View/PublishingPreview.swift
@@ -86,7 +86,7 @@ struct PublishingPreview: View {
     private var joinButton: some View {
         HStack(spacing: 4) {
             AnytypeText(Loc.join, style: .caption2Medium)
-                .foregroundColor(.Text.white)
+                .foregroundColor(.Text.primary)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 2.5)

--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/View/PublishingPreview.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/View/PublishingPreview.swift
@@ -1,9 +1,20 @@
 import SwiftUI
 import Services
 import AnytypeCore
+import Loc
+
+@MainActor
+protocol PublishingPreviewOutput: AnyObject {
+    func onPreviewTap()
+    func onPreviewOpenWebPage()
+    func onPreviewShareLink()
+    func onPreviewCopyLink()
+}
 
 struct PublishingPreview: View {
     let data: PublishingPreviewData
+    let isPublished: Bool
+    weak var output: (any PublishingPreviewOutput)?
     @State private var screenSize: CGSize = .zero
     
     var body: some View {
@@ -30,6 +41,15 @@ struct PublishingPreview: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(Color.Shape.secondary, lineWidth: 1)
         )
+        .if(isPublished) { view in
+            view
+                .onTapGesture {
+                    output?.onPreviewTap()
+                }
+                .contextMenu {
+                    contextMenuContent
+                }
+        }
     }
     
     private var browserHeader: some View {
@@ -86,7 +106,7 @@ struct PublishingPreview: View {
     private var joinButton: some View {
         HStack(spacing: 4) {
             AnytypeText(Loc.join, style: .caption2Medium)
-                .foregroundColor(.Text.primary)
+                .foregroundColor(.Text.inversion)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 2.5)
@@ -173,6 +193,27 @@ struct PublishingPreview: View {
         .padding(.horizontal, 32)
         .padding(.top, 8)
     }
+    
+    @ViewBuilder
+    private var contextMenuContent: some View {
+        Button {
+            output?.onPreviewOpenWebPage()
+        } label: {
+            Label(Loc.openWebPage, systemImage: "arrow.up.forward.app")
+        }
+        
+        Button {
+            output?.onPreviewShareLink()
+        } label: {
+            Label(Loc.SpaceShare.Share.link, systemImage: "square.and.arrow.up")
+        }
+        
+        Button {
+            output?.onPreviewCopyLink()
+        } label: {
+            Label(Loc.Actions.copyLink, systemImage: "doc.on.doc")
+        }
+    }
 }
 
 #Preview {
@@ -191,7 +232,7 @@ struct PublishingPreview: View {
                     )),
                     icon: .emoji(Emoji("🎨")!),
                     showJoinButton: true
-                ))
+                ), isPublished: true, output: nil)
             }
             
             // Branch 2: Has cover but no icon
@@ -207,7 +248,7 @@ struct PublishingPreview: View {
                     )),
                     icon: nil,
                     showJoinButton: false
-                ))
+                ), isPublished: false, output: nil)
             }
             
             // Branch 3: No cover but has icon (white background)
@@ -220,7 +261,7 @@ struct PublishingPreview: View {
                     cover: nil,
                     icon: .emoji(Emoji("📝")!),
                     showJoinButton: true
-                ))
+                ), isPublished: true, output: nil)
             }
             
             // Branch 4: No cover and no icon (no cover section)
@@ -233,7 +274,7 @@ struct PublishingPreview: View {
                     cover: nil,
                     icon: nil,
                     showJoinButton: false
-                ))
+                ), isPublished: false, output: nil)
             }
         }
         .padding()

--- a/Anytype/Sources/PresentationLayer/Settings/PushNotifications/PushNotificationsSettingsView.swift
+++ b/Anytype/Sources/PresentationLayer/Settings/PushNotifications/PushNotificationsSettingsView.swift
@@ -66,7 +66,7 @@ struct PushNotificationsSettingsView: View {
         .padding(.horizontal, 4)
         .newDivider()
         .fixTappableArea()
-        .applyIf(!enabled) {
+        .if(!enabled) {
             $0.onTapGesture {
                 model.openSettings()
             }

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -244,7 +244,7 @@ public extension FeatureDescription {
     
     static let webPublishing = FeatureDescription(
         title: "Web Publishing",
-        type: .feature(author: "vyuignatiov@anytype.io", releaseVersion: "12"),
+        type: .feature(author: "vova@anytype.io", releaseVersion: "12"),
         defaultValue: false,
         debugValue: true
     )

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -305,6 +305,7 @@ public enum Loc {
   public static func openTypeError(_ p1: Any) -> String {
     return Loc.tr("Localizable", "Open Type Error", String(describing: p1), fallback: "Not supported type \"%@\". You can open it via desktop.")
   }
+  public static let openWebPage = Loc.tr("Localizable", "Open web page", fallback: "Open web page")
   public static let openSettings = Loc.tr("Localizable", "OpenSettings", fallback: "Open Settings")
   public static let other = Loc.tr("Localizable", "Other", fallback: "Other")
   public static let otherRelations = Loc.tr("Localizable", "Other relations", fallback: "Other properties")


### PR DESCRIPTION
## Summary
- Add context menu with Open web page, Share link, Copy link actions to publishing preview
- Only show interactive elements when content is published (status exists) 
- Extract URL building logic to separate PublishedUrlBuilder for better architecture
- Show toast notification when copying link to clipboard
- Handle navigation through coordinator for Safari and share actions