### PR TITLE
IOS-4947 Add NewSpaceMembersView with feature flag toggle

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/SpaceSettings/SpaceSettingsCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceSettings/SpaceSettingsCoordinatorView.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import Services
+import AnytypeCore
 
 struct SpaceSettingsCoordinator: View {
     let spaceId: String
@@ -49,8 +50,12 @@ fileprivate struct SpaceSettingInternalsCoordinator: View {
             .sheet(item: $model.showSpaceShareData) {
                 SpaceShareCoordinatorView(data: $0)
             }
-            .sheet(item: $model.showSpaceMembersData) {
-                SpaceMembersView(data: $0)
+            .sheet(item: $model.showSpaceMembersData) { data in
+                if FeatureFlags.newSpaceMembersFlow {
+                    NewSpaceMembersView(data: data)
+                } else {
+                    SpaceMembersView(data: data)
+                }
             }
             .sheet(item: $model.spaceNotificationsSettingsModuleData) {
                 SpaceNotificationsSettingsView(data: $0)

--- a/Anytype/Sources/PresentationLayer/Modules/NewSpaceMembers/NewSpaceMembersView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/NewSpaceMembers/NewSpaceMembersView.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftUI
+
+struct NewSpaceMembersView: View {
+    
+    @StateObject private var model: NewSpaceMembersViewModel
+    
+    init(data: SpaceMembersData) {
+        _model = StateObject(wrappedValue: NewSpaceMembersViewModel(data: data))
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            DragIndicator()
+            TitleView(title: Loc.SpaceShare.members)
+            
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(model.rows) { participant in
+                        SpaceShareParticipantView(participant: participant)
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+        .task {
+            await model.startParticipantTask()
+        }
+        .onAppear {
+            model.onAppear()
+        }
+        .anytypeSheet(item: $model.participantInfo) {
+            ProfileView(info: $0)
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/NewSpaceMembers/NewSpaceMembersViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/NewSpaceMembers/NewSpaceMembersViewModel.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Services
+
+@MainActor
+final class NewSpaceMembersViewModel: ObservableObject {
+    
+    @Published var participantInfo: ObjectInfo?
+    
+    // MARK: - DI
+    
+    @Injected(\.accountManager)
+    private var accountManager: any AccountManagerProtocol
+    private lazy var participantsSubscription: any ParticipantsSubscriptionProtocol = Container.shared.participantSubscription(data.spaceId)
+    
+    private let data: SpaceMembersData
+    
+    // MARK: - State
+    
+    @Published var rows: [SpaceShareParticipantViewModel] = []
+    
+    init(data: SpaceMembersData) {
+        self.data = data
+    }
+    
+    func startParticipantTask() async {
+        for await participants in participantsSubscription.withoutRemovingParticipantsPublisher.values {
+            updateParticipant(items: participants)
+        }
+    }
+    
+    func onAppear() {
+        AnytypeAnalytics.instance().logScreenSettingsSpaceMembers(route: data.route)
+    }
+    
+    private func updateParticipant(items: [Participant]) {
+        rows = items.map { participant in
+            let isYou = accountManager.account.info.profileObjectID == participant.identityProfileLink
+            return SpaceShareParticipantViewModel(
+                id: participant.id,
+                icon: participant.icon?.icon,
+                name: isYou ? Loc.SpaceShare.youSuffix(participant.title) : participant.title,
+                status: .active(permission: participant.permission.title),
+                action: SpaceShareParticipantViewModel.Action(title: nil, action: { [weak self] in
+                    self?.showParticipantInfo(participant)
+                }),
+                contextActions: []
+            )
+        }
+    }
+    
+    private func showParticipantInfo(_ participant: Participant) {
+        participantInfo = ObjectInfo(objectId: participant.id, spaceId: participant.spaceId)
+    }
+}

--- a/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
@@ -138,6 +138,10 @@ public extension FeatureFlags {
         value(for: .newSharingExtension)
     }
 
+    static var newSpaceMembersFlow: Bool {
+        value(for: .newSpaceMembersFlow)
+    }
+
     static var rainbowViews: Bool {
         value(for: .rainbowViews)
     }
@@ -237,6 +241,7 @@ public extension FeatureFlags {
         .webPublishing,
         .keyboardMenuUndoRedo,
         .newSharingExtension,
+        .newSpaceMembersFlow,
         .rainbowViews,
         .showAlertOnAssert,
         .analytics,

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -237,6 +237,13 @@ public extension FeatureDescription {
         defaultValue: false,
         debugValue: false
     )
+    
+    static let newSpaceMembersFlow = FeatureDescription(
+        title: "New Space Members Flow",
+        type: .feature(author: "vova@anytype.io", releaseVersion: "12"),
+        defaultValue: false,
+        debugValue: true
+    )
 
     // MARK: - Debug
     


### PR DESCRIPTION
## Summary
- Add feature flag toggle in SpaceSettingsCoordinatorView to switch between old and new space members flow
- Create NewSpaceMembersView and NewSpaceMembersViewModel with identical logic to original components
- Use existing newSpaceMembersFlow feature flag to control which view is displayed