### PR TITLE
IOS-4997 Add analytics events for pin/unpin spaces in vault

### DIFF
--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -1729,4 +1729,12 @@ extension AnytypeAnalytics {
             ].compactMapValues { $0 }
         )
     }
+    
+    func logPinSpace() {
+        logEvent("PinSpace")
+    }
+    
+    func logUnpinSpace() {
+        logEvent("UnpinSpace")
+    }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -119,10 +119,12 @@ final class SpaceHubViewModel: ObservableObject {
         newOrder.insert(spaceView.id, at: 0)
         
         try await spaceOrderService.setOrder(spaceViewIdMoved: spaceView.id, newOrder: newOrder)
+        AnytypeAnalytics.instance().logPinSpace()
     }
     
     func unpin(spaceView: SpaceView) async throws {
         try await spaceOrderService.unsetOrder(spaceViewId: spaceView.id)
+        AnytypeAnalytics.instance().logUnpinSpace()
     }
     
     func openSpaceSettings(spaceId: String) {


### PR DESCRIPTION
## Summary
- Added `PinSpace` and `UnpinSpace` analytics events to track user engagement with the pin/unpin feature in the vault
- Analytics are triggered when users successfully pin or unpin spaces