### PR TITLE
IOS-5109 Fix icon visibility in link to card when set to none

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Link/BlockLinkCardView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Link/BlockLinkCardView.swift
@@ -44,7 +44,7 @@ final class BlockLinkCardView: UIView, BlockContentView {
         titleLabel.setText(configuration.state.title)
 
         smallIconView.icon = configuration.state.icon
-        smallIconView.isHidden = configuration.state.iconSize == .medium
+        smallIconView.isHidden = configuration.state.iconSize != .small
         
         descriptionLabel.isHidden = configuration.state.description.isEmpty
         descriptionLabel.setText(configuration.state.description)

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Link/BlockTextLinkView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Link/BlockTextLinkView.swift
@@ -29,7 +29,7 @@ final class BlockTextLinkView: UIView, BlockContentView {
         titleLabel.setText(configuration.state.title)
         
         objectIcon.icon = configuration.state.archived ? .asset(.ghost) : configuration.state.icon
-        objectIcon.isHidden = objectIcon.icon.isNil
+        objectIcon.isHidden = objectIcon.icon.isNil || configuration.state.iconSize == .none
         
         descriptionLabel.isHidden = configuration.state.description.isEmpty
         descriptionLabel.setText(configuration.state.attributedDescription)


### PR DESCRIPTION
## Summary
- Fix icon visibility logic in BlockLinkCardView to properly hide icons when iconSize is set to .none
- Fix icon visibility logic in BlockTextLinkView to respect iconSize setting