### PR TITLE
IOS-5905: Rename empty state labels from Space to Channel

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/CreateChannelEmptyStateView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/CreateChannelEmptyStateView.swift
@@ -8,7 +8,7 @@ struct CreateChannelEmptyStateView: View {
 
     var body: some View {
         EmptyStateView(
-            title: Loc.thereAreNoSpacesYet,
+            title: Loc.Channel.Create.EmptyState.title,
             subtitle: "",
             style: .withImage
         ) {
@@ -19,7 +19,7 @@ struct CreateChannelEmptyStateView: View {
                     onTapJoinQR: onTapJoinQR
                 )
             } label: {
-                StandardButton(.text(Loc.createSpace), style: .secondarySmall) {}
+                StandardButton(.text(Loc.Channel.Create.EmptyState.button), style: .secondarySmall) {}
                     .allowsHitTesting(false)
             }
         }

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -1424,6 +1424,10 @@ public enum Loc {
     public enum Create {
       public static let group = Loc.tr("Workspace", "Channel.Create.Group", fallback: "Group")
       public static let personal = Loc.tr("Workspace", "Channel.Create.Personal", fallback: "Personal")
+      public enum EmptyState {
+        public static let button = Loc.tr("Workspace", "Channel.Create.EmptyState.button", fallback: "Create Channel")
+        public static let title = Loc.tr("Workspace", "Channel.Create.EmptyState.title", fallback: "There are no channels yet")
+      }
     }
   }
   public enum Chat {

--- a/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
@@ -81901,6 +81901,28 @@
           }
         }
       }
+    },
+    "Channel.Create.EmptyState.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There are no channels yet"
+          }
+        }
+      }
+    },
+    "Channel.Create.EmptyState.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Channel"
+          }
+        }
+      }
     }
   },
   "version": "1.0"


### PR DESCRIPTION
## Summary
- Rename empty state title: "There are no spaces yet" → "There are no channels yet"
- Rename empty state button: "Create Space" → "Create Channel"
- Only affects the channel flow (under `createChannelFlow` toggle)