### PR TITLE
IOS-5913 Render headers and title with proper fonts in discussions

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -38,8 +38,8 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     private var chatInputConverter: any ChatInputConverterProtocol
     @Injected(\.discussionMessageLimits) @ObservationIgnored
     private var discussionMessageLimits: any ChatMessageLimitsProtocol
-    @Injected(\.messageTextBuilder) @ObservationIgnored
-    private var messageTextBuilder: any MessageTextBuilderProtocol
+    @Injected(\.discussionTextBuilder) @ObservationIgnored
+    private var discussionTextBuilder: any DiscussionTextBuilderProtocol
     @Injected(\.searchService) @ObservationIgnored
     private var searchService: any SearchServiceProtocol
     @Injected(\.objectTypeProvider) @ObservationIgnored
@@ -572,7 +572,7 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
             replyToMessage = ChatInputReplyModel(
                 id: message.message.id,
                 title: Loc.Chat.replyTo(message.authorName),
-                description: messageTextBuilder.makeMessaeWithoutStyle(content: message.message.resolvedContent(useBlocksFormat: true)),
+                description: discussionTextBuilder.makeMessageWithoutStyle(content: message.message.resolvedDiscussionContent()),
                 icon: message.attachmentsDetails.first?.objectIconImage
             )
         }
@@ -597,7 +597,7 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
         AnytypeAnalytics.instance().logClickMessageMenuEdit()
         clearInput()
         editMessage = messageToEdit.message
-        message = await chatInputConverter.convert(content: messageToEdit.message.resolvedContent(useBlocksFormat: true), spaceId: spaceId).value
+        message = await chatInputConverter.convert(content: messageToEdit.message.resolvedDiscussionContent().content, spaceId: spaceId).value
         let attachments = await chatStorage.attachments(message: messageToEdit.message)
         let messageAttachments = attachments.map { MessageAttachmentDetails(details: $0) }
         attachmentHandler.setLinkedObjects(messageAttachments.map { .uploadedObject($0) })

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/ChatMessage+Discussion.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/ChatMessage+Discussion.swift
@@ -1,0 +1,72 @@
+import Services
+import Foundation
+import ProtobufMessages
+
+extension ChatMessage {
+
+    /// Discussion-specific resolved content that preserves block style information for header rendering
+    func resolvedDiscussionContent() -> ResolvedDiscussionContent {
+        guard !blocks.isEmpty else {
+            return ResolvedDiscussionContent(content: message, blockStyleRanges: [])
+        }
+
+        let supportedTextStyles: Set<Anytype_Model_Block.Content.Text.Style> = [
+            .paragraph, .description_, .title,
+            .header1, .header2, .header3, .header4,
+            .toggle, .numbered, .marked, .checkbox, .quote, .callout
+        ]
+
+        var content = ChatMessageContent()
+        var combinedText = ""
+        var combinedMarks: [Anytype_Model_Block.Content.Text.Mark] = []
+        var blockStyleRanges: [ResolvedDiscussionContent.BlockStyleRange] = []
+
+        for block in blocks {
+            if !combinedText.isEmpty {
+                combinedText += "\n"
+            }
+            let textOffset = Int32(combinedText.utf16.count)
+
+            if case .text(let textBlock) = block.content, supportedTextStyles.contains(textBlock.style) {
+                combinedText += textBlock.text
+                for var mark in textBlock.marks {
+                    mark.range.from += textOffset
+                    mark.range.to += textOffset
+                    combinedMarks.append(mark)
+                }
+                let range = NSRange(location: Int(textOffset), length: textBlock.text.utf16.count)
+                blockStyleRanges.append(ResolvedDiscussionContent.BlockStyleRange(style: textBlock.style, range: range))
+            } else if case .text(let textBlock) = block.content {
+                let placeholder = "UNSUPPORTED STYLE (\(textBlock.style)): \(textBlock.text)"
+                combinedText += placeholder
+                var mark = Anytype_Model_Block.Content.Text.Mark()
+                mark.type = .textColor
+                mark.param = MiddlewareColor.red.rawValue
+                mark.range = Anytype_Model_Range()
+                mark.range.from = textOffset
+                mark.range.to = textOffset + Int32(placeholder.utf16.count)
+                combinedMarks.append(mark)
+            } else {
+                let blockName: String
+                switch block.content {
+                case .link: blockName = "link"
+                case .embed: blockName = "embed"
+                case .text, nil: blockName = "unknown"
+                }
+                let placeholder = "UNSUPPORTED BLOCK: \(blockName)"
+                combinedText += placeholder
+                var mark = Anytype_Model_Block.Content.Text.Mark()
+                mark.type = .textColor
+                mark.param = MiddlewareColor.red.rawValue
+                mark.range = Anytype_Model_Range()
+                mark.range.from = textOffset
+                mark.range.to = textOffset + Int32(placeholder.utf16.count)
+                combinedMarks.append(mark)
+            }
+        }
+
+        content.text = combinedText
+        content.marks = combinedMarks
+        return ResolvedDiscussionContent(content: content, blockStyleRanges: blockStyleRanges)
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
@@ -17,7 +17,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
     }
 
     private let accountParticipantsStorage: any ParticipantsStorageProtocol = Container.shared.participantsStorage()
-    private let messageTextBuilder: any MessageTextBuilderProtocol = Container.shared.messageTextBuilder()
+    private let discussionTextBuilder: any DiscussionTextBuilderProtocol = Container.shared.discussionTextBuilder()
     private let openDocumentProvider: any OpenedDocumentsProviderProtocol = Container.shared.openedDocumentProvider()
 
     private let spaceId: String
@@ -81,7 +81,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                 authorIcon: authorParticipant?.icon.map { .object($0) } ?? Icon.object(.profile(.placeholder)),
                 authorId: authorParticipant?.id,
                 createDate: message.createdAtDate.formatted(date: .abbreviated, time: .omitted),
-                messageString: messageTextBuilder.makeMessage(content: message.resolvedContent(useBlocksFormat: true), spaceId: spaceId, position: position),
+                messageString: discussionTextBuilder.makeMessage(content: message.resolvedDiscussionContent(), spaceId: spaceId, position: position),
                 replyModel: mapReply(
                     fullMessage: fullMessage,
                     participants: participants,
@@ -180,9 +180,9 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
             let filesCout = fullMessage.replyAttachments.count(where: \.resolvedLayoutValue.isFile)
 
             let description: String
-            if replyChat.resolvedContent(useBlocksFormat: true).text.isNotEmpty {
-                description = messageTextBuilder
-                    .makeMessaeWithoutStyle(content: replyChat.resolvedContent(useBlocksFormat: true))
+            if replyChat.resolvedDiscussionContent().content.text.isNotEmpty {
+                description = discussionTextBuilder
+                    .makeMessageWithoutStyle(content: replyChat.resolvedDiscussionContent())
                     .replacingOccurrences(of: "\n+", with: "\n", options: .regularExpression)
             } else if fullMessage.replyAttachments.count == 1 {
                 description = replyAttachment?.title ?? ""

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionTextBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionTextBuilder.swift
@@ -1,0 +1,124 @@
+import Services
+import SwiftUI
+import AnytypeCore
+import DeepLinks
+import ProtobufMessages
+
+protocol DiscussionTextBuilderProtocol: Sendable {
+    func makeMessage(content: ResolvedDiscussionContent, spaceId: String, position: MessageHorizontalPosition) -> AttributedString
+    func makeMessageWithoutStyle(content: ResolvedDiscussionContent) -> String
+}
+
+struct DiscussionTextBuilder: DiscussionTextBuilderProtocol, Sendable {
+
+    private let deepLinkParser: any DeepLinkParserProtocol = Container.shared.deepLinkParser()
+
+    func makeMessage(content: ResolvedDiscussionContent, spaceId: String, position: MessageHorizontalPosition) -> AttributedString {
+        let baseFont: AnytypeFont = .chatText
+        var message = AttributedString(content.content.text)
+
+        message.font = AnytypeFontBuilder.font(anytypeFont: baseFont)
+        message.kern = baseFont.config.kern
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = baseFont.lineHeightMultiple
+        message.paragraphStyle = paragraphStyle
+
+        let textColor = position.isRight ? UIColor.Text.white : UIColor.Text.primary
+        message.foregroundColor = textColor.suColor
+        let underlineColor = textColor.withAlphaComponent(0.3)
+        message.uiKit.underlineColor = underlineColor
+
+        for mark in content.content.marks.reversed() {
+            let nsRange = NSRange(mark.range)
+            guard let range = Range(nsRange, in: message) else {
+                continue
+            }
+
+            switch mark.type {
+            case .strikethrough:
+                message[range].strikethroughStyle = .single
+            case .keyboard:
+                message[range].font = AnytypeFontBuilder.font(anytypeFont: .codeBlock)
+            case .italic:
+                message[range].uiKit.obliqueness = CGFloat(0.2)
+            case .bold:
+                message[range].font = message[range].font?.weight(.semibold)
+            case .underscored:
+                message[range].uiKit.underlineStyle = .single
+            case .link:
+                message[range].uiKit.underlineStyle = .single
+                if let link = URL(string: mark.param) {
+                    message[range].link = link
+                }
+            case .object:
+                message[range].uiKit.underlineStyle = .single
+                if let linkToObject = createLinkToObject(mark.param, spaceId: spaceId) {
+                    message[range].link = linkToObject
+                }
+            case .textColor:
+                message[range].foregroundColor = MiddlewareColor(rawValue: mark.param).map { Color.Dark.color(from: $0) }
+            case .backgroundColor:
+                message[range].backgroundColor = MiddlewareColor(rawValue: mark.param).map { Color.Light.color(from: $0) }
+            case .mention:
+                message[range].uiKit.underlineStyle = .single
+                if let linkToObject = createLinkToObject(mark.param, spaceId: spaceId) {
+                    message[range].link = linkToObject
+                }
+            case .emoji:
+                message.replaceSubrange(range, with: AttributedString(mark.param))
+            case .UNRECOGNIZED(let int):
+                anytypeAssertionFailure("Undefined text attribute", info: ["value": int.description, "param": mark.param])
+                break
+            }
+        }
+
+        // Apply block style fonts for headers/title
+        for blockStyle in content.blockStyleRanges {
+            guard let font = anytypeFont(for: blockStyle.style) else { continue }
+            guard font != baseFont else { continue }
+            guard let range = Range(blockStyle.range, in: message) else { continue }
+
+            message[range].font = AnytypeFontBuilder.font(anytypeFont: font)
+            message[range].kern = font.config.kern
+            let styleParagraph = NSMutableParagraphStyle()
+            styleParagraph.lineHeightMultiple = font.lineHeightMultiple
+            message[range].paragraphStyle = styleParagraph
+        }
+
+        return message.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func makeMessageWithoutStyle(content: ResolvedDiscussionContent) -> String {
+        NSAttributedString(makeMessage(content: content, spaceId: "", position: .right)).string
+    }
+
+    private func anytypeFont(for style: Anytype_Model_Block.Content.Text.Style) -> AnytypeFont? {
+        switch style {
+        case .header1:
+            return .title
+        case .header2:
+            return .heading
+        case .header3, .header4:
+            return .subheading
+        case .title:
+            return .title
+        case .description_, .paragraph, .toggle, .numbered, .marked, .checkbox, .quote, .callout:
+            return .chatText
+        default:
+            return nil
+        }
+    }
+
+    private func createLinkToObject(_ objectId: String, spaceId: String) -> URL? {
+        return deepLinkParser.createUrl(
+            deepLink: .object(objectId: objectId, spaceId: spaceId),
+            scheme: .main
+        )
+    }
+}
+
+extension Container {
+    var discussionTextBuilder: Factory<any DiscussionTextBuilderProtocol> {
+        self { DiscussionTextBuilder() }.shared
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -123,7 +123,6 @@ struct DiscussionMessageView: View {
 
         if !data.messageString.isEmpty {
             Text(data.messageString)
-                .anytypeStyle(.chatText)
                 .padding(.vertical, 2)
         }
 

--- a/Modules/Services/Sources/Models/ResolvedDiscussionContent.swift
+++ b/Modules/Services/Sources/Models/ResolvedDiscussionContent.swift
@@ -1,0 +1,22 @@
+import ProtobufMessages
+import Foundation
+
+public struct ResolvedDiscussionContent {
+    public var content: ChatMessageContent
+    public var blockStyleRanges: [BlockStyleRange]
+
+    public struct BlockStyleRange {
+        public var style: Anytype_Model_Block.Content.Text.Style
+        public var range: NSRange // UTF-16 range in combined text
+
+        public init(style: Anytype_Model_Block.Content.Text.Style, range: NSRange) {
+            self.style = style
+            self.range = range
+        }
+    }
+
+    public init(content: ChatMessageContent, blockStyleRanges: [BlockStyleRange]) {
+        self.content = content
+        self.blockStyleRanges = blockStyleRanges
+    }
+}


### PR DESCRIPTION
## Summary
- Add discussion-specific text builder (`DiscussionTextBuilder`) that renders H1/H2/H3/title blocks with proper font sizes (28pt/22pt/17pt bold) instead of showing red "UNSUPPORTED STYLE" placeholders
- Create `ResolvedDiscussionContent` model to carry block style ranges alongside combined text content
- Move discussion-specific block resolution to `ChatMessage+Discussion` extension, keeping shared `ChatModels.swift` unchanged
- 
<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/0802f629-ec02-4420-9923-1958ae574b75" />
