### PR TITLE
IOS-5247 Include space chat in the shared data spaces limits

### DIFF
--- a/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/Model/SpaceSharingInfo.swift
+++ b/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/Model/SpaceSharingInfo.swift
@@ -1,11 +1,8 @@
 struct SpaceSharingInfo {
     let sharedSpacesLimit: Int
-
-    let sharedDataSpacesCount: Int
-    let sharedChatSpacesCount: Int
-    let sharedStreamSpacesCount: Int
+    let sharedSpacesCount: Int
 
     var limitsAllowSharing: Bool {
-        sharedDataSpacesCount < sharedSpacesLimit
+        sharedSpacesCount < sharedSpacesLimit
     }
 }

--- a/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/ParticipantSpacesStorage.swift
+++ b/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/ParticipantSpacesStorage.swift
@@ -70,31 +70,8 @@ final class ParticipantSpacesStorage: ParticipantSpacesStorageProtocol {
     
     var spaceSharingInfo: SpaceSharingInfo? {
         guard let sharedSpacesLimit = profileStorage.profile.sharedSpacesLimit else { return nil }
-
-        let ownedActiveSharedSpaces = allParticipantSpaces.filter {
-            $0.spaceView.isActive &&
-            $0.spaceView.isShared &&
-            $0.isOwner
-        }
-
-        let sharedDataSpacesCount = ownedActiveSharedSpaces.filter {
-            $0.spaceView.uxType == .data
-        }.count
-
-        let sharedChatSpacesCount = ownedActiveSharedSpaces.filter {
-            $0.spaceView.uxType == .chat
-        }.count
-
-        let sharedStreamSpacesCount = ownedActiveSharedSpaces.filter {
-            $0.spaceView.uxType == .stream
-        }.count
-
-        return SpaceSharingInfo(
-            sharedSpacesLimit: sharedSpacesLimit,
-            sharedDataSpacesCount: sharedDataSpacesCount,
-            sharedChatSpacesCount: sharedChatSpacesCount,
-            sharedStreamSpacesCount: sharedStreamSpacesCount
-        )
+        let sharedSpacesCount = allParticipantSpaces.filter { $0.spaceView.isActive && $0.spaceView.isShared && $0.isOwner }.count
+        return SpaceSharingInfo(sharedSpacesLimit: sharedSpacesLimit, sharedSpacesCount: sharedSpacesCount)
     }
     
     func startSubscription() async {


### PR DESCRIPTION
## Summary
- Reverted IOS-5217 changes to include all space types (data, chat, stream) in the shared spaces limit calculation