### PR TITLE
IOS-5952 Fix crash when removing last filter or sort in edit mode

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/List/SetFiltersListView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/List/SetFiltersListView.swift
@@ -46,18 +46,17 @@ struct SetFiltersListView: View {
     }
     
     private var content: some View {
-        Group {
-            if viewModel.rows.isNotEmpty {
-                filtersList
-            } else {
-                emptyState
+        filtersList
+            .overlay {
+                if viewModel.rows.isEmpty {
+                    emptyState
+                }
             }
-        }
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                addButton
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    addButton
+                }
             }
-        }
     }
     
     private var emptyState: some View {
@@ -93,8 +92,10 @@ struct SetFiltersListView: View {
         .buttonStyle(BorderlessButtonStyle())
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                EditButton()
-                    .foregroundStyle(Color.Control.secondary)
+                if viewModel.rows.isNotEmpty {
+                    EditButton()
+                        .foregroundStyle(Color.Control.secondary)
+                }
             }
         }
         .background(Color.Background.secondary)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/List/SetFiltersListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/List/SetFiltersListViewModel.swift
@@ -31,6 +31,8 @@ final class SetFiltersListViewModel {
     private let subscriptionDetailsStorage: ObjectDetailsStorage
 
     @ObservationIgnored
+    private var deletingFilterIds = Set<String>()
+    @ObservationIgnored
     private weak var output: (any SetFiltersListCoordinatorOutput)?
     
     init(
@@ -62,14 +64,21 @@ extension SetFiltersListViewModel {
     }
     
     func delete(_ indexSet: IndexSet) {
-        indexSet.forEach { [weak self] deleteIndex in
-            guard let self else { return }
-            let filters = setDocument.filters(for: viewId)
-            guard deleteIndex < filters.count else { return }
+        let filters = setDocument.filters(for: viewId)
+
+        for deleteIndex in indexSet {
+            guard deleteIndex < filters.count else { continue }
+            deletingFilterIds.insert(filters[deleteIndex].filter.id)
+        }
+        rows.remove(atOffsets: indexSet)
+
+        for deleteIndex in indexSet {
+            guard deleteIndex < filters.count else { continue }
             let filter = filters[deleteIndex]
-            guard !filter.isAdvanced else { return }
+            guard !filter.isAdvanced else { continue }
             Task { [weak self] in
                 guard let self else { return }
+                defer { deletingFilterIds.remove(filter.filter.id) }
                 try await dataviewService.removeFilters(
                     objectId: setDocument.objectId,
                     blockId: setDocument.blockId,
@@ -92,7 +101,8 @@ extension SetFiltersListViewModel {
     }
 
     private func updateRows(with filters: [SetFilter]) {
-        rows = filters.enumerated().map { index, filter in
+        let activeFilters = filters.filter { !deletingFilterIds.contains($0.filter.id) }
+        rows = activeFilters.enumerated().map { index, filter in
             let isAdvanced = filter.isAdvanced
             return SetFilterRowConfiguration(
                 id: "\(filter.relationDetails.id)_\(index)",

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Sorts/List/SetSortsListView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Sorts/List/SetSortsListView.swift
@@ -41,18 +41,17 @@ struct SetSortsListView: View {
     }
     
     private var content: some View {
-        Group {
-            if viewModel.rows.isNotEmpty {
-                sortsList
-            } else {
-                emptyState
+        sortsList
+            .overlay {
+                if viewModel.rows.isEmpty {
+                    emptyState
+                }
             }
-        }
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                addButton
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    addButton
+                }
             }
-        }
     }
     
     private var emptyState: some View {
@@ -90,8 +89,10 @@ struct SetSortsListView: View {
         .buttonStyle(BorderlessButtonStyle())
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                EditButton()
-                    .foregroundStyle(Color.Control.secondary)
+                if viewModel.rows.isNotEmpty {
+                    EditButton()
+                        .foregroundStyle(Color.Control.secondary)
+                }
             }
         }
         .background(Color.Background.secondary)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Sorts/List/SetSortsListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Sorts/List/SetSortsListViewModel.swift
@@ -20,6 +20,8 @@ final class SetSortsListViewModel {
     private var dataviewService: any DataviewServiceProtocol
 
     @ObservationIgnored
+    private var deletingSortIds = Set<String>()
+    @ObservationIgnored
     private weak var output: (any SetSortsListCoordinatorOutput)?
     
     init(
@@ -58,13 +60,20 @@ extension SetSortsListViewModel {
     // MARK: - Actions
     
     func delete(_ indexSet: IndexSet) {
-        indexSet.forEach { [weak self] deleteIndex in
-            guard let self else { return }
-            let sorts = setDocument.sorts(for: viewId)
-            guard deleteIndex < sorts.count else { return }
+        let sorts = setDocument.sorts(for: viewId)
+
+        for deleteIndex in indexSet {
+            guard deleteIndex < sorts.count else { continue }
+            deletingSortIds.insert(sorts[deleteIndex].sort.id)
+        }
+        rows.remove(atOffsets: indexSet)
+
+        for deleteIndex in indexSet {
+            guard deleteIndex < sorts.count else { continue }
             let sort = sorts[deleteIndex]
             Task { [weak self] in
                 guard let self else { return }
+                defer { deletingSortIds.remove(sort.sort.id) }
                 try await dataviewService.removeSorts(
                     objectId: setDocument.objectId,
                     blockId: setDocument.blockId,
@@ -118,7 +127,8 @@ extension SetSortsListViewModel {
     }
     
     private func updateRows(with sorts: [SetSort]) {
-        rows = sorts.enumerated().map { index, sort in
+        let activeSorts = sorts.filter { !deletingSortIds.contains($0.sort.id) }
+        rows = activeSorts.enumerated().map { index, sort in
             SetSortRowConfiguration(
                 id: "\(sort.relationDetails.id)_\(index)",
                 title: sort.relationDetails.name,


### PR DESCRIPTION
## Summary
- Fix UICollectionView crash when removing the last filter or sort via Edit mode (minus → Delete) in Query/Data View
- Keep List always in view hierarchy using `.overlay` for empty state instead of `Group` conditional that removed UICollectionView mid-batch-update
- Add optimistic row removal and deletion ID tracking to prevent stale sync data from restoring deleted items