### PR TITLE
iOS-4980 Core Subscriptions | add preparation for working with types and relationships without open space

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SharingExtensionShareTo/SharingExtensionShareToViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SharingExtensionShareTo/SharingExtensionShareToViewModel.swift
@@ -8,8 +8,11 @@ final class SharingExtensionShareToViewModel: ObservableObject {
     private var workspacesStorage: any WorkspacesStorageProtocol
     @Injected(\.searchService)
     private var searchService: any SearchServiceProtocol
+    @Injected(\.activeSpaceManager)
+    private var activeSpaceManager: any ActiveSpaceManagerProtocol
     
     private let data: SharingExtensionShareToData
+    private var dataPrepared = false
     
     @Published var title: String = ""
     @Published var searchText: String = ""
@@ -21,6 +24,12 @@ final class SharingExtensionShareToViewModel: ObservableObject {
     }
     
     func search() async {
+        
+        if !dataPrepared {
+            await activeSpaceManager.prepareSpaceForPreview(spaceId: data.spaceId)
+            dataPrepared = true
+        }
+        
         do {
             let result = try await searchService.searchObjectsWithLayouts(
                 text: searchText,

--- a/Anytype/Sources/ServiceLayer/ActiveSpaceManager/ActiveSpaceManager.swift
+++ b/Anytype/Sources/ServiceLayer/ActiveSpaceManager/ActiveSpaceManager.swift
@@ -135,7 +135,7 @@ actor ActiveSpaceManager: ActiveSpaceManagerProtocol, Sendable {
         workspaceInfoStreamInternal.send(nil)
         workspaceInfoStorage.value = nil
         activeSpaceId = nil
-        await objectTypeProvider.stopSubscription(cleanCache: false)
-        await propertyDetailsStorage.stopSubscription(cleanCache: false)
+        await objectTypeProvider.stopSubscription()
+        await propertyDetailsStorage.stopSubscription()
     }
 }

--- a/Anytype/Sources/ServiceLayer/ActiveSpaceManager/ActiveSpaceManager.swift
+++ b/Anytype/Sources/ServiceLayer/ActiveSpaceManager/ActiveSpaceManager.swift
@@ -8,6 +8,7 @@ protocol ActiveSpaceManagerProtocol: AnyObject, Sendable {
     var workspaceInfo: AccountInfo? { get }
     @discardableResult
     func setActiveSpace(spaceId: String?) async throws -> AccountInfo?
+    func prepareSpaceForPreview(spaceId: String) async
     func startSubscription() async
     func stopSubscription() async
 }
@@ -96,6 +97,11 @@ actor ActiveSpaceManager: ActiveSpaceManagerProtocol, Sendable {
         activeSpaceId = nil
         workspaceInfoStreamInternal.send(nil)
         workspaceInfoStorage.value = nil
+    }
+    
+    func prepareSpaceForPreview(spaceId: String) async {
+        await objectTypeProvider.prepareData(spaceId: spaceId)
+        await propertyDetailsStorage.prepareData(spaceId: spaceId)
     }
     
     // MARK: - Private

--- a/Anytype/Sources/ServiceLayer/Auth/LoginStateService.swift
+++ b/Anytype/Sources/ServiceLayer/Auth/LoginStateService.swift
@@ -102,8 +102,8 @@ final class LoginStateService: LoginStateServiceProtocol, Sendable {
     
     private func stopSubscriptions() async {
         await workspacesStorage.stopSubscription()
-        await propertyDetailsStorage.stopSubscription(cleanCache: true)
-        await objectTypeProvider.stopSubscription(cleanCache: true)
+        await propertyDetailsStorage.stopSubscription()
+        await objectTypeProvider.stopSubscription()
         await accountParticipantsStorage.stopSubscription()
         await participantSpacesStorage.stopSubscription()
         await membershipStatusStorage.stopSubscriptionAndClean()

--- a/Anytype/Sources/ServiceLayer/MultispaceSubscriptionHelper/MultispaceOneActiveSubscriptionHelper.swift
+++ b/Anytype/Sources/ServiceLayer/MultispaceSubscriptionHelper/MultispaceOneActiveSubscriptionHelper.swift
@@ -50,7 +50,8 @@ actor MultispaceOneActiveSubscriptionHelper<Value: DetailsModel>: Sendable {
     }
     
     func prepareData(spaceId: String) async {
-        guard activeSpaceId != spaceId else { return }
+        guard data[spaceId].isNil else { return }
+        
         let request = subscriptionBuilder.buildSearch(spaceId: spaceId)
         guard let result = try? await searchMiddleService.search(data: request) else { return }
         let items = result.compactMap { try? Value(details: $0) }

--- a/Anytype/Sources/ServiceLayer/MultispaceSubscriptionHelper/MultispaceOneActiveSubscriptionHelper.swift
+++ b/Anytype/Sources/ServiceLayer/MultispaceSubscriptionHelper/MultispaceOneActiveSubscriptionHelper.swift
@@ -32,15 +32,13 @@ actor MultispaceOneActiveSubscriptionHelper<Value: DetailsModel>: Sendable {
         await updateSubscription(spaceId: spaceId, update: update)
     }
     
-    func stopSubscription(cleanCache: Bool) async {
+    func stopSubscription() async {
         spacesSubscription?.cancel()
         spacesSubscription = nil
         try? await activeSubscriptionStorage?.stopSubscription()
         activeSubscriptionStorage = nil
         activeSpaceId = nil
-        if cleanCache {
-            data.removeAll()
-        }
+        data.removeAll()
     }
     
     private func updateSubscription(spaceId: String, update: @escaping (@Sendable () -> Void)) async {

--- a/Anytype/Sources/ServiceLayer/Object/DefaultObjectCreationService/DefaultObjectCreationService.swift
+++ b/Anytype/Sources/ServiceLayer/Object/DefaultObjectCreationService/DefaultObjectCreationService.swift
@@ -43,7 +43,7 @@ final class DefaultObjectCreationService: DefaultObjectCreationServiceProtocol, 
         }
         
         // In case no space is open, we have not started the subscription yet.
-        await objectTypeProvider.startSubscription(spaceId: spaceId)
+        await objectTypeProvider.prepareData(spaceId: spaceId)
         return try objectTypeProvider.defaultObjectType(spaceId: spaceId)
     }
 }

--- a/Anytype/Sources/ServiceLayer/Object/TypeProvider/ObjectTypeProvider.swift
+++ b/Anytype/Sources/ServiceLayer/Object/TypeProvider/ObjectTypeProvider.swift
@@ -131,11 +131,9 @@ final class ObjectTypeProvider: ObjectTypeProviderProtocol, @unchecked Sendable 
         }
     }
     
-    func stopSubscription(cleanCache: Bool) async {
-        await multispaceSubscriptionHelper.stopSubscription(cleanCache: cleanCache)
-        if cleanCache {
-            updateAllCache()
-        }
+    func stopSubscription() async {
+        await multispaceSubscriptionHelper.stopSubscription()
+        updateAllCache()
     }
     
     // MARK: - Private func

--- a/Anytype/Sources/ServiceLayer/Object/TypeProvider/ObjectTypeProvider.swift
+++ b/Anytype/Sources/ServiceLayer/Object/TypeProvider/ObjectTypeProvider.swift
@@ -19,7 +19,7 @@ final class ObjectTypeProvider: ObjectTypeProviderProtocol, @unchecked Sendable 
     
     // MARK: - DI
     
-    private let subscriptionBuilder: any MultispaceSubscriptionDataBuilderProtocol = Container.shared.objectTypeSubscriptionDataBuilder()
+    private let subscriptionBuilder: any MultispaceOneActiveSubscriptionDataBuilder = Container.shared.objectTypeSubscriptionDataBuilder()
     private let userDefaults: any UserDefaultsStorageProtocol = Container.shared.userDefaultsStorage()
     private let multispaceSubscriptionHelper: MultispaceOneActiveSubscriptionHelper<ObjectType>
     

--- a/Anytype/Sources/ServiceLayer/Object/TypeProvider/ObjectTypeProvider.swift
+++ b/Anytype/Sources/ServiceLayer/Object/TypeProvider/ObjectTypeProvider.swift
@@ -136,6 +136,11 @@ final class ObjectTypeProvider: ObjectTypeProviderProtocol, @unchecked Sendable 
         updateAllCache()
     }
     
+    func prepareData(spaceId: String) async {
+        await multispaceSubscriptionHelper.prepareData(spaceId: spaceId)
+        updateAllCache()
+    }
+    
     // MARK: - Private func
     
     private func updateAllCache() {

--- a/Anytype/Sources/ServiceLayer/Object/TypeProvider/ObjectTypeProviderProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/Object/TypeProvider/ObjectTypeProviderProtocol.swift
@@ -18,6 +18,8 @@ protocol ObjectTypeProviderProtocol: AnyObject, Sendable {
     
     func startSubscription(spaceId: String) async
     func stopSubscription() async
+    
+    func prepareData(spaceId: String) async
 }
 
 extension ObjectTypeProviderProtocol {

--- a/Anytype/Sources/ServiceLayer/Object/TypeProvider/ObjectTypeProviderProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/Object/TypeProvider/ObjectTypeProviderProtocol.swift
@@ -17,7 +17,7 @@ protocol ObjectTypeProviderProtocol: AnyObject, Sendable {
     func deletedObjectType(id: String) -> ObjectType
     
     func startSubscription(spaceId: String) async
-    func stopSubscription(cleanCache: Bool) async
+    func stopSubscription() async
 }
 
 extension ObjectTypeProviderProtocol {

--- a/Anytype/Sources/ServiceLayer/Object/TypeProvider/Subscription/ObjectTypeSubscriptionDataBuilder.swift
+++ b/Anytype/Sources/ServiceLayer/Object/TypeProvider/Subscription/ObjectTypeSubscriptionDataBuilder.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Services
 
-final class ObjectTypeSubscriptionDataBuilder: MultispaceSubscriptionDataBuilderProtocol {
+final class ObjectTypeSubscriptionDataBuilder: MultispaceSubscriptionDataBuilderProtocol, MultispaceSearchDataBuilderProtocol {
     
     // MARK: - MultispaceSubscriptionDataBuilderProtocol
     
@@ -25,6 +25,26 @@ final class ObjectTypeSubscriptionDataBuilder: MultispaceSubscriptionDataBuilder
                 keys: ObjectType.subscriptionKeys.map(\.rawValue),
                 noDepSubscription: true
             )
+        )
+    }
+    
+    // MARK: - MultispaceSearchDataBuilderProtocol
+    
+    func buildSearch(spaceId: String) -> SearchRequest {
+        let sort = SearchHelper.sort(
+            relation: BundledPropertyKey.name,
+            type: .asc
+        )
+        let filters = [
+            SearchHelper.layoutFilter([DetailsLayout.objectType])
+        ]
+        return SearchRequest(
+            spaceId: spaceId,
+            filters: filters,
+            sorts: [sort],
+            fullText: "",
+            keys: ObjectType.subscriptionKeys.map(\.rawValue),
+            limit: 0
         )
     }
 }

--- a/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorage.swift
@@ -75,12 +75,10 @@ final class PropertyDetailsStorage: PropertyDetailsStorageProtocol, Sendable {
         }
     }
     
-    func stopSubscription(cleanCache: Bool) async {
-        await multispaceSubscriptionHelper.stopSubscription(cleanCache: cleanCache)
-        if cleanCache {
-            updateSearchCache()
-            sync.value = ()
-        }
+    func stopSubscription() async {
+        await multispaceSubscriptionHelper.stopSubscription()
+        updateSearchCache()
+        sync.value = ()
     }
     
     // MARK: - Private

--- a/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorage.swift
@@ -20,7 +20,7 @@ final class PropertyDetailsStorage: PropertyDetailsStorageProtocol, Sendable {
     
     // MARK: - DI
     
-    private let subscriptionDataBuilder: any MultispaceSubscriptionDataBuilderProtocol = Container.shared.propertySubscriptionDataBuilder()
+    private let subscriptionDataBuilder: any MultispaceOneActiveSubscriptionDataBuilder = Container.shared.propertySubscriptionDataBuilder()
     
     private let multispaceSubscriptionHelper : MultispaceOneActiveSubscriptionHelper<PropertyDetails>
     

--- a/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorage.swift
@@ -81,6 +81,11 @@ final class PropertyDetailsStorage: PropertyDetailsStorageProtocol, Sendable {
         sync.value = ()
     }
     
+    func prepareData(spaceId: String) async {
+        await multispaceSubscriptionHelper.prepareData(spaceId: spaceId)
+        updateSearchCache()
+    }
+    
     // MARK: - Private
     
     private func updateSearchCache() {

--- a/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorageProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorageProtocol.swift
@@ -16,6 +16,8 @@ protocol PropertyDetailsStorageProtocol: AnyObject, Sendable {
     
     func startSubscription(spaceId: String) async
     func stopSubscription() async
+    
+    func prepareData(spaceId: String) async
 }
 
 extension PropertyDetailsStorageProtocol {

--- a/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorageProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/PropertyStorage/PropertyDetailsStorageProtocol.swift
@@ -15,7 +15,7 @@ protocol PropertyDetailsStorageProtocol: AnyObject, Sendable {
     var syncPublisher: AnyPublisher<Void, Never> { get }
     
     func startSubscription(spaceId: String) async
-    func stopSubscription(cleanCache: Bool) async
+    func stopSubscription() async
 }
 
 extension PropertyDetailsStorageProtocol {

--- a/Anytype/Sources/ServiceLayer/PropertyStorage/Subscription/PropertySubscriptionDataBuilder.swift
+++ b/Anytype/Sources/ServiceLayer/PropertyStorage/Subscription/PropertySubscriptionDataBuilder.swift
@@ -1,7 +1,8 @@
 import Foundation
 import Services
 
-final class PropertySubscriptionDataBuilder: MultispaceSubscriptionDataBuilderProtocol {
+final class PropertySubscriptionDataBuilder: MultispaceSubscriptionDataBuilderProtocol, MultispaceSearchDataBuilderProtocol {
+    
     // MARK: - MultispaceSubscriptionDataBuilderProtocol
     
     func build(accountId: String, spaceId: String, subId: String) -> SubscriptionData {
@@ -25,6 +26,27 @@ final class PropertySubscriptionDataBuilder: MultispaceSubscriptionDataBuilderPr
                 keys: PropertyDetails.subscriptionKeys.map(\.rawValue),
                 noDepSubscription: true
             )
+        )
+    }
+    
+    // MARK: - MultispaceSearchDataBuilderProtocol
+    
+    func buildSearch(spaceId: String) -> SearchRequest {
+        let sort = SearchHelper.sort(
+            relation: BundledPropertyKey.name,
+            type: .asc
+        )
+        let filters = [
+            SearchHelper.isArchivedFilter(isArchived: false),
+            SearchHelper.layoutFilter([.relation])
+        ]
+        return SearchRequest(
+            spaceId: spaceId,
+            filters: filters,
+            sorts: [sort],
+            fullText: "",
+            keys: PropertyDetails.subscriptionKeys.map(\.rawValue),
+            limit: 0
         )
     }
 }

--- a/Anytype/Sources/ServiceLayer/ServicesDI.swift
+++ b/Anytype/Sources/ServiceLayer/ServicesDI.swift
@@ -100,7 +100,7 @@ extension Container {
         self { TreeSubscriptionDataBuilder() }
     }
     
-    var objectTypeSubscriptionDataBuilder: Factory<any MultispaceSubscriptionDataBuilderProtocol> {
+    var objectTypeSubscriptionDataBuilder: Factory<any MultispaceOneActiveSubscriptionDataBuilder> {
         self { ObjectTypeSubscriptionDataBuilder() }
     }
     
@@ -152,7 +152,7 @@ extension Container {
         self { PropertyDetailsStorage() }.singleton
     }
     
-    var propertySubscriptionDataBuilder: Factory<any MultispaceSubscriptionDataBuilderProtocol> {
+    var propertySubscriptionDataBuilder: Factory<any MultispaceOneActiveSubscriptionDataBuilder> {
         self { PropertySubscriptionDataBuilder() }
     }
     


### PR DESCRIPTION

Load types and relationships for cases when we work with them without opening the space:
- Sharing Extension
- Read default object type without open a space
- In next PR will be fixed QuickActions

https://github.com/user-attachments/assets/4a53c597-ee25-433d-8a9c-a55dedcc4d57

