### PR TITLE
IOS-5899 Korean text does not render italicised on iOS

### DIFF
--- a/Anytype/Sources/Design system/TextComponents/Markup/MarkStyleModifier.swift
+++ b/Anytype/Sources/Design system/TextComponents/Markup/MarkStyleModifier.swift
@@ -80,10 +80,14 @@ final class MarkStyleModifier {
             
             
         case .italic:
-            guard let oldFont = old[.font] as? UIFont else { return nil }
-            
-            let newFont = shouldApplyMarkup ? oldFont.italic : oldFont.nonItalic
-            return AttributedStringChange(changeAttributes: [.font : newFont])
+            if shouldApplyMarkup {
+                // Use synthetic italic (obliqueness) instead of italic font variant.
+                // CJK fallback fonts (Apple SD Gothic Neo, etc.) lack italic glyphs,
+                // so obliqueness provides consistent italic rendering across all scripts.
+                return AttributedStringChange(changeAttributes: [.obliqueness: 0.2])
+            } else {
+                return AttributedStringChange(deletedKeys: [.obliqueness])
+            }
             
         case .keyboard:
             return keyboardUpdate(with: old, shouldHaveStyle: shouldApplyMarkup)

--- a/Anytype/Sources/Design system/TextComponents/Markup/MarkStyleModifier.swift
+++ b/Anytype/Sources/Design system/TextComponents/Markup/MarkStyleModifier.swift
@@ -84,9 +84,15 @@ final class MarkStyleModifier {
                 // Use synthetic italic (obliqueness) instead of italic font variant.
                 // CJK fallback fonts (Apple SD Gothic Neo, etc.) lack italic glyphs,
                 // so obliqueness provides consistent italic rendering across all scripts.
-                return AttributedStringChange(changeAttributes: [.obliqueness: 0.2])
+                return AttributedStringChange(changeAttributes: [.obliqueness: Float(0.2)])
             } else {
-                return AttributedStringChange(deletedKeys: [.obliqueness])
+                // Also reset font to nonItalic for backwards compatibility with
+                // content saved before this change (which used font trait italic).
+                guard let oldFont = old[.font] as? UIFont else { return nil }
+                return AttributedStringChange(
+                    changeAttributes: [.font: oldFont.nonItalic],
+                    deletedKeys: [.obliqueness]
+                )
             }
             
         case .keyboard:

--- a/Anytype/Sources/Design system/TextComponents/Markup/MarkupState/NSAttributedString+Markup.swift
+++ b/Anytype/Sources/Design system/TextComponents/Markup/MarkupState/NSAttributedString+Markup.swift
@@ -9,7 +9,7 @@ extension NSAttributedString {
     }
     
     func italicState(range: NSRange) -> Bool {
-        return isFontInWhole(range: range, has: .traitItalic)
+        return isFontInWhole(range: range, has: .traitItalic) || isOblique(range: range)
     }
     
     func strikethroughState(range: NSRange) -> Bool {

--- a/Anytype/Sources/FrameworkExtensions/Foundation/NSAttributedStringExtension.swift
+++ b/Anytype/Sources/FrameworkExtensions/Foundation/NSAttributedStringExtension.swift
@@ -40,7 +40,7 @@ extension NSAttributedString {
         guard isRangeValid(range) else { return false }
         var hasObliqueness = false
         enumerateAttribute(.obliqueness, in: range) { value, _, shouldStop in
-            guard let obliqueness = value as? Double, obliqueness != 0.0 else {
+            guard let obliqueness = value as? Float, !obliqueness.isZero else {
                 hasObliqueness = false
                 shouldStop[0] = true
                 return

--- a/Anytype/Sources/FrameworkExtensions/Foundation/NSAttributedStringExtension.swift
+++ b/Anytype/Sources/FrameworkExtensions/Foundation/NSAttributedStringExtension.swift
@@ -36,6 +36,20 @@ extension NSAttributedString {
         return result
     }
     
+    func isOblique(range: NSRange) -> Bool {
+        guard isRangeValid(range) else { return false }
+        var hasObliqueness = false
+        enumerateAttribute(.obliqueness, in: range) { value, _, shouldStop in
+            guard let obliqueness = value as? Double, obliqueness != 0.0 else {
+                hasObliqueness = false
+                shouldStop[0] = true
+                return
+            }
+            hasObliqueness = true
+        }
+        return hasObliqueness
+    }
+
     func isCodeFontInWhole(range: NSRange) -> Bool {
         guard isRangeValid(range) else { return false }
         var result = true

--- a/Anytype/Sources/Models/Documents/Parsers/AttributedTextConverter.swift
+++ b/Anytype/Sources/Models/Documents/Parsers/AttributedTextConverter.swift
@@ -173,7 +173,7 @@ enum AttributedTextConverter {
             if font.fontDescriptor.symbolicTraits.contains(.traitItalic) {
                 return ""
             }
-            if let obliqueness = attributes[.obliqueness] as? Double, obliqueness != 0.0 {
+            if let obliqueness = attributes[.obliqueness] as? Float, !obliqueness.isZero {
                 return ""
             }
             return nil

--- a/Anytype/Sources/Models/Documents/Parsers/AttributedTextConverter.swift
+++ b/Anytype/Sources/Models/Documents/Parsers/AttributedTextConverter.swift
@@ -169,11 +169,14 @@ enum AttributedTextConverter {
             }
             return ""
         case .italic:
-            guard let font = attributes[.font] as? UIFont,
-                  font.fontDescriptor.symbolicTraits.contains(.traitItalic) else {
-                return nil
+            guard let font = attributes[.font] as? UIFont else { return nil }
+            if font.fontDescriptor.symbolicTraits.contains(.traitItalic) {
+                return ""
             }
-            return ""
+            if let obliqueness = attributes[.obliqueness] as? Double, obliqueness != 0.0 {
+                return ""
+            }
+            return nil
         case .keyboard:
             guard let font = attributes[.font] as? UIFont,
                   font.isCode else {

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/InputPanel/Input/ChatTextViewCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/InputPanel/Input/ChatTextViewCoordinator.swift
@@ -278,9 +278,11 @@ final class ChatTextViewCoordinator: NSObject, UITextViewDelegate, NSTextContent
             }
             
             if attrs[.chatItalic] != nil {
-                newFont = newFont.italic
+                newText.addAttribute(.obliqueness, value: Float(0.2), range: range)
+            } else {
+                newText.removeAttribute(.obliqueness, range: range)
             }
-            
+
             if attrs[.chatKeyboard] != nil {
                 newFont = UIKitFontBuilder.uiKitFont(font: anytypeCodeFont)
             }

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageTextBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageTextBuilder.swift
@@ -44,7 +44,7 @@ struct MessageTextBuilder: MessageTextBuilderProtocol, Sendable {
             case .keyboard:
                 message[range].font = AnytypeFontBuilder.font(anytypeFont: .codeBlock)
             case .italic:
-                message[range].font = message[range].font?.italic()
+                message[range].uiKit.obliqueness = CGFloat(0.2)
             case .bold:
                 message[range].font = message[range].font?.weight(.semibold)
             case .underscored:


### PR DESCRIPTION
## Summary
- CJK fallback fonts on iOS (Apple SD Gothic Neo, etc.) lack italic variants, causing Korean/Chinese/Japanese text to appear normal even when italic markup is applied
- Replace font-trait italic with synthetic italic via `.obliqueness` attribute for consistent rendering across all scripts
- Maintain backwards compatibility: removing italic also resets font trait for pre-existing content saved with the old approach

## Notes
- Chat module uses a separate italic rendering path (`font.italic()` in `MessageTextBuilder` / `ChatTextViewCoordinator`) which is not addressed in this PR — follow-up needed