### PR TITLE
IOS-5920: Fix notification settings content not scrollable

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceNotificationsSettings/SpaceNotificationsSettingsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceNotificationsSettings/SpaceNotificationsSettingsView.swift
@@ -15,8 +15,9 @@ struct SpaceNotificationsSettingsView: View {
         VStack(spacing: 0) {
             DragIndicator()
             TitleView(title: Loc.notifications)
-            content
-            Spacer()
+            ScrollView {
+                content
+            }
         }
         .task {
             await model.startSubscriptions()


### PR DESCRIPTION
## Summary
- Wrapped notification settings content in `ScrollView` so it scrolls when there are many chats with custom notification settings
- Removed unnecessary `Spacer()` (not needed inside ScrollView)

Fixes: IOS-5920