### PR TITLE
IOS-5913 Discussion MVP 3: flat layout, context menu preview, unsupported blocks

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorViewModel.swift
@@ -31,7 +31,6 @@ final class DiscussionCoordinatorViewModel: DiscussionModuleOutput, ObjectSettin
     var participantsReactionData: MessageParticipantsReactionData?
     var safariUrl: URL?
     var cameraData: SimpleCameraData?
-    var showSpaceSettingsData: AccountInfo?
     var newLinkedObject: EditorScreenData?
     var spaceShareData: SpaceShareData?
     var qrCodeInviteLink: URL?

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -18,7 +18,7 @@ struct DiscussionView: View {
 
     var body: some View {
         ZStack {
-            HomeWallpaperView(spaceId: model.spaceId)
+            Color.Background.primary
             mainView
                 .ignoresSafeArea()
         }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -209,7 +209,7 @@ struct DiscussionView: View {
     private func cell(data: MessageSectionItem) -> some View {
         switch data {
         case .message(let data):
-            MessageView(data: data, output: model)
+            DiscussionMessageView(data: data, output: model)
         case .unread:
             ChatMessageUnreadView()
         }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
@@ -18,7 +18,6 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
 
     private let accountParticipantsStorage: any ParticipantsStorageProtocol = Container.shared.participantsStorage()
     private let messageTextBuilder: any MessageTextBuilderProtocol = Container.shared.messageTextBuilder()
-    private let workspaceStorage: any SpaceViewsStorageProtocol = Container.shared.spaceViewsStorage()
     private let openDocumentProvider: any OpenedDocumentsProviderProtocol = Container.shared.openedDocumentProvider()
 
     private let spaceId: String
@@ -38,9 +37,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
         limits: any ChatMessageLimitsProtocol
     ) async -> [MessageSectionData] {
 
-        let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
-        let showsMessageAuthor = spaceUxType?.showsMessageAuthor ?? true
-        let positionsYourMessageOnRight = spaceUxType?.positionsYourMessageOnRight ?? true
+        // Discussion always shows all authors equally, no left/right distinction
         let participant = accountParticipantsStorage.participants.first { $0.spaceId == spaceId }
         let chatObject = openDocumentProvider.document(objectId: chatId, spaceId: spaceId)
         let isChatDeletedOrArchived = (chatObject.details?.isDeleted ?? false) || (chatObject.details?.isArchived ?? false)
@@ -73,7 +70,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
 
             let isYourMessage = message.creator == yourProfileIdentity
             let authorParticipant = participants.first { $0.identity == message.creator }
-            let position: MessageHorizontalPosition = (isYourMessage && positionsYourMessageOnRight) ? .right : .left
+            let position: MessageHorizontalPosition = .left
             let isUnread = message.orderID == firstUnreadMessageOrderId
             let nextIsUnread = nextMessage?.orderID == firstUnreadMessageOrderId
 
@@ -83,7 +80,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                 authorName: authorParticipant?.title ?? "",
                 authorIcon: authorParticipant?.icon.map { .object($0) } ?? Icon.object(.profile(.placeholder)),
                 authorId: authorParticipant?.id,
-                createDate: message.createdAtDate.formatted(date: .omitted, time: .shortened),
+                createDate: message.createdAtDate.formatted(date: .abbreviated, time: .omitted),
                 messageString: messageTextBuilder.makeMessage(content: message.resolvedContent(useBlocksFormat: true), spaceId: spaceId, position: position),
                 replyModel: mapReply(
                     fullMessage: fullMessage,
@@ -102,8 +99,8 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                 canAddReaction: canEdit && limits.canAddReaction(message: fullMessage.message, yourProfileIdentity: yourProfileIdentity ?? ""),
                 canReply: canEdit,
                 nextSpacing: (lastInSection || nextIsUnread) ? .disable : (lastForCurrentUser || nextDateIntervalIsBig ? .medium : .small),
-                authorIconMode: (isYourMessage || !showsMessageAuthor) ? .hidden : (lastForCurrentUser || lastInSection || nextDateIntervalIsBig ? .show : .empty),
-                showAuthorName: (firstForCurrentUser || prevDateIntervalIsBig) && !isYourMessage && showsMessageAuthor,
+                authorIconMode: .show,
+                showAuthorName: firstForCurrentUser || prevDateIntervalIsBig,
                 canDelete: isYourMessage && canEdit,
                 canEdit: isYourMessage && canEdit,
                 showMessageSyncIndicator: isYourMessage,

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
@@ -38,7 +38,7 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
 
     private let chatService: any ChatServiceProtocol = Container.shared.chatService()
     @Injected(\.searchService)
-    private var seachService: any SearchServiceProtocol
+    private var searchService: any SearchServiceProtocol
     @Injected(\.objectIdsSubscriptionService)
     private var objectIdsSubscriptionService: any ObjectIdsSubscriptionServiceProtocol
     private let mediaCacheHeatingService: any MediaCacheHeatingServiceProtocol = Container.shared.mediaCacheHeatingService()
@@ -321,7 +321,7 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
 
         guard newAttachmentsIds.isNotEmpty else { return }
         do {
-            let newAttachmentsDetails = try await seachService.searchObjects(spaceId: spaceId, objectIds: Array(newAttachmentsIds))
+            let newAttachmentsDetails = try await searchService.searchObjects(spaceId: spaceId, objectIds: Array(newAttachmentsIds))
             attachments.update(details: newAttachmentsDetails)
         } catch {}
     }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -40,6 +40,24 @@ struct DiscussionMessageView: View {
     }
 
     private var content: some View {
+        messageBody
+            .fixTappableArea()
+            .coordinateSpace(name: Constants.coordinateSpace)
+            .messageFlashBackground(id: data.id)
+            .background(Color.Background.primary)
+            .contentShape(.contextMenuPreview, Rectangle())
+            .contextMenu {
+                contextMenu
+            } preview: {
+                messageBody
+                    .background(Color.Background.primary)
+            }
+            .readFrame(space: .named(Constants.coordinateSpace)) {
+                contentCenterOffsetY = $0.midY
+            }
+    }
+
+    private var messageBody: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
             reply
@@ -48,16 +66,6 @@ struct DiscussionMessageView: View {
         }
         .padding(.horizontal, Constants.messageHorizontalPadding)
         .padding(.bottom, data.nextSpacing.height)
-        .fixTappableArea()
-        .coordinateSpace(name: Constants.coordinateSpace)
-        .messageFlashBackground(id: data.id)
-        .contentShape(.contextMenuPreview, Rectangle())
-        .contextMenu {
-            contextMenu
-        }
-        .readFrame(space: .named(Constants.coordinateSpace)) {
-            contentCenterOffsetY = $0.midY
-        }
     }
 
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -1,0 +1,252 @@
+import Foundation
+import SwiftUI
+import AnytypeCore
+
+struct DiscussionMessageView: View {
+
+    private enum Constants {
+        static let attachmentsPadding: CGFloat = 4
+        static let messageHorizontalPadding: CGFloat = 16
+        static let coordinateSpace = "DiscussionMessageViewCoordinateSpace"
+        static let emoji = ["👍", "️️❤️", "😂"]
+    }
+
+    private let data: MessageViewData
+    private weak var output: (any MessageModuleOutput)?
+
+    @State private var contentCenterOffsetY: CGFloat = 0
+
+    init(
+        data: MessageViewData,
+        output: (any MessageModuleOutput)? = nil
+    ) {
+        self.data = data
+        self.output = output
+    }
+
+    var body: some View {
+        MessageReplyActionView(
+            isEnabled: data.canReply,
+            contentHorizontalPadding: Constants.messageHorizontalPadding,
+            centerOffsetY: $contentCenterOffsetY,
+            content: {
+                content
+            },
+            action: {
+                output?.didSelectReplyTo(message: data)
+            }
+        )
+        .id(data.id)
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            reply
+            messageContent
+            reactions
+        }
+        .padding(.horizontal, Constants.messageHorizontalPadding)
+        .padding(.bottom, data.nextSpacing.height)
+        .fixTappableArea()
+        .coordinateSpace(name: Constants.coordinateSpace)
+        .messageFlashBackground(id: data.id)
+        .contentShape(.contextMenuPreview, Rectangle())
+        .contextMenu {
+            contextMenu
+        }
+        .readFrame(space: .named(Constants.coordinateSpace)) {
+            contentCenterOffsetY = $0.midY
+        }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        if data.showAuthorName {
+            Divider()
+                .foregroundStyle(Color.Shape.tertiary)
+                .padding(.top, 4)
+
+            HStack(spacing: 8) {
+                Button {
+                    if let authorId = data.authorId {
+                        output?.didSelectAuthor(authorId: authorId)
+                    }
+                } label: {
+                    HStack(spacing: 8) {
+                        IconView(icon: data.authorIcon)
+                            .frame(width: 28, height: 28)
+
+                        Text(data.authorName.isNotEmpty ? data.authorName : " ")
+                            .anytypeStyle(.caption1Medium)
+                            .lineLimit(1)
+                            .foregroundStyle(Color.Text.primary)
+                    }
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+
+                Text(data.createDate)
+                    .anytypeStyle(.caption2Regular)
+                    .foregroundStyle(Color.Text.secondary)
+            }
+            .padding(.top, 12)
+            .padding(.bottom, 4)
+        }
+    }
+
+    @ViewBuilder
+    private var reply: some View {
+        if let reply = data.replyModel {
+            Button {
+                output?.didSelectReplyMessage(message: data)
+            } label: {
+                MessageReplyView(model: reply)
+            }
+            .buttonStyle(.plain)
+            .padding(.bottom, 4)
+        }
+    }
+
+    @ViewBuilder
+    private var messageContent: some View {
+        linkedObjectsForTop
+
+        if !data.messageString.isEmpty {
+            Text(data.messageString)
+                .anytypeStyle(.chatText)
+                .padding(.vertical, 2)
+        }
+
+        linkedObjectsForBottom
+    }
+
+    @ViewBuilder
+    private var linkedObjectsForTop: some View {
+        if let objects = data.linkedObjects {
+            switch objects {
+            case .list:
+                EmptyView()
+            case .grid(let items):
+                MessageGridAttachmentsContainer(objects: items, spacing: 4) {
+                    output?.didSelectAttachment(data: data, details: $0)
+                }
+                .padding(.vertical, Constants.attachmentsPadding)
+            case .bookmark(let item):
+                MessageObjectBigBookmarkView(details: item, position: data.position) {
+                    output?.didSelectAttachment(data: data, details: $0)
+                }
+                .padding(.vertical, Constants.attachmentsPadding)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var linkedObjectsForBottom: some View {
+        if let objects = data.linkedObjects {
+            switch objects {
+            case .list(let items):
+                MessageListAttachmentsViewContainer(objects: items, position: data.position) {
+                    output?.didSelectAttachment(data: data, details: $0)
+                }
+                .padding(.vertical, Constants.attachmentsPadding)
+            case .grid, .bookmark:
+                EmptyView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var reactions: some View {
+        if data.reactions.isNotEmpty {
+            MessageReactionList(
+                rows: data.reactions,
+                canAddReaction: data.canAddReaction,
+                canToggleReaction: data.canAddReaction,
+                position: data.position,
+                onTapRow: { reaction in
+                    try await output?.didTapOnReaction(data: data, emoji: reaction.emoji)
+                },
+                onLongTapRow: { reaction in
+                    output?.didLongTapOnReaction(data: data, reaction: reaction)
+                },
+                onTapAdd: {
+                    output?.didSelectAddReaction(messageId: data.message.id)
+                }
+            )
+            .padding(.top, 4)
+        }
+    }
+
+    @ViewBuilder
+    private var contextMenu: some View {
+        if data.canAddReaction {
+            ControlGroup {
+                ForEach(Constants.emoji, id:\.self) { emoji in
+                    AsyncButton {
+                        try await output?.didTapOnReaction(data: data, emoji: emoji)
+                    } label: {
+                        Text(emoji)
+                    }
+                }
+                Button {
+                    output?.didSelectAddReaction(messageId: data.message.id)
+                } label: {
+                    Image(asset: .Reactions.selectEmoji)
+                }
+            }
+            .controlGroupStyle(.compactMenu)
+        }
+
+        Divider()
+
+        #if DEBUG || RELEASE_NIGHTLY
+        if data.canEdit {
+            AsyncButton {
+                try await output?.didSelectUnread(message: data)
+            } label: {
+                Label(Loc.Message.Action.unread, systemImage: "envelope.badge")
+            }
+        }
+        #endif
+
+        if data.canReply {
+            Button {
+                output?.didSelectReplyTo(message: data)
+            } label: {
+                Label(Loc.Message.Action.reply, systemImage: "arrowshape.turn.up.left")
+            }
+        }
+
+        if !data.messageString.isEmpty {
+            Button {
+                output?.didSelectCopyPlainText(message: data)
+            } label: {
+                Label(Loc.Message.Action.copyPlainText, systemImage: "doc.on.doc")
+            }
+        }
+
+        Button {
+            output?.didSelectCopyLink(message: data)
+        } label: {
+            Label(Loc.copyLink, systemImage: "link")
+        }
+
+        if data.canEdit {
+            AsyncButton {
+                await output?.didSelectEditMessage(message: data)
+            } label: {
+                Label(Loc.edit, systemImage: "pencil")
+            }
+        }
+
+        if data.canDelete {
+            Button(role: .destructive) {
+                output?.didSelectDeleteMessage(message: data)
+            } label: {
+                Label(Loc.delete, systemImage: "trash")
+            }
+        }
+    }
+}

--- a/Modules/Services/Sources/Models/ChatModels.swift
+++ b/Modules/Services/Sources/Models/ChatModels.swift
@@ -31,15 +31,43 @@ public extension ChatMessage {
         var combinedMarks: [Anytype_Model_Block.Content.Text.Mark] = []
 
         for block in blocks {
-            guard case .text(let textBlock) = block.content else { continue }
             if !combinedText.isEmpty {
                 combinedText += "\n"
             }
             let textOffset = Int32(combinedText.utf16.count)
-            combinedText += textBlock.text
-            for var mark in textBlock.marks {
-                mark.range.from += textOffset
-                mark.range.to += textOffset
+
+            if case .text(let textBlock) = block.content, textBlock.style == .paragraph {
+                combinedText += textBlock.text
+                for var mark in textBlock.marks {
+                    mark.range.from += textOffset
+                    mark.range.to += textOffset
+                    combinedMarks.append(mark)
+                }
+            } else if case .text(let textBlock) = block.content {
+                let placeholder = "UNSUPPORTED STYLE (\(textBlock.style)): \(textBlock.text)"
+                combinedText += placeholder
+                var mark = Anytype_Model_Block.Content.Text.Mark()
+                mark.type = .textColor
+                mark.param = MiddlewareColor.red.rawValue
+                mark.range = Anytype_Model_Range()
+                mark.range.from = textOffset
+                mark.range.to = textOffset + Int32(placeholder.utf16.count)
+                combinedMarks.append(mark)
+            } else {
+                let blockName: String
+                switch block.content {
+                case .link: blockName = "link"
+                case .embed: blockName = "embed"
+                case .text, nil: blockName = "unknown"
+                }
+                let placeholder = "UNSUPPORTED BLOCK: \(blockName)"
+                combinedText += placeholder
+                var mark = Anytype_Model_Block.Content.Text.Mark()
+                mark.type = .textColor
+                mark.param = MiddlewareColor.red.rawValue
+                mark.range = Anytype_Model_Range()
+                mark.range.from = textOffset
+                mark.range.to = textOffset + Int32(placeholder.utf16.count)
                 combinedMarks.append(mark)
             }
         }


### PR DESCRIPTION
## Summary
- Replace bubble messages with flat discussion-style layout using solid background instead of wallpaper
- Add context menu preview with proper background by extracting `messageBody` from `content`
- Show red placeholder text for unsupported block types and text styles in discussions
- Simplify message builder: always show author icons, use date-only format, remove left/right positioning

https://github.com/user-attachments/assets/4a1d8831-4485-4385-894d-78261a9e2e8c