### PR TITLE
IOS-4936 Design update of space sharing buttons

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Text/Actions/TextPropertyCopyActionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Text/Actions/TextPropertyCopyActionViewModel.swift
@@ -51,7 +51,7 @@ private extension TextPropertyCopyActionViewModel.SupportedTextType {
         switch self {
         case .phone: return Loc.RelationAction.copyPhone
         case .email: return Loc.RelationAction.copyEmail
-        case .url: return Loc.RelationAction.copyLink
+        case .url: return Loc.copyLink
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/LinkToObject/LinkToObjectSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/LinkToObject/LinkToObjectSearchViewModel.swift
@@ -138,7 +138,7 @@ final class LinkToObjectSearchViewModel: ObservableObject {
             
             copyLink = LinkToObjectSearchData(
                 searchKind: .copyLink(url),
-                searchTitle: Loc.Editor.LinkToObject.copyLink,
+                searchTitle: Loc.copyLink,
                 iconImage: .asset(.TextEditor.BlocksOption.copy)
             )
         } else if let blockId = data.currentLinkString {

--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/View/PublishingPreview.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/View/PublishingPreview.swift
@@ -211,7 +211,7 @@ struct PublishingPreview: View {
         Button {
             output?.onPreviewCopyLink()
         } label: {
-            Label(Loc.Actions.copyLink, systemImage: "doc.on.doc")
+            Label(Loc.copyLink, systemImage: "doc.on.doc")
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceProfile/SpaceProfileView.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceProfile/SpaceProfileView.swift
@@ -81,41 +81,45 @@ struct SpaceProfileView: View {
         if model.inviteLink.isNotNil {
             Spacer.fixedHeight(8)
             
-            HStack(spacing: 8) {
+            HStack(spacing: 24) {
                 Button {
                     model.onInviteTap()
                 } label: {
-                    HStack {
-                        Spacer()
-                        VStack(spacing: 0) {
-                            Image(asset: .X32.Island.addMember)
-                                .foregroundStyle(Color.Text.primary)
-                                .frame(width: 32, height: 32)
-                            AnytypeText(Loc.invite, style: .caption1Regular)
-                        }
-                        .padding(.vertical, 14)
-                        Spacer()
-                    }
-                    .border(12, color: .Shape.primary, lineWidth: 0.5)
+                    inviteLinkActionView(asset: .X32.linkTo, title: Loc.SpaceShare.Share.link)
+                }
+                
+                Button {
+                    model.onCopyLinkTap()
+                } label: {
+                    inviteLinkActionView(asset: .X32.copy, title: Loc.copyLink)
                 }
                 
                 Button {
                     model.onQRCodeTap()
                 } label: {
-                    HStack {
-                        Spacer()
-                        VStack(spacing: 0) {
-                            Image(asset: .X32.qrCode)
-                                .foregroundStyle(Color.Text.primary)
-                                .frame(width: 32, height: 32)
-                            AnytypeText(Loc.qrCode, style: .caption1Regular)
-                        }
-                        .padding(.vertical, 14)
-                        Spacer()
-                    }
-                    .border(12, color: .Shape.primary, lineWidth: 0.5)
+                    inviteLinkActionView(asset: .X32.qrCode, title: Loc.qrCode)
                 }
             }.padding(.horizontal, 16)
+            
+            Spacer.fixedHeight(16)
+        }
+    }
+    
+    private func inviteLinkActionView(asset: ImageAsset, title: String) -> some View {
+        VStack(spacing: 0) {
+            VStack(spacing: 0) {
+                Image(asset: asset)
+                    .foregroundStyle(Color.Text.primary)
+                    .frame(width: 24, height: 24)
+            }
+            .padding(20)
+            .background(Color.Shape.transperentSecondary)
+            .cornerRadius(10)
+            
+            Spacer.fixedHeight(6)
+            
+            AnytypeText(title, style: .caption2Regular)
+                .foregroundColor(.Text.primary)
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceProfile/SpaceProfileViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceProfile/SpaceProfileViewModel.swift
@@ -73,6 +73,12 @@ final class SpaceProfileViewModel: ObservableObject {
         shareInviteLink = inviteLink
     }
     
+    func onCopyLinkTap() {
+        guard let inviteLink else { return }
+        UIPasteboard.general.string = inviteLink.absoluteString
+        snackBarData = ToastBarData(Loc.copiedToClipboard(Loc.link), type: .success)
+    }
+    
     // MARK: - Private
     
     private func generateInviteIfPossible(spaceView: SpaceView) async {

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsView.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsView.swift
@@ -104,35 +104,46 @@ struct SpaceSettingsView: View {
         if model.inviteLink.isNotNil {
             Spacer.fixedHeight(24)
             
-            HStack(spacing: 8) {                
+            HStack(spacing: 24) {
                 Button {
                     model.onInviteTap()
                 } label: {
-                    borderedView(asset: .X32.Island.addMember, title: Loc.invite)
+                    inviteLinkActionView(asset: .X32.linkTo, title: Loc.SpaceShare.Share.link)
+                }
+                
+                Button {
+                    model.onCopyLinkTap()
+                } label: {
+                    inviteLinkActionView(asset: .X32.copy, title: Loc.copyLink)
                 }
                 
                 Button {
                     model.onQRCodeTap()
                 } label: {
-                    borderedView(asset: .X32.qrCode, title: Loc.qrCode)
+                    inviteLinkActionView(asset: .X32.qrCode, title: Loc.qrCode)
                 }
             }
+            
+            Spacer.fixedHeight(16)
         }
     }
     
-    private func borderedView(asset: ImageAsset, title: String) -> some View {
-        HStack {
-            Spacer()
+    private func inviteLinkActionView(asset: ImageAsset, title: String) -> some View {
+        VStack(spacing: 0) {
             VStack(spacing: 0) {
                 Image(asset: asset)
                     .foregroundStyle(Color.Text.primary)
-                    .frame(width: 32, height: 32)
-                AnytypeText(title, style: .caption1Regular)
+                    .frame(width: 24, height: 24)
             }
-            .padding(.vertical, 14)
-            Spacer()
+            .padding(20)
+            .background(Color.Shape.transperentSecondary)
+            .cornerRadius(10)
+            
+            Spacer.fixedHeight(6)
+            
+            AnytypeText(title, style: .caption2Regular)
+                .foregroundColor(.Text.primary)
         }
-        .border(16, color: .Shape.primary, lineWidth: 0.5)
     }
     
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
@@ -142,6 +142,15 @@ final class SpaceSettingsViewModel: ObservableObject {
         }
     }
     
+    func onCopyLinkTap() {
+        Task {
+            try await generateInviteIfNeeded()
+            guard let inviteLink else { return }
+            UIPasteboard.general.string = inviteLink.absoluteString
+            snackBarData = ToastBarData(Loc.copiedToClipboard(Loc.link), type: .success)
+        }
+    }
+    
     func onChangeIconTap() {
         showIconPickerSpaceId = workspaceInfo.accountSpaceId.identifiable
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionRow.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionRow.swift
@@ -70,7 +70,7 @@ private extension ObjectAction {
         case .createWidget:
             return Loc.Actions.CreateWidget.title
         case .copyLink:
-            return Loc.Actions.copyLink
+            return Loc.copyLink
         }
     }
 

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -101,6 +101,7 @@ public enum Loc {
     return Loc.tr("Localizable", "copied to clipboard", String(describing: p1), fallback: "%@ copied to clipboard")
   }
   public static let copy = Loc.tr("Localizable", "Copy", fallback: "Copy")
+  public static let copyLink = Loc.tr("Localizable", "Copy link", fallback: "Copy link")
   public static let copySpaceInfo = Loc.tr("Localizable", "Copy space info", fallback: "Copy space info")
   public static let cover = Loc.tr("Localizable", "Cover", fallback: "Cover")
   public static let create = Loc.tr("Localizable", "Create", fallback: "Create")
@@ -557,7 +558,6 @@ public enum Loc {
     }
   }
   public enum Actions {
-    public static let copyLink = Loc.tr("Localizable", "Actions.CopyLink", fallback: "Copy link")
     public static let linkItself = Loc.tr("Localizable", "Actions.LinkItself", fallback: "Link to")
     public static let makeAsTemplate = Loc.tr("Localizable", "Actions.MakeAsTemplate", fallback: "Make template")
     public static let templateMakeDefault = Loc.tr("Localizable", "Actions.TemplateMakeDefault", fallback: "Make default")
@@ -1043,7 +1043,6 @@ public enum Loc {
   }
   public enum Editor {
     public enum LinkToObject {
-      public static let copyLink = Loc.tr("Localizable", "Editor.LinkToObject.CopyLink", fallback: "Copy link")
       public static let linkedTo = Loc.tr("Localizable", "Editor.LinkToObject.LinkedTo", fallback: "Linked to")
       public static let pasteFromClipboard = Loc.tr("Localizable", "Editor.LinkToObject.PasteFromClipboard", fallback: "Paste from clipboard")
       public static let removeLink = Loc.tr("Localizable", "Editor.LinkToObject.RemoveLink", fallback: "Remove link")
@@ -1651,7 +1650,6 @@ public enum Loc {
     public static let callPhone = Loc.tr("Localizable", "RelationAction.CallPhone", fallback: "Call phone numbler")
     public static let copied = Loc.tr("Localizable", "RelationAction.Copied", fallback: "Copied")
     public static let copyEmail = Loc.tr("Localizable", "RelationAction.CopyEmail", fallback: "Copy email")
-    public static let copyLink = Loc.tr("Localizable", "RelationAction.CopyLink", fallback: "Copy link")
     public static let copyPhone = Loc.tr("Localizable", "RelationAction.CopyPhone", fallback: "Copy phone number")
     public static let openLink = Loc.tr("Localizable", "RelationAction.OpenLink", fallback: "Open link")
     public static let reloadContent = Loc.tr("Localizable", "RelationAction.ReloadContent", fallback: "Reload object content")


### PR DESCRIPTION
## Summary
- Updated space sharing section design to show 3 action buttons instead of 2
- Added new "Copy link" functionality alongside existing "Share link" and "QR code" options
- Applied consistent styling with rounded icon containers and improved spacing
- Updated both SpaceSettingsView and SpaceProfileView for design consistency

Icon for sharing will be updated when design team will update design system

https://github.com/user-attachments/assets/94a64864-9153-448a-a570-a9be0d7b2958

