### PR TITLE
IOS-5246 Return limit on the editor in chat space

### DIFF
--- a/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
@@ -110,7 +110,6 @@ extension SpaceView {
     
     func canAddWriters(participants: [Participant]) -> Bool {
         guard canAddReaders(participants: participants) else { return false }
-        guard uxType != .chat else { return true }
         guard let writersLimit else { return true }
         return writersLimit > activeWriters(participants: participants)
     }
@@ -127,7 +126,6 @@ extension SpaceView {
     
     func canChangeReaderToWriter(participants: [Participant]) -> Bool {
         guard let writersLimit else { return true }
-        guard uxType != .chat else { return true }
         return writersLimit > activeWriters(participants: participants)
     }
     


### PR DESCRIPTION
## Summary
- Reverted PR #3971 changes that removed writer limits for chat spaces
- Restored writer limit validation in `canAddWriters` and `canChangeReaderToWriter` methods