### PR TITLE
IOS-5925: Fix empty state appearance in SpacesManagerView dark mode

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/EmptyStateView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/EmptyStateView.swift
@@ -1,16 +1,26 @@
 import SwiftUI
 
-struct EmptyStateView: View {
+struct EmptyStateView<ButtonContent: View>: View {
     let title: String
     let subtitle: String
     let style: Style
     let buttonData: ButtonData?
+    let customButton: ButtonContent?
     
-    init(title: String, subtitle: String = "", style: Style, buttonData: ButtonData? = nil) {
+    init(title: String, subtitle: String = "", style: Style, buttonData: ButtonData? = nil) where ButtonContent == Never {
         self.title = title
         self.subtitle = subtitle
         self.style = style
         self.buttonData = buttonData
+        self.customButton = nil
+    }
+
+    init(title: String, subtitle: String = "", style: Style, @ViewBuilder button: () -> ButtonContent) {
+        self.title = title
+        self.subtitle = subtitle
+        self.style = style
+        self.buttonData = nil
+        self.customButton = button()
     }
     
     var body: some View {
@@ -42,6 +52,8 @@ struct EmptyStateView: View {
                 AsyncStandardButton(buttonData.title, style: .secondarySmall) {
                     try await buttonData.action()
                 }
+            } else if let customButton {
+                customButton
             }
             Spacer.fixedHeight(48)
             Spacer()

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/EmptyStateView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/EmptyStateView.swift
@@ -59,6 +59,7 @@ struct EmptyStateView<ButtonContent: View>: View {
             Spacer()
         }
         .padding(.horizontal, 20)
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -206,6 +206,18 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     func onSelectCreateObject() {
         showSpaceTypeForCreate = true
     }
+
+    func onSelectCreatePersonalChannel() {
+        spaceCreateData = SpaceCreateData(spaceUxType: .data)
+    }
+
+    func onSelectCreateGroupChannel() {
+        // Placeholder — will be implemented in IOS-5906
+    }
+
+    func onSelectQrCodeJoin() {
+        shouldScanQrCode = true
+    }
     
     func onSelectSpace(spaceId: String) {
         Task { await showSpace(spaceId: spaceId) }

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -216,7 +216,10 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     }
 
     func onSelectQrCodeJoin() {
-        shouldScanQrCode = true
+        Task {
+            await dismissAllPresented?()
+            shouldScanQrCode = true
+        }
     }
     
     func onSelectSpace(spaceId: String) {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubOutput.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubOutput.swift
@@ -3,6 +3,9 @@ import Foundation
 @MainActor
 protocol SpaceHubModuleOutput: AnyObject {
     func onSelectCreateObject()
+    func onSelectCreatePersonalChannel()
+    func onSelectCreateGroupChannel()
+    func onSelectQrCodeJoin()
     func onSelectSpace(spaceId: String)
     func onOpenSpaceSettings(spaceId: String)
     func onSelectAppSettings()

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubView.swift
@@ -45,15 +45,22 @@ struct SpaceHubView: View {
         .ignoresSafeArea(edges: .bottom)
     }
     
+    private var isEmptyState: Bool {
+        model.filteredSpaces.isEmpty && model.searchText.isEmpty
+    }
+
+    @ViewBuilder
     private func spacesView() -> some View {
         NavigationStack {
             SpaceHubList(model: model)
                 .navigationTitle(Loc.myChannels)
                 .scrollEdgeEffectStyleIOS26(.soft, for: .top)
                 .toolbar { toolbarItems }
-                .searchable(text: $model.searchText)
-                .onChange(of: model.searchText) {
-                    model.searchTextUpdated()
+                .if(!isEmptyState) { view in
+                    view.searchable(text: $model.searchText)
+                        .onChange(of: model.searchText) {
+                            model.searchTextUpdated()
+                        }
                 }
         }.tint(Color.Text.secondary)
     }
@@ -62,9 +69,19 @@ struct SpaceHubView: View {
         SpaceHubToolbar(
             profileIcon: model.profileIcon,
             notificationsNotDetermined: model.notificationsNotDetermined,
+            hideCreateButton: isEmptyState,
             namespace: namespace,
             onTapCreateSpace: {
                 model.onTapCreateSpace()
+            },
+            onTapCreatePersonalChannel: {
+                model.onTapCreatePersonalChannel()
+            },
+            onTapCreateGroupChannel: {
+                model.onTapCreateGroupChannel()
+            },
+            onTapJoinViaQrCode: {
+                model.onTapJoinViaQrCode()
             },
             onTapSettings: {
                 model.onTapSettings()

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -54,6 +54,18 @@ final class SpaceHubViewModel {
     func onTapCreateSpace() {
         output?.onSelectCreateObject()
     }
+
+    func onTapCreatePersonalChannel() {
+        output?.onSelectCreatePersonalChannel()
+    }
+
+    func onTapCreateGroupChannel() {
+        output?.onSelectCreateGroupChannel()
+    }
+
+    func onTapJoinViaQrCode() {
+        output?.onSelectQrCodeJoin()
+    }
     
     func onAppear() {
         AnytypeAnalytics.instance().logScreenVault(type: "General")

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/CreateChannelEmptyStateView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/CreateChannelEmptyStateView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct CreateChannelEmptyStateView: View {
+
+    let onTapPersonal: () -> Void
+    let onTapGroup: () -> Void
+    let onTapJoinQR: () -> Void
+
+    var body: some View {
+        EmptyStateView(
+            title: Loc.thereAreNoSpacesYet,
+            subtitle: "",
+            style: .withImage
+        ) {
+            Menu {
+                CreateChannelMenuItems(
+                    onTapPersonal: onTapPersonal,
+                    onTapGroup: onTapGroup,
+                    onTapJoinQR: onTapJoinQR
+                )
+            } label: {
+                StandardButton(.text(Loc.createSpace), style: .secondarySmall) {}
+                    .allowsHitTesting(false)
+            }
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/CreateChannelEmptyStateView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/CreateChannelEmptyStateView.swift
@@ -8,7 +8,7 @@ struct CreateChannelEmptyStateView: View {
 
     var body: some View {
         EmptyStateView(
-            title: Loc.thereAreNoSpacesYet,
+            title: Loc.Channel.Create.EmptyState.title,
             subtitle: "",
             style: .withImage
         ) {
@@ -19,7 +19,7 @@ struct CreateChannelEmptyStateView: View {
                     onTapJoinQR: onTapJoinQR
                 )
             } label: {
-                StandardButton(.text(Loc.createSpace), style: .secondarySmall) {}
+                StandardButton(.text(Loc.Channel.Create.EmptyState.button), style: .secondarySmall) {}
                     .allowsHitTesting(false)
             }
         }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubEmptyStateView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubEmptyStateView.swift
@@ -1,18 +1,34 @@
 import SwiftUI
+import AnytypeCore
 
 struct SpaceHubEmptyStateView: View {
     
     let onTapCreateSpace: () -> Void
+    let onTapCreatePersonalChannel: () -> Void
+    let onTapCreateGroupChannel: () -> Void
+    let onTapJoinViaQrCode: () -> Void
     
     var body: some View {
         HomeUpdateSubmoduleView().padding(8)
-        EmptyStateView(
-            title: Loc.thereAreNoSpacesYet,
-            subtitle: "",
-            style: .withImage,
-            buttonData: EmptyStateView.ButtonData(title: Loc.createSpace) {
-                onTapCreateSpace()
-            }
+        if FeatureFlags.createChannelFlow {
+            channelMenuEmptyState
+        } else {
+            EmptyStateView(
+                title: Loc.thereAreNoSpacesYet,
+                subtitle: "",
+                style: .withImage,
+                buttonData: EmptyStateView.ButtonData(title: Loc.createSpace) {
+                    onTapCreateSpace()
+                }
+            )
+        }
+    }
+    
+    private var channelMenuEmptyState: some View {
+        CreateChannelEmptyStateView(
+            onTapPersonal: { onTapCreatePersonalChannel() },
+            onTapGroup: { onTapCreateGroupChannel() },
+            onTapJoinQR: { onTapJoinViaQrCode() }
         )
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubList.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubList.swift
@@ -39,9 +39,12 @@ struct SpaceHubList: View {
     }
     
     private var emptyStateView: some View {
-        SpaceHubEmptyStateView {
-            model.onTapCreateSpace()
-        }
+        SpaceHubEmptyStateView(
+            onTapCreateSpace: { model.onTapCreateSpace() },
+            onTapCreatePersonalChannel: { model.onTapCreatePersonalChannel() },
+            onTapCreateGroupChannel: { model.onTapCreateGroupChannel() },
+            onTapJoinViaQrCode: { model.onTapJoinViaQrCode() }
+        )
     }
     
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubNewSpaceButton.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubNewSpaceButton.swift
@@ -1,27 +1,56 @@
 import SwiftUI
+import AnytypeCore
 
 struct SpaceHubNewSpaceButton: View {
     
     @StateObject var spaceCreationTip = SpaceCreationTipWrapper()
     
     let onTap: () -> Void
+    let onTapPersonal: () -> Void
+    let onTapGroup: () -> Void
+    let onTapJoinQR: () -> Void
     
     var body: some View {
+        if FeatureFlags.createChannelFlow {
+            menuContent
+        } else {
+            buttonContent
+        }
+    }
+    
+    private var buttonContent: some View {
         Button {
             spaceCreationTip.invalidate()
             onTap()
         }
         label: {
-            Image(asset: .X32.addFilled)
-                .foregroundStyle(Color.Control.secondary)
-                .frame(width: 32, height: 32)
-                .overlay(alignment: .bottomLeading) {
-                    if spaceCreationTip.shouldDisplay {
-                        AttentionDotView()
-                    }
-                }
-                .padding(.vertical, 6)
+            buttonLabel
         }
         .accessibilityLabel("NewSpaceButton")
+    }
+    
+    private var menuContent: some View {
+        Menu {
+            CreateChannelMenuItems(
+                onTapPersonal: { spaceCreationTip.invalidate(); onTapPersonal() },
+                onTapGroup: { spaceCreationTip.invalidate(); onTapGroup() },
+                onTapJoinQR: { spaceCreationTip.invalidate(); onTapJoinQR() }
+            )
+        } label: {
+            buttonLabel
+        }
+        .accessibilityLabel("NewSpaceButton")
+    }
+    
+    private var buttonLabel: some View {
+        Image(asset: .X32.addFilled)
+            .foregroundStyle(Color.Control.secondary)
+            .frame(width: 32, height: 32)
+            .overlay(alignment: .bottomLeading) {
+                if spaceCreationTip.shouldDisplay {
+                    AttentionDotView()
+                }
+            }
+            .padding(.vertical, 6)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubToolbar.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubToolbar.swift
@@ -1,12 +1,17 @@
 import SwiftUI
+import AnytypeCore
 
 struct SpaceHubToolbar: ToolbarContent {
 
     let profileIcon: Icon?
     let notificationsNotDetermined: Bool
+    let hideCreateButton: Bool
     let namespace: Namespace.ID
 
     let onTapCreateSpace: () -> Void
+    let onTapCreatePersonalChannel: () -> Void
+    let onTapCreateGroupChannel: () -> Void
+    let onTapJoinViaQrCode: () -> Void
     let onTapSettings: () -> Void
     
     var body: some ToolbarContent {
@@ -35,9 +40,14 @@ struct SpaceHubToolbar: ToolbarContent {
             }
         }
         
-        ToolbarItem(placement: .topBarTrailing) {
-            SpaceHubNewSpaceButton {
-                onTapCreateSpace()
+        if !hideCreateButton {
+            ToolbarItem(placement: .topBarTrailing) {
+                SpaceHubNewSpaceButton(
+                    onTap: { onTapCreateSpace() },
+                    onTapPersonal: { onTapCreatePersonalChannel() },
+                    onTapGroup: { onTapCreateGroupChannel() },
+                    onTapJoinQR: { onTapJoinViaQrCode() }
+                )
             }
         }
     }
@@ -62,17 +72,32 @@ struct SpaceHubToolbar: ToolbarContent {
         }
         .sharedBackgroundVisibility(.hidden)
         
-        DefaultToolbarItem(kind: .search, placement: .bottomBar)
+        if !hideCreateButton {
+            DefaultToolbarItem(kind: .search, placement: .bottomBar)
         
-        ToolbarSpacer(placement: .bottomBar)
-
-        ToolbarItem(placement: .bottomBar) {
-            Button { onTapCreateSpace() } label: {
-                Image(systemName: "plus")
-                    .foregroundStyle(Color.Control.primary)
+            ToolbarSpacer(placement: .bottomBar)
+        
+            ToolbarItem(placement: .bottomBar) {
+                if FeatureFlags.createChannelFlow {
+                    Menu {
+                        CreateChannelMenuItems(
+                            onTapPersonal: { onTapCreatePersonalChannel() },
+                            onTapGroup: { onTapCreateGroupChannel() },
+                            onTapJoinQR: { onTapJoinViaQrCode() }
+                        )
+                    } label: {
+                        Image(systemName: "plus")
+                            .foregroundStyle(Color.Control.primary)
+                    }
+                } else {
+                    Button { onTapCreateSpace() } label: {
+                        Image(systemName: "plus")
+                            .foregroundStyle(Color.Control.primary)
+                    }
+                }
             }
+            .matchedTransitionSource(id: "SpaceCreateTypePickerView", in: namespace)
         }
-        .matchedTransitionSource(id: "SpaceCreateTypePickerView", in: namespace)
     }
 
     private var attentionDotView: some View {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceTypePicker/CreateChannelMenuItems.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceTypePicker/CreateChannelMenuItems.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct CreateChannelMenuItems: View {
+
+    let onTapPersonal: () -> Void
+    let onTapGroup: () -> Void
+    let onTapJoinQR: () -> Void
+
+    var body: some View {
+        Group {
+            Button { onTapJoinQR() } label: {
+                Label(Loc.Qr.Join.title, systemImage: "qrcode")
+            }
+            Button { onTapGroup() } label: {
+                Label(Loc.Channel.Create.group, systemImage: "person.2.fill")
+            }
+            Button { onTapPersonal() } label: {
+                Label(Loc.Channel.Create.personal, systemImage: "person.fill")
+            }
+        }
+        .tint(Color.Control.primary)
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/SpacesManager/SpacesManagerView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpacesManager/SpacesManagerView.swift
@@ -14,7 +14,6 @@ struct SpacesManagerView: View {
             .onAppear {
                 model.onAppear()
             }
-            .background(Color.Background.primary)
             .anytypeSheet(item: $model.spaceForCancelRequestAlert) { space in
                 SpaceCancelRequestAlert(spaceId: space.targetSpaceId)
             }
@@ -30,7 +29,7 @@ struct SpacesManagerView: View {
             .sheet(item: $model.exportSpaceUrl) { link in
                 ActivityView(activityItems: [link])
             }
-            .anytypeSheet(isPresented: $model.showSpaceTypeForCreate) {
+            .sheet(isPresented: $model.showSpaceTypeForCreate) {
                 SpaceCreateTypePickerView(onSelectSpaceType: { type in
                     model.onSpaceTypeSelected(type)
                 }, onSelectQrCodeScan: {

--- a/Anytype/Sources/PresentationLayer/Modules/SpacesManager/SpacesManagerView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpacesManager/SpacesManagerView.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import AnytypeCore
 
 struct SpacesManagerView: View {
 
@@ -46,6 +47,19 @@ struct SpacesManagerView: View {
     private var content: some View {
         if model.participantSpaces.isNotEmpty {
             spaces
+        } else {
+            emptyState
+        }
+    }
+    
+    @ViewBuilder
+    private var emptyState: some View {
+        if FeatureFlags.createChannelFlow {
+            CreateChannelEmptyStateView(
+                onTapPersonal: { model.onTapCreatePersonalChannel() },
+                onTapGroup: { model.onTapCreateGroupChannel() },
+                onTapJoinQR: { model.onSelectQrCodeScan() }
+            )
         } else {
             EmptyStateView(
                 title: Loc.thereAreNoSpacesYet,

--- a/Anytype/Sources/PresentationLayer/Modules/SpacesManager/SpacesManagerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpacesManager/SpacesManagerViewModel.swift
@@ -73,6 +73,14 @@ final class SpacesManagerViewModel {
     func onSpaceTypeSelected(_ type: SpaceUxType) {
             spaceCreateData = SpaceCreateData(spaceUxType: type)
     }
+
+    func onTapCreatePersonalChannel() {
+        spaceCreateData = SpaceCreateData(spaceUxType: .data)
+    }
+
+    func onTapCreateGroupChannel() {
+        // Placeholder — will be implemented in IOS-5906
+    }
 }
 
 private extension ParticipantSpaceViewData {

--- a/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
@@ -18,6 +18,10 @@ public extension FeatureFlags {
         value(for: .qrCodeCircularText)
     }
 
+    static var createChannelFlow: Bool {
+        value(for: .createChannelFlow)
+    }
+
     static var channelTypeSwitcher: Bool {
         value(for: .channelTypeSwitcher)
     }
@@ -107,6 +111,7 @@ public extension FeatureFlags {
         .showUploadStatusIndicator,
         .homePage,
         .qrCodeCircularText,
+        .createChannelFlow,
         .channelTypeSwitcher,
         .setKanbanView,
         .fullInlineSetImpl,

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -23,6 +23,13 @@ public extension FeatureDescription {
         debugValue: true
     )
     
+    static let createChannelFlow = FeatureDescription(
+        title: "Create Channel Flow - IOS-5856",
+        category: .productFeature(author: "k@anytype.io", targetRelease: "18"),
+        defaultValue: false,
+        debugValue: true
+    )
+
     // should be disabled
     static let channelTypeSwitcher = FeatureDescription(
         title: "Channel type switcher - IOS-5378",

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -1420,6 +1420,12 @@ public enum Loc {
   public static let propertiesFormats = Loc.tr("Workspace", "Properties formats", fallback: "Properties formats")
   public static let shared = Loc.tr("Workspace", "Shared", fallback: "Shared")
   public static let task = Loc.tr("Workspace", "Task", fallback: "Task")
+  public enum Channel {
+    public enum Create {
+      public static let group = Loc.tr("Workspace", "Channel.Create.Group", fallback: "Group")
+      public static let personal = Loc.tr("Workspace", "Channel.Create.Personal", fallback: "Personal")
+    }
+  }
   public enum Chat {
     public static let channelSettings = Loc.tr("Workspace", "Chat.ChannelSettings", fallback: "Channel Settings")
     public static let editMessage = Loc.tr("Workspace", "Chat.EditMessage", fallback: "Edit Message")

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -1424,6 +1424,10 @@ public enum Loc {
     public enum Create {
       public static let group = Loc.tr("Workspace", "Channel.Create.Group", fallback: "Group")
       public static let personal = Loc.tr("Workspace", "Channel.Create.Personal", fallback: "Personal")
+      public enum EmptyState {
+        public static let button = Loc.tr("Workspace", "Channel.Create.EmptyState.button", fallback: "Create Channel")
+        public static let title = Loc.tr("Workspace", "Channel.Create.EmptyState.title", fallback: "There are no channels yet")
+      }
     }
   }
   public enum Chat {

--- a/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
@@ -81901,6 +81901,28 @@
           }
         }
       }
+    },
+    "Channel.Create.EmptyState.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There are no channels yet"
+          }
+        }
+      }
+    },
+    "Channel.Create.EmptyState.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Channel"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
@@ -81879,6 +81879,28 @@
           }
         }
       }
+    },
+    "Channel.Create.Personal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personal"
+          }
+        }
+      }
+    },
+    "Channel.Create.Group": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group"
+          }
+        }
+      }
     }
   },
   "version": "1.0"


### PR DESCRIPTION
## Summary
- Fix background color mismatch in dark mode on the Channels screen empty state in settings: `EmptyStateView` VStack now fills full width so the sheet's native background is consistent
- Fix space type picker rendering: use `.sheet` instead of `.anytypeSheet` (which used `fullScreenCover` + clear background) so the picker appears as a proper bottom sheet
- Remove explicit `.background(Color.Background.primary)` from `SpacesManagerView` to use the native sheet background color