### PR TITLE
IOS-4905 Add camera permission check before opening camera or document scanner

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorView.swift
@@ -66,5 +66,6 @@ struct EditorPageCoordinatorView: View {
             }
             .snackbar(toastBarData: $model.toastBarData)
             .openUrl(url: $model.openUrlData)
+            .cameraPermissionAlert(isPresented: $model.showCameraPermissionAlertData)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorPageFlow/EditorPageCoordinatorViewModel.swift
@@ -27,6 +27,7 @@ final class EditorPageCoordinatorViewModel: ObservableObject, EditorPageModuleOu
     @Published var openUrlData: URL?
     @Published var syncStatusSpaceId: StringIdentifiable?
     @Published var settingsOutput: ObjectSettingsCoordinatorOutputIdentifiable?
+    @Published var showCameraPermissionAlertData = false
     
     init(
         data: EditorPageObject,
@@ -121,6 +122,10 @@ final class EditorPageCoordinatorViewModel: ObservableObject, EditorPageModuleOu
     
     func showObectSettings(output: any ObjectSettingsCoordinatorOutput) {
         settingsOutput = ObjectSettingsCoordinatorOutputIdentifiable(value: output)
+    }
+    
+    func showCameraPermissionAlert() {
+        showCameraPermissionAlertData = true
     }
     
     // MARK: - Private

--- a/Anytype/Sources/PresentationLayer/TextEditor/Assembly/Page/EditorPageModuleOutput.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Assembly/Page/EditorPageModuleOutput.swift
@@ -18,6 +18,7 @@ protocol EditorPageModuleOutput: AnyObject, ObjectHeaderModuleOutput {
     func showSyncStatusInfo(spaceId: String)
     func showAddPropertyInfoView(document: some BaseDocumentProtocol, onSelect: @escaping (PropertyDetails, _ isNew: Bool) -> Void)
     func showObectSettings(output: any ObjectSettingsCoordinatorOutput)
+    func showCameraPermissionAlert()
     
     // TODO: Refactoring templates. Delete it
     func setModuleInput(input: some EditorPageModuleInput, objectId: String)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelActions.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelActions.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UniformTypeIdentifiers
 import Combine
+import Services
 
 @MainActor
 protocol MediaBlockActionsProviderProtocol: AnyObject {
@@ -19,6 +20,8 @@ final class MediaBlockActionsProvider: MediaBlockActionsProviderProtocol {
 
     private let handler: any BlockActionHandlerProtocol
     private let router: any EditorRouterProtocol
+    @Injected(\.cameraPermissionVerifier)
+    private var cameraPermissionVerifier: any CameraPermissionVerifierProtocol
     
     init(
         handler: some BlockActionHandlerProtocol,
@@ -45,6 +48,17 @@ final class MediaBlockActionsProvider: MediaBlockActionsProviderProtocol {
     }
     
     func openCamera(blockId: String) {
+        Task {
+            let isGranted = await cameraPermissionVerifier.cameraIsGranted()
+            if isGranted {
+                showCamera(blockId: blockId)
+            } else {
+                router.showCameraPermissionAlert()
+            }
+        }
+    }
+    
+    private func showCamera(blockId: String) {
         router.showCamera { [weak self] media in
             guard let self else { return }
             
@@ -58,6 +72,17 @@ final class MediaBlockActionsProvider: MediaBlockActionsProviderProtocol {
     }
     
     func openDocumentScanner(blockId: String) {
+        Task {
+            let isGranted = await cameraPermissionVerifier.cameraIsGranted()
+            if isGranted {
+                showDocumentScanner(blockId: blockId)
+            } else {
+                router.showCameraPermissionAlert()
+            }
+        }
+    }
+    
+    private func showDocumentScanner(blockId: String) {
         router.showDocumentScanner { [weak self] result in
             guard let self else { return }
             

--- a/Anytype/Sources/PresentationLayer/TextEditor/Routing/Editor/EditorRouter.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Routing/Editor/EditorRouter.swift
@@ -413,6 +413,12 @@ extension EditorRouter {
     func showAddPropertyInfoView(document: some BaseDocumentProtocol, onSelect: @escaping (PropertyDetails, _ isNew: Bool) -> Void) {
         output?.showAddPropertyInfoView(document: document, onSelect: onSelect)
     }
+    
+    func showCameraPermissionAlert() {
+        Task { @MainActor in
+            output?.showCameraPermissionAlert()
+        }
+    }
 }
 
 extension EditorRouter: PropertyValueCoordinatorOutput {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Routing/Editor/EditorRouterProtocol.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Routing/Editor/EditorRouterProtocol.swift
@@ -53,6 +53,7 @@ protocol EditorRouterProtocol:
     func showRelationValueEditingView(key: String)
     func showAddPropertyInfoView(document: some BaseDocumentProtocol, onSelect: @escaping (PropertyDetails, _ isNew: Bool) -> Void)
     func showLinkContextualMenu(inputParameters: TextBlockURLInputParameters)
+    func showCameraPermissionAlert()
 
     func showWaitingView(text: String)
     func hideWaitingView()


### PR DESCRIPTION
## Summary
- Added camera permission check before opening camera or document scanner in the editor
- Shows permission alert if camera access is not granted
- Follows existing pattern from QRCodeScannerViewModifier

## Implementation Details
- Added showCameraPermissionAlert method to EditorPageModuleOutput protocol
- Implemented routing through EditorRouter to EditorPageCoordinatorViewModel
- Camera permission alert is shown when user tries to use camera/scanner without permission