### PR TITLE
IOS-5939 Unsupported block placeholder design in discussions

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionBlockItemView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionBlockItemView.swift
@@ -54,13 +54,8 @@ struct DiscussionBlockItemView: View {
             }
             .padding(.vertical, 2)
         case .unsupported(_, let blockName):
-            #if DEBUG
-            Text("UNSUPPORTED: \(blockName)")
-                .foregroundStyle(Color.Pure.red)
+            DiscussionUnsupportedBlockView(blockName: blockName)
                 .padding(.vertical, 2)
-            #else
-            EmptyView()
-            #endif
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionUnsupportedBlockView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionUnsupportedBlockView.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SwiftUI
+import AnytypeCore
+
+struct DiscussionUnsupportedBlockView: View {
+    let blockName: String
+
+    var body: some View {
+        Text(title)
+            .anytypeStyle(.caption1Medium)
+            .foregroundColor(.Text.secondary)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.Shape.transparentSecondary)
+            .clipShape(.rect(cornerRadius: 8))
+    }
+
+    private var title: String {
+        #if DEBUG
+        "\(Loc.unsupportedBlock) (\(blockName))"
+        #else
+        Loc.unsupportedBlock
+        #endif
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionUnsupportedBlockView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionUnsupportedBlockView.swift
@@ -8,7 +8,7 @@ struct DiscussionUnsupportedBlockView: View {
     var body: some View {
         Text(title)
             .anytypeStyle(.caption1Medium)
-            .foregroundColor(.Text.secondary)
+            .foregroundStyle(Color.Text.secondary)
             .padding(12)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.Shape.transparentSecondary)


### PR DESCRIPTION
## Summary
- Replace debug-only red "UNSUPPORTED" text and production `EmptyView` with a styled placeholder visible in all builds
- New `DiscussionUnsupportedBlockView` matches Figma design: `caption1Medium` text, `transparentSecondary` background, 12pt padding, 8pt corner radius
- In debug builds, block name is shown in parentheses for easier identification