### PR TITLE
IOS-5916 Fix sender name overflow in vault space list

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/NewSpaceCardLastMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/NewSpaceCardLastMessageView.swift
@@ -70,7 +70,6 @@ struct NewSpaceCardLastMessageView: View {
                     AnytypeText("\(creatorTitle):", style: .chatPreviewRegular)
                         .foregroundStyle(previewTextColor)
                         .lineLimit(1)
-                        .fixedSize(horizontal: true, vertical: false)
                 }
                 Spacer.fixedWidth(2)
 


### PR DESCRIPTION
## Summary
- Remove `.fixedSize(horizontal: true, vertical: false)` from sender name text in `NewSpaceCardLastMessageView` so long names truncate with ellipsis instead of overflowing and breaking the layout