### PR TITLE
IOS-4815 Add toast notifications for publishing actions

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/PublishToWeb/PublishToWebInternalViewModel.swift
@@ -72,8 +72,10 @@ final class PublishToWebInternalViewModel: ObservableObject, PublishingPreviewOu
             switch action {
             case .create:
                 AnytypeAnalytics.instance().logShareObjectPublish(objectType: analyticsObjectType)
+                toastBarData = ToastBarData(Loc.PublishingToWeb.published)
             case .update:
                 AnytypeAnalytics.instance().logShareObjectUpdate(objectType: analyticsObjectType)
+                toastBarData = ToastBarData(Loc.PublishingToWeb.updated)
             }
         }
         
@@ -88,6 +90,7 @@ final class PublishToWebInternalViewModel: ObservableObject, PublishingPreviewOu
         
         if status.isNil {
             AnytypeAnalytics.instance().logShareObjectUnpublish(objectType: analyticsObjectType)
+            toastBarData = ToastBarData(Loc.PublishingToWeb.unpublished)
         }
         
         UINotificationFeedbackGenerator().notificationOccurred(.success)

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -1470,6 +1470,11 @@ public enum Loc {
       public static let viewSite = Loc.tr("Localizable", "Publishing.WebBanner.ViewSite", fallback: "View site ↗︎")
     }
   }
+  public enum PublishingToWeb {
+    public static let published = Loc.tr("Localizable", "PublishingToWeb.published", fallback: "Successfully published")
+    public static let unpublished = Loc.tr("Localizable", "PublishingToWeb.unpublished", fallback: "Successfully unpublished")
+    public static let updated = Loc.tr("Localizable", "PublishingToWeb.updated", fallback: "Successfully updated")
+  }
   public enum PushNotifications {
     public enum DisabledAlert {
       public static let description = Loc.tr("Localizable", "PushNotifications.DisabledAlert.description", fallback: "It looks like you didn’t allow notifications. That means you won’t see new messages, mentions, or invites. Go to settings to turn them on.")


### PR DESCRIPTION
## Summary
- Added toast notifications for publish, update, and unpublish actions in the PublishToWeb module
- Created new localization keys for the toast messages
- Toast messages display success feedback when users publish, update, or unpublish objects to the web