### PR TITLE
IOS-5522: Auto-open space from invite link for existing members

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceJoin/SpaceJoinViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceJoin/SpaceJoinViewModel.swift
@@ -114,14 +114,14 @@ final class SpaceJoinViewModel {
         dismiss.toggle()
     }
     
-    func onTapManageSpaces() {
-        callManageSpaces = true
-        dismiss.toggle()
-    }
-    
     func onTapGoToSpace() async throws {
         guard let inviteView else { return }
         try await activeSpaceManager.setActiveSpace(spaceId: inviteView.spaceId)
+        dismiss.toggle()
+    }
+
+    func onTapManageSpaces() {
+        callManageSpaces = true
         dismiss.toggle()
     }
     
@@ -155,24 +155,33 @@ final class SpaceJoinViewModel {
         do {
             let inviteView = try await workspaceService.inviteView(cid: data.cid, key: data.key)
             
-            handleInviteType(inviteView: inviteView)
-            
             self.inviteView = inviteView
-            state = .data
-            
-            let inviteWithoutApprove = inviteView.inviteType.withoutApprove
+
             if let spaceView = workspaceStorage.allSpaceViews.first(where: { $0.targetSpaceId == inviteView.spaceId }) {
                 switch spaceView.accountStatus {
+                case .spaceActive:
+                    // IOS-5522: Auto-open space for existing members
+                    try? await activeSpaceManager.setActiveSpace(spaceId: inviteView.spaceId)
+                    dismiss.toggle()
+                    return
+                case .unknown:
+                    dataState = .alreadyJoined
+                    state = .data
+                    return
                 case .spaceJoining:
                     dataState = .requestSent
-                case .spaceActive, .unknown:
-                    dataState = .alreadyJoined
+                    state = .data
+                    return
                 default:
-                    dataState = .invite(withoutApprove: inviteWithoutApprove)
+                    break
                 }
-            } else {
-                dataState = .invite(withoutApprove: inviteWithoutApprove)
             }
+
+            handleInviteType(inviteView: inviteView)
+
+            let inviteWithoutApprove = inviteView.inviteType.withoutApprove
+            dataState = .invite(withoutApprove: inviteWithoutApprove)
+            state = .data
         } catch let error as SpaceInviteViewError where error.code == .inviteNotFound {
             dataState = .inviteNotFound
             state = .data

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceJoin/SpaceJoinViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceJoin/SpaceJoinViewModel.swift
@@ -161,9 +161,15 @@ final class SpaceJoinViewModel {
                 switch spaceView.accountStatus {
                 case .spaceActive:
                     // IOS-5522: Auto-open space for existing members
-                    try? await activeSpaceManager.setActiveSpace(spaceId: inviteView.spaceId)
-                    dismiss.toggle()
-                    return
+                    do {
+                        try await activeSpaceManager.setActiveSpace(spaceId: inviteView.spaceId)
+                        dismiss.toggle()
+                        return
+                    } catch {
+                        dataState = .alreadyJoined
+                        state = .data
+                        return
+                    }
                 case .unknown:
                     dataState = .alreadyJoined
                     state = .data


### PR DESCRIPTION
## Summary

- When a user clicks an invite link for a space they're already an active member of (`.spaceActive`), automatically switch to that space instead of showing the "You are already a member" confirmation modal
- Falls back to showing the modal if the space switch fails, or if the account status is `.unknown` (space not loaded yet)