### PR TITLE
IOS-4900 Add analytics events for publishing to web

### DIFF
--- a/Anytype/Sources/Analytics/AnalyticsConstants.swift
+++ b/Anytype/Sources/Analytics/AnalyticsConstants.swift
@@ -310,6 +310,7 @@ enum ClickUpgradePlanTooltipType: String {
     case members = "members"
     case editors = "editors"
     case sharedSpaces = "sharedSpaces"
+    case publish = "publish"
 }
 
 enum ClickUpgradePlanTooltipRoute: String {
@@ -317,6 +318,7 @@ enum ClickUpgradePlanTooltipRoute: String {
     case spaceSharing = "ScreenSettingsSpaceShare"
     case confirmInvite = "ScreenInviteConfirm"
     case remoteStorage = "ScreenRemoteStorage"
+    case publish = "ScreenPublish"
 }
 
 enum ChangeObjectTypeRoute: String {
@@ -428,4 +430,9 @@ enum ScreenSlashMenuRoute: String {
 enum UndoRedoResultType: String {
     case `true` = "True"
     case `false` = "False"
+}
+
+enum ShareObjectOpenPageRoute: String {
+    case menu = "Menu"
+    case notification = "Notification"
 }

--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -1587,4 +1587,108 @@ extension AnytypeAnalytics {
             logRemoveReaction()
         }
     }
+    
+    // MARK: - Publishing to Web
+    
+    func logClickShareObject(objectType: AnalyticsObjectType) {
+        logEvent(
+            "ClickShareObject",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId
+            ]
+        )
+    }
+    
+    func logClickShareObjectPublish(objectType: AnalyticsObjectType) {
+        logEvent(
+            "ClickShareObjectPublish",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId
+            ]
+        )
+    }
+    
+    func logClickShareObjectCopyUrl(objectType: AnalyticsObjectType) {
+        logEvent(
+            "ClickShareObjectCopyUrl",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId
+            ]
+        )
+    }
+    
+    func logJoinSpaceButtonToPublish(objectType: AnalyticsObjectType, type: Bool) {
+        logEvent(
+            "JoinSpaceButtonToPublish",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId,
+                AnalyticsEventsPropertiesKey.type: type
+            ]
+        )
+    }
+    
+    
+    func logShareObjectPublish(objectType: AnalyticsObjectType) {
+        logEvent(
+            "ShareObjectPublish",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId
+            ]
+        )
+    }
+    
+    func logClickShareObjectUnpublish(objectType: AnalyticsObjectType) {
+        logEvent(
+            "ClickShareObjectUnpublish",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId
+            ]
+        )
+    }
+    
+    func logShareObjectUnpublish(objectType: AnalyticsObjectType) {
+        logEvent(
+            "ShareObjectUnpublish",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId
+            ]
+        )
+    }
+    
+    func logClickShareObjectUpdate(objectType: AnalyticsObjectType) {
+        logEvent(
+            "ClickShareObjectUpdate",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId
+            ]
+        )
+    }
+    
+    func logShareObjectUpdate(objectType: AnalyticsObjectType) {
+        logEvent(
+            "ShareObjectUpdate",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId
+            ]
+        )
+    }
+    
+    func logClickShareObjectOpenPage(objectType: AnalyticsObjectType, route: ShareObjectOpenPageRoute) {
+        logEvent(
+            "ClickShareObjectOpenPage",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId,
+                AnalyticsEventsPropertiesKey.route: route.rawValue
+            ]
+        )
+    }
+    
+    func logClickShareObjectShareLink(objectType: AnalyticsObjectType) {
+        logEvent(
+            "ClickShareObjectShareLink",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.objectType: objectType.analyticsId
+            ]
+        )
+    }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalView.swift
@@ -173,7 +173,7 @@ struct PublishToWebInternalView: View {
                 AsyncStandardButton(
                     Loc.update,
                     style: .primaryLarge,
-                    action: { try await model.onPublishTap() }
+                    action: { try await model.onPublishTap(action: .update) }
                 )
             }
             
@@ -188,7 +188,7 @@ struct PublishToWebInternalView: View {
             AsyncStandardButton(
                 Loc.publish,
                 style: .primaryLarge,
-                action: { try await model.onPublishTap() }
+                action: { try await model.onPublishTap(action: .create) }
             )
             
             Spacer.fixedHeight(16)

--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/View/PublishingPreview.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/View/PublishingPreview.swift
@@ -5,7 +5,6 @@ import Loc
 
 @MainActor
 protocol PublishingPreviewOutput: AnyObject {
-    func onPreviewTap()
     func onPreviewOpenWebPage()
     func onPreviewShareLink()
     func onPreviewCopyLink()
@@ -44,7 +43,7 @@ struct PublishingPreview: View {
         .if(isPublished) { view in
             view
                 .onTapGesture {
-                    output?.onPreviewTap()
+                    output?.onPreviewOpenWebPage()
                 }
                 .contextMenu {
                     contextMenuContent

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
@@ -289,6 +289,10 @@ extension EditorPageViewModel {
     }
     
     func onPublishingBannerTap() {
+        if let details = document.details {
+            AnytypeAnalytics.instance().logClickShareObjectOpenPage(objectType: details.objectType.analyticsType, route: .notification)
+        }
+        
         guard let publishState else {
             anytypeAssertionFailure("Empty PublishState upon banner tap")
             return

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
@@ -103,6 +103,9 @@ final class ObjectSettingsViewModel: ObservableObject, ObjectActionsOutput {
     }
     
     func onTapPublishing() {
+        if let details = document.details {
+            AnytypeAnalytics.instance().logClickShareObject(objectType: details.objectType.analyticsType)
+        }
         output?.showPublising(document: document)
     }
     


### PR DESCRIPTION
## Summary
- Implemented all 12 analytics events from IOS-4900 for publish to web feature
- Track objectType for all events and differentiate create/update actions  
- Added route tracking for copy URL and open page actions