### PR TITLE
IOS-5820 Restore recursive cleaning of empty advanced filters

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/DataviewFilter+Condition.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/DataviewFilter+Condition.swift
@@ -33,10 +33,11 @@ extension DataviewFilter {
 extension Array where Element == DataviewFilter {
     func removingUnsupportedFilters() -> [DataviewFilter] {
         compactMap { filter in
-            // Advanced filters (AND/OR) are created on desktop and passed through as-is.
-            // Middleware handles them correctly; iOS displays them read-only.
+            // Advanced filter: recursively clean nested filters
             if filter.operator != .no {
-                return filter
+                var cleaned = filter
+                cleaned.nestedFilters = filter.nestedFilters.removingUnsupportedFilters()
+                return cleaned.nestedFilters.isEmpty ? nil : cleaned
             }
             return filter.isSupportedForSubscription ? filter : nil
         }


### PR DESCRIPTION
## Summary

- Restore recursive cleaning of empty advanced (AND/OR) filters that was accidentally reverted by IOS-5852
- Empty advanced filters created on desktop are now correctly treated as "disabled" instead of "match nothing"
- Fixes regression where Sets showed no objects when desktop had empty advanced filters

## Release
Label: Release