### PR TITLE
IOS-5933 Add discussion layout handling

### DIFF
--- a/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
+++ b/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
@@ -78,6 +78,8 @@ extension BundledPropertiesValueProvider {
             return .bookmark
         case .chatDeprecated, .chatDerived:
             return .chat
+        case .discussion:
+            return .chat
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/Models/AttachmentsTextInfoBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/Models/AttachmentsTextInfoBuilder.swift
@@ -46,7 +46,7 @@ final class AttachmentsTextInfoBuilder {
         case .tag:
             return Loc.tag(count)
         case .UNRECOGNIZED, .dashboard, .space, .relationOptionsList, .relationOption, .spaceView,
-                .participant, .chatDeprecated, .chatDerived, .notification, .missingObject, .devices:
+                .participant, .chatDeprecated, .chatDerived, .notification, .missingObject, .devices, .discussion:
             return Loc.attachment(count)
         }
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Icon/Object/ObjectIconPicker.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Icon/Object/ObjectIconPicker.swift
@@ -49,7 +49,7 @@ struct ObjectIconPicker: View {
                 EmptyView()
             case .todo, .note, .bookmark, .UNRECOGNIZED, .relation, .relationOption,
                     .dashboard, .relationOptionsList, .audio, .video, .pdf, .date, .space,
-                    .spaceView, .tag, .chatDeprecated, .notification, .missingObject, .devices:
+                    .spaceView, .tag, .chatDeprecated, .notification, .missingObject, .devices, .discussion:
                 EmptyView()
                     .onAppear {
                         anytypeAssertionFailure("Not supported layout")

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Layout/DetailsLayout+Metadata.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Layout/DetailsLayout+Metadata.swift
@@ -16,7 +16,7 @@ extension DetailsLayout {
         case .set, .collection, .bookmark, .space, .file, .image, .objectType, .UNRECOGNIZED, .relation,
                 .relationOption, .dashboard, .relationOptionsList, .pdf, .audio,
                 .video, .date, .spaceView, .tag, .chatDeprecated, .chatDerived, .notification,
-                .missingObject, .devices:
+                .missingObject, .devices, .discussion:
             return .noImage
         }
     }
@@ -38,7 +38,7 @@ extension DetailsLayout {
         case .bookmark, .space, .file, .image, .objectType, .UNRECOGNIZED, .relation,
                 .relationOption, .dashboard, .relationOptionsList, .pdf, .audio,
                 .video, .date, .spaceView, .tag, .chatDeprecated, .chatDerived, .notification,
-                .missingObject, .devices:
+                .missingObject, .devices, .discussion:
             return ""
         }
     }
@@ -58,7 +58,7 @@ extension DetailsLayout {
         case .bookmark, .space, .file, .image, .objectType, .UNRECOGNIZED, .relation,
                 .relationOption, .dashboard, .relationOptionsList, .pdf, .audio,
                 .video, .date, .spaceView, .tag, .chatDeprecated, .chatDerived, .notification,
-                .missingObject, .devices:
+                .missingObject, .devices, .discussion:
             return ""
         }
     }

--- a/Modules/Services/Sources/Models/Details/ObjectIconBuilder.swift
+++ b/Modules/Services/Sources/Models/Details/ObjectIconBuilder.swift
@@ -56,7 +56,7 @@ public final class ObjectIconBuilder: ObjectIconBuilderProtocol {
         case .objectType:
             return objectTypeIcon(customIcon: relations.customIcon, customIconColor: relations.customIconColor, iconImage: relations.iconImage, iconEmoji: relations.iconEmoji)
         case .todo, .note, .file, .UNRECOGNIZED, .relation, .relationOption, .dashboard, .relationOptionsList,
-                .audio, .video, .pdf, .date, .tag, .chatDeprecated, .notification, .missingObject, .devices:
+                .audio, .video, .pdf, .date, .tag, .chatDeprecated, .notification, .missingObject, .devices, .discussion:
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- Add `.discussion` case to all switch statements on `ObjectType.Layout` across the app
- Maps discussion layout to chat screen type, consistent with existing `.chatDeprecated` and `.chatDerived` handling
- Covers icon builder, icon picker, layout metadata, and attachment text info builder