### PR TITLE
Fix RTL for none latin languages in block link description and title

### DIFF
--- a/Anytype/Sources/Design system/TextComponents/UIKitAnytypeText.swift
+++ b/Anytype/Sources/Design system/TextComponents/UIKitAnytypeText.swift
@@ -21,13 +21,10 @@ final class UIKitAnytypeText: Hashable {
         let newAttrString = NSMutableAttributedString(attributedString: attributedString)
         textModifier = MarkStyleModifier(attributedString: newAttrString, anytypeFont: style)
                 
-        let paragraphStyle = attributedString.length > 0
-        ? (attributedString.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSMutableParagraphStyle) ?? NSMutableParagraphStyle()
-        : NSMutableParagraphStyle()
+        let paragraphStyle = TextDirection.paragraphStyle(for: attributedString.string)
         
         paragraphStyle.lineSpacing = style.lineSpacing
         paragraphStyle.lineBreakMode = lineBreakModel
-        paragraphStyle.alignment = .left
         
         let range = NSMakeRange(0, newAttrString.length)
         newAttrString.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)

--- a/Anytype/Sources/Helpers/TextDirection.swift
+++ b/Anytype/Sources/Helpers/TextDirection.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+enum TextDirection {
+    static func isRTL(_ text: String) -> Bool {
+        // Detect Arabic (and optionally extend with other RTL scripts if needed)
+        return text.range(of: "\\p{Arabic}", options: .regularExpression) != nil
+    }
+
+    static func paragraphStyle(for text: String) -> NSMutableParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        if isRTL(text) {
+            style.baseWritingDirection = .rightToLeft
+        } else {
+            style.baseWritingDirection = .leftToRight
+        }
+        style.alignment = .natural
+        return style
+    }
+
+    static func alignment(for text: String) -> NSTextAlignment {
+        .natural
+    }
+}


### PR DESCRIPTION
Added a utility to allow RTL text for block link title and description for arabic and can be extended to other RTL languages.

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2025-09-13 at 12 17 25" src="https://github.com/user-attachments/assets/d3415678-d1b3-4eaa-a751-7b3159fc2ac1" />


<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
This is part of an effort to add more RTL support for anytype as discussed:
- [here](https://community.anytype.io/t/how-to-complete-rtl-persian-arabic-language-support-fix/28481)
- [here](https://community.anytype.io/t/please-add-arabic-language-support/27940)


### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?
No

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
