### PR TITLE
IOS-5091 Fix join button text not centering

### DIFF
--- a/Anytype/Sources/PresentationLayer/Settings/Settings/Sections/SettingsSectionItemView.swift
+++ b/Anytype/Sources/PresentationLayer/Settings/Settings/Sections/SettingsSectionItemView.swift
@@ -77,8 +77,7 @@ struct SettingsSectionItemView: View {
                         .dynamicForegroundStyle(color: .Control.secondary, disabledColor: .Control.tertiary)
                 }
             case .button(let text):
-                Text(text)
-                    .anytypeStyle(.caption1Medium)
+                AnytypeText(text, style: .caption1Medium)
                     .foregroundColor(.Text.inversion)
                     .lineLimit(1)
                     .padding(.horizontal, 11)


### PR DESCRIPTION
Current problem to fix on global level: Text + anytypeStyle do not account for line height 

before
<img width="260" height="472" alt="before" src="https://github.com/user-attachments/assets/91021381-e9c1-417c-881b-e9dcf068d78d" />

after 
<img width="260" height="472" alt="Screenshot 2025-08-27 at 4 43 11 PM" src="https://github.com/user-attachments/assets/2528f0ff-4722-4e1b-b665-553bb230c822" />
