### PR TITLE
IOS-5107 Remove client-side 50 space creation limit

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -24,7 +24,6 @@ final class SpaceHubViewModel: ObservableObject {
     
     @Published var wallpapers: [String: SpaceWallpaperType] = [:]
     
-    @Published var createSpaceAvailable = false
     @Published var notificationsDenied = false
     @Published var spaceMuteData: SpaceMuteData?
     @Published var toastBarData: ToastBarData?
@@ -33,11 +32,7 @@ final class SpaceHubViewModel: ObservableObject {
     
     private weak var output: (any SpaceHubModuleOutput)?
     
-    var showPlusInNavbar: Bool {
-        guard let allSpaces else { return false }
-        return allSpaces.count > 6 && createSpaceAvailable
-    }
-    
+
     @Injected(\.userDefaultsStorage)
     private var userDefaults: any UserDefaultsStorageProtocol
     @Injected(\.activeSpaceManager)
@@ -148,7 +143,6 @@ final class SpaceHubViewModel: ObservableObject {
     private func subscribeOnSpaces() async {
         for await spaces in await spaceHubSpacesStorage.spacesStream {
             self.spaces = spaces.sorted(by: sortSpacesForPinnedFeature)
-            createSpaceAvailable = workspacesStorage.canCreateNewSpace()
             if FeatureFlags.spaceLoadingForScreen {
                 showLoading = spaces.contains { $0.spaceView.isLoading }
             }

--- a/Anytype/Sources/PreviewMocks/Mocks/Services/WorkspacesStorageMock.swift
+++ b/Anytype/Sources/PreviewMocks/Mocks/Services/WorkspacesStorageMock.swift
@@ -31,5 +31,4 @@ final class WorkspacesStorageMock: WorkspacesStorageProtocol, @unchecked Sendabl
     func spaceView(spaceViewId: String) -> SpaceView? { return nil }
     func workspaceInfo(spaceId: String) -> AccountInfo? { return nil }
     func addWorkspaceInfo(spaceId: String, info: AccountInfo) {}
-    func canCreateNewSpace() -> Bool { true }
 }

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/WorkspacesStorage.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/WorkspacesStorage.swift
@@ -13,9 +13,6 @@ protocol WorkspacesStorageProtocol: AnyObject, Sendable {
     func workspaceInfo(spaceId: String) -> AccountInfo?
     // TODO: Kostyl. Waiting when middleware to add method for receive account info without set active space
     func addWorkspaceInfo(spaceId: String, info: AccountInfo)
-    
-    func canCreateNewSpace() -> Bool
-    
 }
 
 extension WorkspacesStorageProtocol {
@@ -94,7 +91,4 @@ final class WorkspacesStorage: WorkspacesStorageProtocol {
         workspacesInfo[spaceId] = info
     }
     
-    func canCreateNewSpace() -> Bool {
-        return activeWorkspaces.count < 50
-    }
 }


### PR DESCRIPTION
## Summary
- Remove hardcoded 50 space creation limit from client-side code
- Remove canCreateNewSpace() method from WorkspacesStorage protocol and implementation
- Clean up unused createSpaceAvailable and showPlusInNavbar properties in SpaceHub
- Space creation limits now managed entirely by payment node