### PR TITLE
iOS-5040 Attempt to fix collection view reuse crash in Editor

### DIFF
--- a/.github/workflows/branch_build.yaml
+++ b/.github/workflows/branch_build.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
-          xcode-version: '16.1'
+          xcode-version: '16.4'
 
       - name: Download Middleware
         run: make setup-middle-ci

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
@@ -561,7 +561,9 @@ private extension EditorPageController {
                     item: block
                 )
                 
-                cell.contentConfiguration = block.makeContentConfiguration(maxWidth: collectionView.frame.width)
+                if !FeatureFlags.fixCollectionViewReuseCrashInEditor {
+                    cell.contentConfiguration = block.makeContentConfiguration(maxWidth: collectionView.frame.width)
+                }
             case let .header(header):
                 return collectionView.dequeueConfiguredReusableCell(
                     using: headerCellRegistration,

--- a/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
@@ -158,6 +158,10 @@ public extension FeatureFlags {
         value(for: .updatedHomePlusMenu)
     }
 
+    static var fixCollectionViewReuseCrashInEditor: Bool {
+        value(for: .fixCollectionViewReuseCrashInEditor)
+    }
+
     static var rainbowViews: Bool {
         value(for: .rainbowViews)
     }
@@ -266,6 +270,7 @@ public extension FeatureFlags {
         .removeMessagesFromNotificationsCenter,
         .mediaCarouselForWidgets,
         .updatedHomePlusMenu,
+        .fixCollectionViewReuseCrashInEditor,
         .rainbowViews,
         .showAlertOnAssert,
         .analytics,

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -266,6 +266,12 @@ public extension FeatureDescription {
         defaultValue: false,
         debugValue: true
     )
+    
+    static let fixCollectionViewReuseCrashInEditor = FeatureDescription(
+        title: "Attempt to fix collection view reuse crash in Editor",
+        type: .feature(author: "joe_pusya@anytype.io", releaseVersion: "13"),
+        defaultValue: true
+    )
 
     // MARK: - Debug
     


### PR DESCRIPTION
We made cell.contentConfiguration two times - when create cell and during registration, fix that - configure cell only one time