### PR TITLE
IOS-5953 Fix filter checkbox not updating and pre-selected items not showing

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/SelectionIndicatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/SelectionIndicatorView.swift
@@ -31,7 +31,7 @@ struct SelectionIndicatorView: View {
 
 extension SelectionIndicatorView {
     
-    enum Model {
+    enum Model: Hashable {
         case notSelected
         case selected(index: Int)
     }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Configurations/ListRowConfiguration.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Configurations/ListRowConfiguration.swift
@@ -35,7 +35,7 @@ extension ListRowConfiguration {
     }
     
     static func == (lhs: ListRowConfiguration, rhs: ListRowConfiguration) -> Bool {
-        lhs.id == lhs.id && lhs.contentHash == rhs.contentHash
+        lhs.id == rhs.id && lhs.contentHash == rhs.contentHash
     }
     
 }

--- a/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/Legacy_ObjectTypeSearchViewModel/MultiselectObjectTypesSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/Legacy_ObjectTypeSearchViewModel/MultiselectObjectTypesSearchViewModel.swift
@@ -74,13 +74,14 @@ private extension Array where Element == ObjectDetails {
 
     func asRowConfigurations(with selectedIds: [String]) -> [ListRowConfiguration] {
         map { details in
-            ListRowConfiguration(
+            let selectionIndicator = SelectionIndicatorViewModelBuilder.buildModel(id: details.id, selectedIds: selectedIds)
+            return ListRowConfiguration(
                 id: details.id,
-                contentHash: details.hashValue
+                contentHash: details.hashValue ^ selectionIndicator.hashValue
             ) {
                 SearchObjectRowView(
                     viewModel: SearchObjectRowView.Model(details: details),
-                    selectionIndicatorViewModel: SelectionIndicatorViewModelBuilder.buildModel(id: details.id, selectedIds: selectedIds)
+                    selectionIndicatorViewModel: selectionIndicator
                 ).eraseToAnyView()
             }
         }

--- a/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/ObjectsSearchViewModel/ObjectsSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/ObjectsSearchViewModel/ObjectsSearchViewModel.swift
@@ -88,17 +88,18 @@ private extension Array where Element == ObjectDetails {
 
     func asRowConfigurations(with selectedIds: [String], selectionMode: LegacySearchViewModel.SelectionMode) -> [ListRowConfiguration] {
         map { details in
-            ListRowConfiguration(
+            let selectionIndicator = selectionMode.asSelectionIndicatorViewModel(
+                details: details,
+                selectedIds: selectedIds
+            )
+            return ListRowConfiguration(
                 id: details.id,
-                contentHash: details.hashValue
+                contentHash: details.hashValue ^ (selectionIndicator?.hashValue ?? 0)
             ) {
                 AnyView(
                     SearchObjectRowView(
                         viewModel: SearchObjectRowView.Model(details: details),
-                        selectionIndicatorViewModel: selectionMode.asSelectionIndicatorViewModel(
-                            details: details,
-                            selectedIds: selectedIds
-                        )
+                        selectionIndicatorViewModel: selectionIndicator
                     )
                 )
             }

--- a/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/StatusSearchViewModel/StatusSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/StatusSearchViewModel/StatusSearchViewModel.swift
@@ -79,9 +79,10 @@ private extension Array where Element == Property.Status.Option {
 
     func asRowConfigurations(with selectedIds: [String], selectionMode: LegacySearchViewModel.SelectionMode) -> [ListRowConfiguration] {
         map { option in
-            ListRowConfiguration(
+            let selectionIndicator = selectionMode.asSelectionIndicatorViewModel(option: option, selectedIds: selectedIds)
+            return ListRowConfiguration(
                 id: option.id,
-                contentHash: option.hashValue
+                contentHash: option.hashValue ^ (selectionIndicator?.hashValue ?? 0)
             ) {
                 AnyView(
                     StatusSearchRowView(
@@ -89,7 +90,7 @@ private extension Array where Element == Property.Status.Option {
                             text: option.text,
                             color: option.color
                         ),
-                        selectionIndicatorViewModel: selectionMode.asSelectionIndicatorViewModel(option: option, selectedIds: selectedIds)
+                        selectionIndicatorViewModel: selectionIndicator
                     )
                 )
             }

--- a/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/TagsSearchViewModel/TagsSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/TagsSearchViewModel/TagsSearchViewModel.swift
@@ -80,9 +80,10 @@ private extension Array where Element == Property.Tag.Option {
     func asRowConfigurations(with selectedTagIds: [String]) -> [ListRowConfiguration] {
         let style = PropertyStyle.regular(allowMultiLine: false)
         return map { tag in
-            ListRowConfiguration(
+            let selectionIndicator = SelectionIndicatorViewModelBuilder.buildModel(id: tag.id, selectedIds: selectedTagIds)
+            return ListRowConfiguration(
                 id: tag.id,
-                contentHash: tag.hashValue
+                contentHash: tag.hashValue ^ selectionIndicator.hashValue
             ) {
                 TagSearchRowView(
                     config: TagView.Config(
@@ -92,7 +93,7 @@ private extension Array where Element == Property.Tag.Option {
                         textFont: style.font,
                         guidlines: style.tagViewGuidlines
                     ),
-                    selectionIndicatorViewModel: SelectionIndicatorViewModelBuilder.buildModel(id: tag.id, selectedIds: selectedTagIds)
+                    selectionIndicatorViewModel: selectionIndicator
                 ).eraseToAnyView()
             }
         }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/Selection/List/SetFiltersContentViewBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/Selection/List/SetFiltersContentViewBuilder.swift
@@ -93,7 +93,7 @@ final class SetFiltersContentViewBuilder {
                     interactor: TagsSearchInteractor(
                         spaceId: self.spaceId,
                         relationKey: self.filter.relationDetails.key,
-                        selectedTagIds: selectedTagIds,
+                        selectedTagIds: [],
                         isPreselectModeAvailable: selectionMode.isPreselectModeAvailable
                     ),
                     onSelect: onSelect
@@ -122,7 +122,7 @@ final class SetFiltersContentViewBuilder {
                     interactor: StatusSearchInteractor(
                         spaceId: self.spaceId,
                         relationKey: self.filter.relationDetails.key,
-                        selectedStatusesIds: selectedStatusesIds,
+                        selectedStatusesIds: [],
                         isPreselectModeAvailable: selectionMode.isPreselectModeAvailable
                     ),
                     onSelect: onSelect


### PR DESCRIPTION
## Summary
- Fix filter value checkboxes not visually updating when selecting/deselecting items (Tag, Status, Object, File filters)
- Fix pre-selected filter values not appearing in the list when reopening an existing filter
- Fix `ListRowConfiguration.==` typo comparing `lhs.id == lhs.id` instead of `lhs.id == rhs.id`

Root cause: `ListRowConfiguration.contentHash` didn't include selection state, so SwiftUI's `ForEach` skipped re-rendering rows. Additionally, `TagsSearchInteractor` and `StatusSearchInteractor` excluded pre-selected IDs from search results.