### PR TITLE
IOS-5907: Show selected members on ChannelCreateView

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
@@ -39,7 +39,8 @@ final class GroupChannelCreateCoordinatorViewModel {
 
     func onSelectMembersNext(_ members: [SelectedMember]) {
         selectedMembers = members
-        spaceCreateData = SpaceCreateData(spaceUxType: .data)
-        // TODO: IOS-5904 — pass selectedMembers to SpaceCreate (separate task)
+        let selectedIdentities = Set(members.map(\.identity))
+        let contacts = selectMembersData?.contacts.filter { selectedIdentities.contains($0.identity) } ?? []
+        spaceCreateData = SpaceCreateData(spaceUxType: .data, selectedContacts: contacts)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
@@ -40,7 +40,9 @@ final class GroupChannelCreateCoordinatorViewModel {
     func onSelectMembersNext(_ members: [SelectedMember]) {
         selectedMembers = members
         let selectedIdentities = Set(members.map(\.identity))
-        let contacts = selectMembersData?.contacts.filter { selectedIdentities.contains($0.identity) } ?? []
+        let contacts = selectMembersData?.contacts
+            .filter { selectedIdentities.contains($0.identity) }
+            .sorted { $0.name.caseInsensitiveCompare($1.name) == .orderedAscending } ?? []
         spaceCreateData = SpaceCreateData(spaceUxType: .data, selectedContacts: contacts)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SelectMembers/Subviews/MemberRow.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SelectMembers/Subviews/MemberRow.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import Services
+import DesignKit
+
+struct MemberRow<Trailing: View>: View {
+
+    let icon: ObjectIcon?
+    let name: String
+    let globalName: String
+    @ViewBuilder let trailing: () -> Trailing
+
+    var body: some View {
+        HStack(spacing: 12) {
+            IconView(icon: icon?.icon)
+                .frame(width: 48, height: 48)
+
+            VStack(alignment: .leading, spacing: 0) {
+                AnytypeText(name, style: .uxTitle2Medium)
+                    .foregroundStyle(Color.Text.primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                AnytypeText(globalName, style: .caption1Regular)
+                    .foregroundStyle(Color.Text.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            trailing()
+        }
+        .fixTappableArea()
+        .padding(.horizontal, 16)
+        .padding(.vertical, 9)
+        .frame(height: 72)
+        .newDivider()
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/SelectMembers/Subviews/MemberSelectionRow.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SelectMembers/Subviews/MemberSelectionRow.swift
@@ -13,30 +13,10 @@ struct MemberSelectionRow: View {
         Button {
             isSelected.toggle()
         } label: {
-            HStack(spacing: 12) {
-                IconView(icon: icon?.icon)
-                    .frame(width: 48, height: 48)
-
-                VStack(alignment: .leading, spacing: 0) {
-                    AnytypeText(name, style: .uxTitle2Medium)
-                        .foregroundStyle(Color.Text.primary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    AnytypeText(globalName, style: .caption1Regular)
-                        .foregroundStyle(Color.Text.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
+            MemberRow(icon: icon, name: name, globalName: globalName) {
                 AnytypeCircleCheckbox(checked: $isSelected)
                     .allowsHitTesting(false)
             }
-            .fixTappableArea()
-            .padding(.horizontal, 16)
-            .padding(.vertical, 9)
-            .frame(height: 72)
-            .newDivider()
         }
         .buttonStyle(.plain)
     }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/ChannelCreateView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/ChannelCreateView.swift
@@ -15,19 +15,23 @@ struct ChannelCreateView: View {
     var body: some View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 0) {
-                iconSection
+                VStack(spacing: 0) {
+                    iconSection
 
-                FramedTextField(
-                    title: Loc.name,
-                    placeholder: Loc.untitled,
-                    axis: .vertical,
-                    text: $model.spaceName
-                )
-                .accessibilityLabel("SpaceNameTextField")
+                    FramedTextField(
+                        title: Loc.name,
+                        placeholder: Loc.untitled,
+                        axis: .vertical,
+                        text: $model.spaceName
+                    )
+                    .accessibilityLabel("SpaceNameTextField")
 
-                ThresholdCounter(usecase: .spaceName, count: model.spaceName.count)
+                    ThresholdCounter(usecase: .spaceName, count: model.spaceName.count)
+                }
+                .padding(.horizontal, 20)
+
+                membersSection
             }
-            .padding(.horizontal, 20)
         }
         .navigationTitle(Loc.Channel.Create.newChannel)
         .navigationBarTitleDisplayMode(.inline)
@@ -52,6 +56,28 @@ struct ChannelCreateView: View {
         .background(Color.Background.primary)
         .onChange(of: model.spaceName) {
             model.updateNameIconIfNeeded($1)
+        }
+    }
+
+    @ViewBuilder
+    private var membersSection: some View {
+        let contacts = model.data.selectedContacts
+        if contacts.isNotEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                Spacer.fixedHeight(20)
+                AnytypeText(
+                    Loc.membersPlural(contacts.count),
+                    style: .caption1Regular
+                )
+                .foregroundStyle(Color.Text.secondary)
+                .padding(.horizontal, 20)
+                Spacer.fixedHeight(8)
+                ForEach(contacts) { contact in
+                    MemberRow(icon: contact.icon, name: contact.name, globalName: contact.globalName) {
+                        EmptyView()
+                    }
+                }
+            }
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateData.swift
@@ -4,7 +4,13 @@ import AnytypeCore
 
 struct SpaceCreateData: Equatable, Identifiable, Hashable {
     let spaceUxType: SpaceUxType
-    
+    let selectedContacts: [Contact]
+
+    init(spaceUxType: SpaceUxType, selectedContacts: [Contact] = []) {
+        self.spaceUxType = spaceUxType
+        self.selectedContacts = selectedContacts
+    }
+
     var id: Int { hashValue }
     
     var title: String {

--- a/Anytype/Sources/ServiceLayer/ContactsService/ContactsService.swift
+++ b/Anytype/Sources/ServiceLayer/ContactsService/ContactsService.swift
@@ -21,6 +21,8 @@ final class ContactsService: ContactsServiceProtocol {
                     let subscription = participantSubscriptionProvider.subscription(spaceId: spaceView.targetSpaceId)
 
                     for await participants in subscription.participantsPublisher.values {
+                        guard participants.isNotEmpty else { continue }
+
                         if let participant = participants.first(where: { $0.identity == spaceView.oneToOneIdentity }) {
                             return Contact(
                                 identity: participant.identity,
@@ -29,6 +31,7 @@ final class ContactsService: ContactsServiceProtocol {
                                 icon: participant.icon
                             )
                         }
+                        break
                     }
                     return nil
                 }


### PR DESCRIPTION
## Summary

- Extract generic `MemberRow<Trailing>` from `MemberSelectionRow` for cell reuse across screens
- Pass selected contacts from `GroupChannelCreateCoordinator` through `SpaceCreateData` to `ChannelCreateView`
- Display members section (count header + member list) on the Name & Icon screen for Group channel flow
- Fix contact loading hang in `ContactsService` — restore break on first non-empty participant emission
- Sort selected contacts by name