### PR TITLE
IOS-5886 Cherry-pick: Fix empty vault state after deleting all spaces

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -135,7 +135,7 @@ final class SpaceHubViewModel {
         for await spaces in await spaceHubSpacesStorage.spacesStream {
             self.spaces = spaces.sorted(by: sortSpacesForPinnedFeature)
             await updateFilteredSpaces()
-            self.dataLoaded = spaces.isNotEmpty
+            self.dataLoaded = true
         }
     }
     


### PR DESCRIPTION
## Summary
- Cherry-pick of `3a5ae526f5` from develop — fixes white screen when user deletes all spaces (empty vault state not showing)
- User is blocked from accessing the app and needs this fix to delete their vault

## Context
Community report: user deleted all spaces, gets blank screen, cannot delete vault before switching devices.