### PR TITLE
IOS-5747 Fix white screen after fresh install authorization

### DIFF
--- a/Anytype/Sources/ServiceLayer/Badge/AppIconBadgeService.swift
+++ b/Anytype/Sources/ServiceLayer/Badge/AppIconBadgeService.swift
@@ -14,7 +14,9 @@ protocol AppIconBadgeServiceProtocol: AnyObject, Sendable {
 
 actor AppIconBadgeService: AppIconBadgeServiceProtocol {
 
-    @Injected(\.chatMessagesPreviewsStorage)
+    // LazyInjected to avoid creating ChatMessagesPreviewsStorage before auth
+    // (when basicUserInfoStorage.usersId is empty, its subscription silently skips)
+    @LazyInjected(\.chatMessagesPreviewsStorage)
     private var chatMessagesPreviewsStorage: any ChatMessagesPreviewsStorageProtocol
     @Injected(\.spaceViewsStorage)
     private var spaceViewsStorage: any SpaceViewsStorageProtocol


### PR DESCRIPTION
## Summary

- Fixes white screen that appears after authorization on a fresh install (delete app → reinstall → authorize → blank screen)

## Problem

Two changes in combination created the bug:

1. **IOS-5566** changed `SpaceHubSpacesStorage` to use `previewsSequence` (no initial value) instead of `previewsSequenceWithEmpty` — to prevent UI jumping when previews load
2. **IOS-5747** added `AppIconBadgeService` to `LoginStateService` with eager `@Injected`, which pulls in `ChatMessagesPreviewsStorage` at app startup — **before the user has authenticated**

`ChatMessagesPreviewsStorage.init()` fires a `Task { startSubscription() }` that checks `basicUserInfoStorage.usersId`. On a fresh install, `usersId` is empty at that point, so the subscription silently skips and `previewsStream` never emits. Since the storage is a shared singleton, `init()` only runs once — there is no retry after auth completes.

As a result, `SpaceHubSpacesStorage.spacesStream` uses `combineLatest` which waits for all three input streams to emit. With `previewsSequence` (no initial value) blocked forever, `combineLatest` never fires, `dataLoaded` stays `false`, and the Space Hub shows an empty view over `Color.Background.primary` — a white screen.

**For returning users** (who already have `usersId` saved), the subscription starts successfully at init time, so the bug doesn't reproduce.

## Solution

Changed `@Injected` → `@LazyInjected` for `chatMessagesPreviewsStorage` in `AppIconBadgeService`. This defers the creation of `ChatMessagesPreviewsStorage` until `startUpdating()` is first called — which happens inside `LoginStateService.startSubscriptions()`, after `basicUserInfoStorage.usersId` has been set.