### PR TITLE
IOS-5809: Mute and Hide notification setting for chat objects

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -214,11 +214,21 @@ final class HomeWidgetsViewModel {
 
         let previewsSequence = await chatMessagesPreviewsStorage.previewsSequenceWithEmpty
         let chatsSequence = await chatDetailsStorage.allChatsSequence
+        let spaceViewSequence = workspaceStorage.spaceViewPublisher(spaceId: spaceId).removeDuplicates().values
 
-        for await (previews, chatDetails) in combineLatest(previewsSequence, chatsSequence) {
+        for await (previews, chatDetails, currentSpaceView) in combineLatest(previewsSequence, chatsSequence, spaceViewSequence) {
             let newUnreadChats = previews
                 .filter { preview in
-                    guard preview.spaceId == spaceId && (preview.unreadCounter > 0 || preview.hasUnreadReactions) else { return false }
+                    guard preview.spaceId == spaceId else { return false }
+
+                    if FeatureFlags.muteAndHide {
+                        let mode = currentSpaceView.effectiveNotificationMode(for: preview.chatId)
+                        if mode == .nothing {
+                            guard preview.mentionCounter > 0 || preview.hasUnreadReactions else { return false }
+                        }
+                    }
+
+                    guard preview.unreadCounter > 0 || preview.hasUnreadReactions else { return false }
                     guard let chatDetail = chatDetails.first(where: { $0.id == preview.chatId }) else { return false }
                     return !chatDetail.isArchivedOrDeleted
                 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -228,7 +228,7 @@ final class HomeWidgetsViewModel {
                         }
                     }
 
-                    guard preview.unreadCounter > 0 || preview.hasUnreadReactions else { return false }
+                    guard preview.hasCounters else { return false }
                     guard let chatDetail = chatDetails.first(where: { $0.id == preview.chatId }) else { return false }
                     return !chatDetail.isArchivedOrDeleted
                 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Container/WidgetContainerView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Container/WidgetContainerView.swift
@@ -74,7 +74,7 @@ struct WidgetContainerView<Content: View>: View {
                         titleColor: badgeModel?.titleColor ?? .Text.primary,
                         icon: icon,
                         rightAccessory: {
-                            if let badgeModel, badgeModel.hasCounters {
+                            if let badgeModel, badgeModel.hasVisibleCounters {
                                 HStack(spacing: 4) {
                                     if badgeModel.hasUnreadReactions {
                                         HeartBadge(style: badgeModel.reactionStyle)
@@ -82,7 +82,7 @@ struct WidgetContainerView<Content: View>: View {
                                     if badgeModel.mentionCounter > 0 {
                                         MentionBadge(style: badgeModel.mentionCounterStyle)
                                     }
-                                    if badgeModel.unreadCounter > 0 {
+                                    if badgeModel.shouldShowUnreadCounter {
                                         CounterView(
                                             count: badgeModel.unreadCounter,
                                             style: badgeModel.unreadCounterStyle

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/Content/Subviews/ListWidgetCompactRow.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/Content/Subviews/ListWidgetCompactRow.swift
@@ -27,7 +27,7 @@ struct ListWidgetCompactRow: View {
 
                 Spacer()
 
-                if let chatPreview = model.chatPreview, chatPreview.hasCounters {
+                if let chatPreview = model.chatPreview, chatPreview.hasVisibleCounters {
                     HStack(spacing: 4) {
                         if chatPreview.hasUnreadReactions {
                             HeartBadge(style: chatPreview.reactionStyle)
@@ -35,7 +35,7 @@ struct ListWidgetCompactRow: View {
                         if chatPreview.mentionCounter > 0 {
                             MentionBadge(style: chatPreview.mentionCounterStyle)
                         }
-                        if chatPreview.unreadCounter > 0 {
+                        if chatPreview.shouldShowUnreadCounter {
                             CounterView(
                                 count: chatPreview.unreadCounter,
                                 style: chatPreview.unreadCounterStyle

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/Content/Subviews/ListWidgetRow.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/Content/Subviews/ListWidgetRow.swift
@@ -75,7 +75,7 @@ struct ListWidgetRow: View {
 
                 Spacer()
 
-                if chatPreview.hasCounters {
+                if chatPreview.hasVisibleCounters {
                     HStack(spacing: 4) {
                         if chatPreview.hasUnreadReactions {
                             HeartBadge(style: chatPreview.reactionStyle)
@@ -83,7 +83,7 @@ struct ListWidgetRow: View {
                         if chatPreview.mentionCounter > 0 {
                             MentionBadge(style: chatPreview.mentionCounterStyle)
                         }
-                        if chatPreview.unreadCounter > 0 {
+                        if chatPreview.shouldShowUnreadCounter {
                             CounterView(
                                 count: chatPreview.unreadCounter,
                                 style: chatPreview.unreadCounterStyle

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatRowView.swift
@@ -23,7 +23,7 @@ struct UnreadChatRowView: View {
                     .frame(width: 20, height: 20)
 
                 AnytypeText(model.name, style: .bodySemibold)
-                    .foregroundStyle(Color.Text.primary)
+                    .foregroundStyle(model.muted ? Color.Text.secondary : Color.Text.primary)
                     .lineLimit(1)
 
                 Spacer()
@@ -35,7 +35,7 @@ struct UnreadChatRowView: View {
                     if model.hasMentions {
                         MentionBadge(style: model.muted ? .muted : .highlighted)
                     }
-                    if model.unreadCounter > 0 {
+                    if model.unreadCounter > 0 && !(FeatureFlags.muteAndHide && model.notificationMode == .nothing) {
                         CounterView(count: model.unreadCounter, style: model.muted ? .muted : .highlighted)
                     }
                 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatRowView.swift
@@ -35,7 +35,7 @@ struct UnreadChatRowView: View {
                     if model.hasMentions {
                         MentionBadge(style: model.muted ? .muted : .highlighted)
                     }
-                    if model.unreadCounter > 0 && !(FeatureFlags.muteAndHide && model.notificationMode == .nothing) {
+                    if model.shouldShowUnreadCounter {
                         CounterView(count: model.unreadCounter, style: model.muted ? .muted : .highlighted)
                     }
                 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatRowView.swift
@@ -23,7 +23,7 @@ struct UnreadChatRowView: View {
                     .frame(width: 20, height: 20)
 
                 AnytypeText(model.name, style: .bodySemibold)
-                    .foregroundStyle(model.muted ? Color.Text.secondary : Color.Text.primary)
+                    .foregroundStyle(model.notificationMode == .nothing ? Color.Text.secondary : Color.Text.primary)
                     .lineLimit(1)
 
                 Spacer()

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatWidgetViewModel.swift
@@ -27,10 +27,7 @@ final class UnreadChatWidgetViewModel {
     private(set) var hasMentions: Bool = false
     private(set) var hasUnreadReactions: Bool = false
     private(set) var notificationMode: SpacePushNotificationsMode = .all
-    var muted: Bool {
-        guard FeatureFlags.muteAndHide else { return notificationMode != .all }
-        return notificationMode == .nothing
-    }
+    var muted: Bool { notificationMode != .all }
 
     var shouldShowUnreadCounter: Bool {
         guard FeatureFlags.muteAndHide else { return unreadCounter > 0 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatWidgetViewModel.swift
@@ -27,7 +27,10 @@ final class UnreadChatWidgetViewModel {
     private(set) var hasMentions: Bool = false
     private(set) var hasUnreadReactions: Bool = false
     private(set) var notificationMode: SpacePushNotificationsMode = .all
-    var muted: Bool { notificationMode != .all }
+    var muted: Bool {
+        guard FeatureFlags.muteAndHide else { return notificationMode != .all }
+        return notificationMode == .nothing
+    }
 
     var shouldShowUnreadCounter: Bool {
         guard FeatureFlags.muteAndHide else { return unreadCounter > 0 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatWidgetViewModel.swift
@@ -26,7 +26,8 @@ final class UnreadChatWidgetViewModel {
     private(set) var unreadCounter: Int = 0
     private(set) var hasMentions: Bool = false
     private(set) var hasUnreadReactions: Bool = false
-    private(set) var muted: Bool = false
+    private(set) var notificationMode: SpacePushNotificationsMode = .all
+    var muted: Bool { notificationMode != .all }
 
     init(data: UnreadChatWidgetData) {
         self.data = data
@@ -55,7 +56,7 @@ final class UnreadChatWidgetViewModel {
 
     private func startMutedSubscription() async {
         for await spaceView in spaceViewsStorage.spaceViewPublisher(spaceId: data.spaceId).values {
-            muted = spaceView.effectiveNotificationMode(for: data.id) != .all
+            notificationMode = spaceView.effectiveNotificationMode(for: data.id)
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadChatWidgetViewModel.swift
@@ -29,6 +29,11 @@ final class UnreadChatWidgetViewModel {
     private(set) var notificationMode: SpacePushNotificationsMode = .all
     var muted: Bool { notificationMode != .all }
 
+    var shouldShowUnreadCounter: Bool {
+        guard FeatureFlags.muteAndHide else { return unreadCounter > 0 }
+        return unreadCounter > 0 && notificationMode != .nothing
+    }
+
     init(data: UnreadChatWidgetData) {
         self.data = data
     }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpaceHubSpacesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpaceHubSpacesStorage.swift
@@ -56,7 +56,7 @@ actor SpaceHubSpacesStorage: SpaceHubSpacesStorageProtocol {
                     let unreadPreviews = nonArchivedPreviews
                         .filter { preview in
                             guard preview.hasCounters else { return false }
-                            if FeatureFlags.muteAndHide {
+                            if FeatureFlags.muteAndHide && space.spaceView.uxType.supportsMultiChats {
                                 let mode = space.spaceView.effectiveNotificationMode(for: preview.chatId)
                                 if mode == .nothing {
                                     return preview.mentionCounter > 0 || preview.hasUnreadReactions

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpaceHubSpacesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpaceHubSpacesStorage.swift
@@ -54,7 +54,16 @@ actor SpaceHubSpacesStorage: SpaceHubSpacesStorageProtocol {
                     )
 
                     let unreadPreviews = nonArchivedPreviews
-                        .filter { $0.hasCounters }
+                        .filter { preview in
+                            guard preview.hasCounters else { return false }
+                            if FeatureFlags.muteAndHide {
+                                let mode = space.spaceView.effectiveNotificationMode(for: preview.chatId)
+                                if mode == .nothing {
+                                    return preview.mentionCounter > 0 || preview.hasUnreadReactions
+                                }
+                            }
+                            return true
+                        }
                         .sorted { preview1, preview2 in
                             let date1 = preview1.lastMessage?.createdAt ?? .distantPast
                             let date2 = preview2.lastMessage?.createdAt ?? .distantPast

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
@@ -56,7 +56,7 @@ enum SpacePreviewCountersBuilder {
 
             if FeatureFlags.muteAndHide {
                 switch effectiveMode {
-                case .all:
+                case .all, .UNRECOGNIZED:
                     totalUnread += preview.unreadCounter
                     // TODO: IOS-5561 - Temporary client-side fix. Should be handled by middleware.
                     if spaceView.uxType.supportsMentions {
@@ -66,7 +66,7 @@ enum SpacePreviewCountersBuilder {
                     if spaceView.uxType.supportsMentions {
                         totalMentions += preview.mentionCounter
                     }
-                case .nothing, .UNRECOGNIZED:
+                case .nothing:
                     if spaceView.uxType.supportsMentions {
                         totalMentions += preview.mentionCounter
                     }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
@@ -1,4 +1,5 @@
 import Services
+import AnytypeCore
 
 struct SpacePreviewCountersData: Equatable {
     let totalUnread: Int
@@ -53,10 +54,29 @@ enum SpacePreviewCountersBuilder {
         for preview in previews {
             let effectiveMode = spaceView.effectiveNotificationMode(for: preview.chatId)
 
-            totalUnread += preview.unreadCounter
-            // TODO: IOS-5561 - Temporary client-side fix. Should be handled by middleware.
-            if spaceView.uxType.supportsMentions {
-                totalMentions += preview.mentionCounter
+            if FeatureFlags.muteAndHide {
+                switch effectiveMode {
+                case .all:
+                    totalUnread += preview.unreadCounter
+                    // TODO: IOS-5561 - Temporary client-side fix. Should be handled by middleware.
+                    if spaceView.uxType.supportsMentions {
+                        totalMentions += preview.mentionCounter
+                    }
+                case .mentions:
+                    if spaceView.uxType.supportsMentions {
+                        totalMentions += preview.mentionCounter
+                    }
+                case .nothing, .UNRECOGNIZED:
+                    if spaceView.uxType.supportsMentions {
+                        totalMentions += preview.mentionCounter
+                    }
+                }
+            } else {
+                totalUnread += preview.unreadCounter
+                // TODO: IOS-5561 - Temporary client-side fix. Should be handled by middleware.
+                if spaceView.uxType.supportsMentions {
+                    totalMentions += preview.mentionCounter
+                }
             }
 
             if preview.unreadCounter > 0 && effectiveMode == .all {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
@@ -56,13 +56,9 @@ enum SpacePreviewCountersBuilder {
 
             if FeatureFlags.muteAndHide && spaceView.uxType.supportsMultiChats {
                 switch effectiveMode {
-                case .all, .UNRECOGNIZED:
+                case .all, .mentions, .UNRECOGNIZED:
                     totalUnread += preview.unreadCounter
                     // TODO: IOS-5561 - Temporary client-side fix. Should be handled by middleware.
-                    if spaceView.uxType.supportsMentions {
-                        totalMentions += preview.mentionCounter
-                    }
-                case .mentions:
                     if spaceView.uxType.supportsMentions {
                         totalMentions += preview.mentionCounter
                     }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
@@ -54,7 +54,7 @@ enum SpacePreviewCountersBuilder {
         for preview in previews {
             let effectiveMode = spaceView.effectiveNotificationMode(for: preview.chatId)
 
-            if FeatureFlags.muteAndHide {
+            if FeatureFlags.muteAndHide && spaceView.uxType.supportsMultiChats {
                 switch effectiveMode {
                 case .all, .UNRECOGNIZED:
                     totalUnread += preview.unreadCounter

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/MessagePreviewModel+Presentation.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/MessagePreviewModel+Presentation.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AnytypeCore
 
 extension MessagePreviewModel {
 
@@ -44,5 +45,18 @@ extension MessagePreviewModel {
 
     var hasCounters: Bool {
         totalCounter > 0 || hasUnreadReactions
+    }
+
+    var shouldShowUnreadCounter: Bool {
+        guard FeatureFlags.muteAndHide else { return unreadCounter > 0 }
+        return unreadCounter > 0 && notificationMode != .nothing
+    }
+
+    var hasVisibleCounters: Bool {
+        guard FeatureFlags.muteAndHide else { return hasCounters }
+        if notificationMode == .nothing {
+            return mentionCounter > 0 || hasUnreadReactions
+        }
+        return hasCounters
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/MessagePreviewModel+Presentation.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/MessagePreviewModel+Presentation.swift
@@ -4,7 +4,8 @@ import AnytypeCore
 extension MessagePreviewModel {
 
     var isMuted: Bool {
-        !notificationMode.isUnmutedAll
+        guard FeatureFlags.muteAndHide else { return !notificationMode.isUnmutedAll }
+        return notificationMode == .nothing
     }
 
     var unreadCounterStyle: CounterViewStyle {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Collection/Cell/SetChatPreviewView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Collection/Cell/SetChatPreviewView.swift
@@ -20,7 +20,7 @@ struct SetChatPreviewView: View {
 
                 Spacer()
 
-                if chatPreview.hasCounters {
+                if chatPreview.hasVisibleCounters {
                     HStack(spacing: 4) {
                         if chatPreview.hasUnreadReactions {
                             HeartBadge(style: chatPreview.reactionStyle)
@@ -28,7 +28,7 @@ struct SetChatPreviewView: View {
                         if chatPreview.mentionCounter > 0 {
                             MentionBadge(style: chatPreview.mentionCounterStyle)
                         }
-                        if chatPreview.unreadCounter > 0 {
+                        if chatPreview.shouldShowUnreadCounter {
                             CounterView(
                                 count: chatPreview.unreadCounter,
                                 style: chatPreview.unreadCounterStyle

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Collection/Cell/SetListChatPreviewView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Collection/Cell/SetListChatPreviewView.swift
@@ -34,7 +34,7 @@ struct SetListChatPreviewView: View {
 
                     Spacer()
 
-                    if chatPreview.hasCounters {
+                    if chatPreview.hasVisibleCounters {
                         HStack(spacing: 4) {
                             if chatPreview.hasUnreadReactions {
                                 HeartBadge(style: chatPreview.reactionStyle)
@@ -42,7 +42,7 @@ struct SetListChatPreviewView: View {
                             if chatPreview.mentionCounter > 0 {
                                 MentionBadge(style: chatPreview.mentionCounterStyle)
                             }
-                            if chatPreview.unreadCounter > 0 {
+                            if chatPreview.shouldShowUnreadCounter {
                                 CounterView(
                                     count: chatPreview.unreadCounter,
                                     style: chatPreview.unreadCounterStyle

--- a/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
@@ -22,6 +22,10 @@ public extension FeatureFlags {
         value(for: .channelTypeSwitcher)
     }
 
+    static var muteAndHide: Bool {
+        value(for: .muteAndHide)
+    }
+
     static var setKanbanView: Bool {
         value(for: .setKanbanView)
     }
@@ -108,6 +112,7 @@ public extension FeatureFlags {
         .homePage,
         .qrCodeCircularText,
         .channelTypeSwitcher,
+        .muteAndHide,
         .setKanbanView,
         .fullInlineSetImpl,
         .dndOnCollectionsAndSets,

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -30,6 +30,12 @@ public extension FeatureDescription {
         defaultValue: false
     )
 
+    static let muteAndHide = FeatureDescription(
+        title: "Mute and hide notification setting - IOS-5809",
+        category: .productFeature(author: "k@anytype.io", targetRelease: "18"),
+        defaultValue: true
+    )
+
     // MARK: - Experemental
     
     static let setKanbanView = FeatureDescription(


### PR DESCRIPTION
## Summary

- Add "Mute and Hide" behavior for chat objects in multi-chat spaces (`.nothing` notification mode)
- When enabled: no unread counter, gray title, excluded from Unread section and Space Hub counter — except when @mentioned or reacted to
- Space Hub counter aggregation is now notification-mode-aware (only for multi-chat spaces)
- All changes gated behind `FeatureFlags.muteAndHide` (default: `true`)

## Changes

- **Feature flag**: `muteAndHide` in `FeatureDescription+Flags.swift`
- **Counter hiding**: `shouldShowUnreadCounter` / `hasVisibleCounters` on `MessagePreviewModel` — used by 6 cell views
- **Unread section**: Filter `.nothing` chats unless mention/reaction; added `spaceViewPublisher` reactivity
- **Space Hub**: Mode-aware counter aggregation + preview text filtering (scoped to `supportsMultiChats`)
- **Title color**: Gray only for `.nothing` mode (`.mentions` stays black)
- **Unread row**: `notificationMode` stored in ViewModel for counter/title logic