### PR TITLE
IOS-5906: Personal channel creation flow with homepage

### DIFF
--- a/AnyTypeTests/Markdown/Mocks/UserDefaultsStorageMock.swift
+++ b/AnyTypeTests/Markdown/Mocks/UserDefaultsStorageMock.swift
@@ -34,18 +34,6 @@ final class UserDefaultsStorageMock: UserDefaultsStorageProtocol {
         fatalError()
     }
 
-    func homeObjectId(spaceId: String) -> String? {
-        fatalError()
-    }
-
-    func setHomeObjectId(spaceId: String, objectId: String?) {
-        fatalError()
-    }
-
-    func homeObjectIdPublisher(spaceId: String) -> AnyPublisher<String?, Never> {
-        fatalError()
-    }
-
     func cleanStateAfterLogout() {
         fatalError()
     }

--- a/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
@@ -29,7 +29,7 @@ final class GroupChannelCreateCoordinatorViewModel {
             .first { $0.isActive && $0.isShared }?.writersLimit
 
         if contacts.isEmpty {
-            spaceCreateData = SpaceCreateData(spaceUxType: .data)
+            spaceCreateData = SpaceCreateData(spaceUxType: .data, channelType: .group)
         } else {
             selectMembersData = SelectMembersData(contacts: contacts, writersLimit: writersLimit)
         }
@@ -43,6 +43,6 @@ final class GroupChannelCreateCoordinatorViewModel {
         let contacts = selectMembersData?.contacts
             .filter { selectedIdentities.contains($0.identity) }
             .sorted { $0.name.caseInsensitiveCompare($1.name) == .orderedAscending } ?? []
-        spaceCreateData = SpaceCreateData(spaceUxType: .data, selectedContacts: contacts)
+        spaceCreateData = SpaceCreateData(spaceUxType: .data, selectedContacts: contacts, channelType: .group)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorView.swift
@@ -54,6 +54,7 @@ private struct HomeWidgetsCoordinatorInternalView: View {
         HomeWidgetsView(info: model.spaceInfo, context: context, output: model)
             .onAppear {
                 model.pageNavigation = pageNavigation
+                model.onAppear()
             }
             .sheet(item: $model.showChangeTypeData) {
                 WidgetTypeChangeView(data: $0)
@@ -72,6 +73,12 @@ private struct HomeWidgetsCoordinatorInternalView: View {
             }
             .anytypeSheet(item: $model.qrCodeInviteData) {
                 QrCodeView(title: Loc.joinSpace, data: $0.value.absoluteString, analyticsType: .inviteSpace, route: .inviteLink)
+            }
+            .sheet(isPresented: $model.showHomepagePicker) {
+                HomepagePickerView(spaceId: model.spaceInfo.accountSpaceId) { result in
+                    model.onHomepagePickerFinished(result: result)
+                }
+                .interactiveDismissDisabled(true)
             }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
@@ -18,12 +18,32 @@ final class HomeWidgetsCoordinatorViewModel: HomeWidgetsModuleOutput, SetObjectC
     var showGlobalSearchData: GlobalSearchModuleData?
     var spaceShareData: SpaceShareData?
     var qrCodeInviteData: URLIdentifiable?
+    var showHomepagePicker = false
 
     @Injected(\.legacySetObjectCreationCoordinator) @ObservationIgnored
     private var setObjectCreationCoordinator: any SetObjectCreationCoordinatorProtocol
 
     init(info: AccountInfo) {
         self.spaceInfo = info
+    }
+
+    func onAppear() {
+        let spaceView = Container.shared.spaceViewsStorage().spaceView(spaceId: spaceInfo.accountSpaceId)
+        var homepageNotSet = spaceView?.homepage.isEmpty == true
+        #if DEBUG
+        // TODO: Remove when middleware stops setting "widgets" as default homepage for new spaces
+        homepageNotSet = homepageNotSet || spaceView?.homepage == "widgets"
+        #endif
+        if homepageNotSet, !showHomepagePicker {
+            showHomepagePicker = true
+        }
+    }
+
+    func onHomepagePickerFinished(result: HomepagePickerResult) {
+        showHomepagePicker = false
+
+        guard case .homepageSet(let value) = result, case .object(let details) = value else { return }
+        pageNavigation?.open(details.screenData())
     }
 
     // MARK: - HomeWidgetsModuleOutput

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorView.swift
@@ -62,8 +62,16 @@ struct SpaceHubCoordinatorView: View {
             .safariBookmarkObject($model.bookmarkScreenData) {
                 model.onOpenBookmarkAsObject($0)
             }
-            .sheet(item: $model.spaceCreateData) {
-                SpaceCreateCoordinatorView(data: $0)
+            .sheet(item: $model.spaceCreateData) { data in
+                SpaceCreateCoordinatorView(data: data) { spaceId in
+                    model.setPendingHomepagePicker(spaceId: spaceId)
+                }
+            }
+            .sheet(item: $model.homepagePickerData) { data in
+                HomepagePickerView(spaceId: data.spaceId) { result in
+                    try await model.onHomepagePickerFinished(spaceId: data.spaceId, result: result)
+                }
+                .interactiveDismissDisabled(true)
             }
             .sheet(isPresented: $model.showGroupChannelCreate) {
                 GroupChannelCreateCoordinatorView()

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorView.swift
@@ -62,16 +62,8 @@ struct SpaceHubCoordinatorView: View {
             .safariBookmarkObject($model.bookmarkScreenData) {
                 model.onOpenBookmarkAsObject($0)
             }
-            .sheet(item: $model.spaceCreateData) { data in
-                SpaceCreateCoordinatorView(data: data) { spaceId in
-                    model.setPendingHomepagePicker(spaceId: spaceId)
-                }
-            }
-            .sheet(item: $model.homepagePickerData) { data in
-                HomepagePickerView(spaceId: data.spaceId) { result in
-                    try await model.onHomepagePickerFinished(spaceId: data.spaceId, result: result)
-                }
-                .interactiveDismissDisabled(true)
+            .sheet(item: $model.spaceCreateData) {
+                SpaceCreateCoordinatorView(data: $0)
             }
             .sheet(isPresented: $model.showGroupChannelCreate) {
                 GroupChannelCreateCoordinatorView()

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -26,6 +26,7 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     var chatProvider = ChatActionProvider()
     var bookmarkScreenData: BookmarkScreenData?
     var spaceCreateData: SpaceCreateData?
+    var homepagePickerData: HomePagePickerData?
     var chatCreateData: ChatCreateScreenData?
     var bookmarkCreateData: BookmarkCreateScreenData?
     var overlayWidgetsData: HomeWidgetData?
@@ -41,6 +42,8 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     
     @ObservationIgnored
     private var uploadSpaceId: String?
+    @ObservationIgnored
+    private var pendingHomepageSpaceId: String?
     
     var currentSpaceId: String?
     var spaceInfo: AccountInfo? {
@@ -92,8 +95,6 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     private var documentsProvider: any DocumentsProviderProtocol
     @Injected(\.spaceViewsStorage) @ObservationIgnored
     private var workspaceStorage: any SpaceViewsStorageProtocol
-    @Injected(\.userDefaultsStorage) @ObservationIgnored
-    private var userDefaults: any UserDefaultsStorageProtocol
     @Injected(\.objectTypeProvider) @ObservationIgnored
     private var typeProvider: any ObjectTypeProviderProtocol
     @Injected(\.objectActionsService) @ObservationIgnored
@@ -208,7 +209,30 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     }
 
     func onSelectCreatePersonalChannel() {
-        spaceCreateData = SpaceCreateData(spaceUxType: .data)
+        spaceCreateData = SpaceCreateData(spaceUxType: .data, channelType: .personal)
+    }
+
+    func setPendingHomepagePicker(spaceId: String) {
+        pendingHomepageSpaceId = spaceId
+    }
+
+    func onHomepagePickerFinished(spaceId: String, result: HomepagePickerResult) async throws {
+        homepagePickerData = nil
+
+        guard case .homepageSet(let value) = result, case .object(let objectId) = value else { return }
+
+        let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [objectId]).first
+        guard let details, !details.isArchivedOrDeleted else { return }
+
+        let homeObject: AnyHashable
+        switch details.screenData() {
+        case .editor(let data): homeObject = data
+        case .chat(let data): homeObject = data
+        case .discussion(let data): homeObject = data
+        default: return
+        }
+
+        navigationPath = HomePath(initialPath: [SpaceHubNavigationItem(), homeObject])
     }
 
     func onSelectCreateGroupChannel() {
@@ -279,22 +303,38 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     }
     
     private func homeObjectScreenData(spaceId: String, spaceUxType: SpaceUxType? = nil) async -> AnyHashable {
-        if let objectId = userDefaults.homeObjectId(spaceId: spaceId) {
-            let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [objectId]).first
-            if let details, !details.isArchivedOrDeleted, let editorData = details.screenData().editorScreenData {
+        let spaceView = workspaceStorage.spaceView(spaceId: spaceId)
+
+        // 1-1 spaces always open on chat
+        let isOneToOne = spaceUxType == .oneToOne || spaceView?.uxType == .oneToOne
+        if isOneToOne {
+            return SpaceChatCoordinatorData(spaceId: spaceId)
+        }
+
+        // Read homepage from middleware-synced SpaceView
+        let homepage = spaceView?.homepage ?? ""
+
+        if homepage == "widgets" || homepage.isEmpty {
+            return HomeWidgetData(spaceId: spaceId)
+        }
+
+        // Homepage is an object ID — validate and open it
+        let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [homepage]).first
+        if let details, !details.isArchivedOrDeleted {
+            switch details.screenData() {
+            case .editor(let editorData):
                 return editorData
+            case .chat(let chatData):
+                return chatData
+            case .discussion(let discussionData):
+                return discussionData
+            default:
+                break
             }
         }
 
-        let isChat = spaceUxType?.initialScreenIsChat
-            ?? workspaceStorage.spaceView(spaceId: spaceId)?.initialScreenIsChat
-            ?? false
-
-        if isChat {
-            return SpaceChatCoordinatorData(spaceId: spaceId)
-        } else {
-            return HomeWidgetData(spaceId: spaceId)
-        }
+        // Fallback: object not found or deleted → widgets
+        return HomeWidgetData(spaceId: spaceId)
     }
 
     private func showSpace(spaceId: String, spaceUxType: SpaceUxType? = nil) async {
@@ -302,18 +342,23 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
 
         setActiveSpace(spaceId: spaceId)
         let homeObject = await homeObjectScreenData(spaceId: spaceId, spaceUxType: spaceUxType)
-        
+
         let path: [AnyHashable] = .builder {
             SpaceHubNavigationItem()
             homeObject
         }
-        
+
         let currentPath = HomePath(initialPath: path)
         if navigationPath != currentPath {
             await dismissAllPresented?()
             navigationPath = currentPath
         }
-        
+
+        // Show homepage picker after space is loaded (if pending from create flow)
+        if let pendingSpaceId = pendingHomepageSpaceId, pendingSpaceId == spaceId {
+            pendingHomepageSpaceId = nil
+            homepagePickerData = HomePagePickerData(spaceId: spaceId)
+        }
     }
     
     // main show screen logic

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -26,7 +26,6 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     var chatProvider = ChatActionProvider()
     var bookmarkScreenData: BookmarkScreenData?
     var spaceCreateData: SpaceCreateData?
-    var homepagePickerData: HomePagePickerData?
     var chatCreateData: ChatCreateScreenData?
     var bookmarkCreateData: BookmarkCreateScreenData?
     var overlayWidgetsData: HomeWidgetData?
@@ -42,8 +41,6 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     
     @ObservationIgnored
     private var uploadSpaceId: String?
-    @ObservationIgnored
-    private var pendingHomepageSpaceId: String?
     
     var currentSpaceId: String?
     var spaceInfo: AccountInfo? {
@@ -212,28 +209,7 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
         spaceCreateData = SpaceCreateData(spaceUxType: .data, channelType: .personal)
     }
 
-    func setPendingHomepagePicker(spaceId: String) {
-        pendingHomepageSpaceId = spaceId
-    }
 
-    func onHomepagePickerFinished(spaceId: String, result: HomepagePickerResult) async throws {
-        homepagePickerData = nil
-
-        guard case .homepageSet(let value) = result, case .object(let objectId) = value else { return }
-
-        let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [objectId]).first
-        guard let details, !details.isArchivedOrDeleted else { return }
-
-        let homeObject: AnyHashable
-        switch details.screenData() {
-        case .editor(let data): homeObject = data
-        case .chat(let data): homeObject = data
-        case .discussion(let data): homeObject = data
-        default: return
-        }
-
-        navigationPath = HomePath(initialPath: [SpaceHubNavigationItem(), homeObject])
-    }
 
     func onSelectCreateGroupChannel() {
         showGroupChannelCreate = true
@@ -352,12 +328,6 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
         if navigationPath != currentPath {
             await dismissAllPresented?()
             navigationPath = currentPath
-        }
-
-        // Show homepage picker after space is loaded (if pending from create flow)
-        if let pendingSpaceId = pendingHomepageSpaceId, pendingSpaceId == spaceId {
-            pendingHomepageSpaceId = nil
-            homepagePickerData = HomePagePickerData(spaceId: spaceId)
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/Coordinator/SpaceCreateCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/Coordinator/SpaceCreateCoordinatorView.swift
@@ -6,8 +6,8 @@ struct SpaceCreateCoordinatorView: View {
     @State private var model: SpaceCreateCoordinatorViewModel
     private let embedInNavigationStack: Bool
 
-    init(data: SpaceCreateData, embedInNavigationStack: Bool = true) {
-        _model = State(initialValue: SpaceCreateCoordinatorViewModel(data: data))
+    init(data: SpaceCreateData, embedInNavigationStack: Bool = true, onShowHomepagePicker: ((String) -> Void)? = nil) {
+        _model = State(initialValue: SpaceCreateCoordinatorViewModel(data: data, onShowHomepagePicker: onShowHomepagePicker))
         self.embedInNavigationStack = embedInNavigationStack
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/Coordinator/SpaceCreateCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/Coordinator/SpaceCreateCoordinatorView.swift
@@ -6,8 +6,8 @@ struct SpaceCreateCoordinatorView: View {
     @State private var model: SpaceCreateCoordinatorViewModel
     private let embedInNavigationStack: Bool
 
-    init(data: SpaceCreateData, embedInNavigationStack: Bool = true, onShowHomepagePicker: ((String) -> Void)? = nil) {
-        _model = State(initialValue: SpaceCreateCoordinatorViewModel(data: data, onShowHomepagePicker: onShowHomepagePicker))
+    init(data: SpaceCreateData, embedInNavigationStack: Bool = true) {
+        _model = State(initialValue: SpaceCreateCoordinatorViewModel(data: data))
         self.embedInNavigationStack = embedInNavigationStack
     }
 
@@ -27,17 +27,6 @@ struct SpaceCreateCoordinatorView: View {
         }
         .sheet(item: $model.localObjectIconPickerData) {
             LocalObjectIconPickerView(data: $0)
-        }
-        .sheet(item: $model.homePagePickerData) { data in
-            HomePagePickerView(spaceId: data.spaceId) {
-                try await model.onHomePagePickerFinished()
-            }.interactiveDismissDisabled(true)
-        }
-        .sheet(item: $model.newHomepagePickerData) { data in
-            HomepagePickerView(spaceId: data.spaceId) { result in
-                try await model.onHomepagePickerFinished(result: result)
-            }
-            .interactiveDismissDisabled(true)
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/Coordinator/SpaceCreateCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/Coordinator/SpaceCreateCoordinatorViewModel.swift
@@ -2,12 +2,6 @@ import SwiftUI
 import Factory
 import AnytypeCore
 
-
-struct HomePagePickerData: Identifiable, Equatable {
-    let spaceId: String
-    var id: String { spaceId }
-}
-
 @Observable
 final class SpaceCreateCoordinatorViewModel: SpaceCreateModuleOutput {
 
@@ -18,23 +12,9 @@ final class SpaceCreateCoordinatorViewModel: SpaceCreateModuleOutput {
     let data: SpaceCreateData
 
     var localObjectIconPickerData: LocalObjectIconPickerData?
-    var homePagePickerData: HomePagePickerData?
-    var newHomepagePickerData: HomePagePickerData?
 
-    @ObservationIgnored
-    private var pendingSpaceId: String?
-    @ObservationIgnored
-    private let onShowHomepagePicker: ((String) -> Void)?
-
-    init(data: SpaceCreateData, onShowHomepagePicker: ((String) -> Void)? = nil) {
+    init(data: SpaceCreateData) {
         self.data = data
-        self.onShowHomepagePicker = onShowHomepagePicker
-    }
-
-    func onHomePagePickerFinished() async throws {
-        guard let spaceId = pendingSpaceId else { return }
-        pendingSpaceId = nil
-        try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
     }
 
     // MARK: - SpaceCreateModuleOutput
@@ -46,32 +26,7 @@ final class SpaceCreateCoordinatorViewModel: SpaceCreateModuleOutput {
         )
     }
 
-    func onHomepagePickerFinished(result: HomepagePickerResult) async throws {
-        guard let spaceId = pendingSpaceId else { return }
-        pendingSpaceId = nil
-
-        switch result {
-        case .homepageSet:
-            try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
-            // TODO: Navigate to the homepage object (separate task)
-        case .later:
-            try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
-            // TODO: Handle temporary widgets (separate task)
-        }
-    }
-
     func onSpaceCreated(spaceId: String) async throws {
-        if data.channelType != nil, let onShowHomepagePicker {
-            // New channel flow: activate space first (dismisses create sheet),
-            // then hub shows homepage picker after dismiss
-            onShowHomepagePicker(spaceId)
-            try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
-        } else if FeatureFlags.homePage {
-            // Legacy homepage picker flow (shown inside create sheet)
-            pendingSpaceId = spaceId
-            newHomepagePickerData = HomePagePickerData(spaceId: spaceId)
-        } else {
-            try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
-        }
+        try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/Coordinator/SpaceCreateCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/Coordinator/SpaceCreateCoordinatorViewModel.swift
@@ -10,11 +10,10 @@ struct HomePagePickerData: Identifiable, Equatable {
 
 @Observable
 final class SpaceCreateCoordinatorViewModel: SpaceCreateModuleOutput {
-  
+
     @ObservationIgnored
     @Injected(\.activeSpaceManager)
     private var activeSpaceManager: any ActiveSpaceManagerProtocol
-
 
     let data: SpaceCreateData
 
@@ -24,9 +23,12 @@ final class SpaceCreateCoordinatorViewModel: SpaceCreateModuleOutput {
 
     @ObservationIgnored
     private var pendingSpaceId: String?
-    
-    init(data: SpaceCreateData) {
+    @ObservationIgnored
+    private let onShowHomepagePicker: ((String) -> Void)?
+
+    init(data: SpaceCreateData, onShowHomepagePicker: ((String) -> Void)? = nil) {
         self.data = data
+        self.onShowHomepagePicker = onShowHomepagePicker
     }
 
     func onHomePagePickerFinished() async throws {
@@ -59,7 +61,13 @@ final class SpaceCreateCoordinatorViewModel: SpaceCreateModuleOutput {
     }
 
     func onSpaceCreated(spaceId: String) async throws {
-        if FeatureFlags.homePage {
+        if data.channelType != nil, let onShowHomepagePicker {
+            // New channel flow: activate space first (dismisses create sheet),
+            // then hub shows homepage picker after dismiss
+            onShowHomepagePicker(spaceId)
+            try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
+        } else if FeatureFlags.homePage {
+            // Legacy homepage picker flow (shown inside create sheet)
             pendingSpaceId = spaceId
             newHomepagePickerData = HomePagePickerData(spaceId: spaceId)
         } else {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateData.swift
@@ -2,18 +2,28 @@ import Foundation
 import Services
 import AnytypeCore
 
+enum ChannelType: Equatable, Hashable {
+    case personal
+    case group
+}
+
 struct SpaceCreateData: Equatable, Identifiable, Hashable {
     let spaceUxType: SpaceUxType
     let selectedContacts: [Contact]
+    let channelType: ChannelType?
 
-    init(spaceUxType: SpaceUxType, selectedContacts: [Contact] = []) {
+    init(spaceUxType: SpaceUxType, selectedContacts: [Contact] = [], channelType: ChannelType? = nil) {
         self.spaceUxType = spaceUxType
         self.selectedContacts = selectedContacts
+        self.channelType = channelType
     }
 
     var id: Int { hashValue }
-    
+
     var title: String {
+        if channelType != nil {
+            return Loc.SpaceCreate.Space.title
+        }
         switch spaceUxType {
         case .chat:
             return Loc.SpaceCreate.Chat.title

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
@@ -40,37 +40,26 @@ final class SpaceCreateViewModel: LocalObjectIconPickerOutput {
         self.data = data
         self.output = output
         self.spaceIconOption = IconColorStorage.randomOption()
-        self.spaceIcon = .object(.space(.name(name: "", iconOption: spaceIconOption, circular: data.spaceUxType.isChat)))
+        let isCircular = data.channelType == nil && data.spaceUxType.isChat
+        self.spaceIcon = .object(.space(.name(name: "", iconOption: spaceIconOption, circular: isCircular)))
     }
     
     func onTapCreate() async throws {
-        let uxType = data.spaceUxType
-        let createResponse = try await workspaceService.createSpace(
-            name: spaceName,
-            iconOption: spaceIconOption,
-            accessType: .private,
-            useCase: uxType.useCase,
-            withChat: true,
-            uxType: uxType
-        )
-        
-        let spaceId = createResponse.spaceID
-                    
+        let spaceId: String
+
+        if let channelType = data.channelType {
+            spaceId = try await createChannel(channelType: channelType)
+        } else {
+            spaceId = try await createLegacySpace()
+        }
+
         if let fileData {
             let fileDetails = try await fileActionsService.uploadFileObject(spaceId: spaceId, data: fileData, origin: .none)
             try await workspaceService.workspaceSetDetails(spaceId: spaceId, details: [.iconObjectId(fileDetails.id)])
         }
-        
-        if uxType.isChat {
-            // Do not rethrow error to main flow
-            do {
-                _ = try await workspaceService.makeSharable(spaceId: spaceId)
-                _ = try await workspaceService.generateInvite(spaceId: spaceId, inviteType: .withoutApprove, permissions: .writer)
-            } catch {}
-        }
 
         UINotificationFeedbackGenerator().notificationOccurred(.success)
-        AnytypeAnalytics.instance().logCreateSpace(spaceId: createResponse.spaceID, spaceUxType: uxType, route: .navigation)
+        AnytypeAnalytics.instance().logCreateSpace(spaceId: spaceId, spaceUxType: data.spaceUxType, route: .navigation)
         try await output?.onSpaceCreated(spaceId: spaceId)
     }
     
@@ -80,7 +69,8 @@ final class SpaceCreateViewModel: LocalObjectIconPickerOutput {
     
     func updateNameIconIfNeeded(_ name: String) {
         guard fileData.isNil else { return }
-        spaceIcon = .object(.space(.name(name: name, iconOption: spaceIconOption, circular: data.spaceUxType.isChat)))
+        let isCircular = data.channelType == nil && data.spaceUxType.isChat
+        spaceIcon = .object(.space(.name(name: name, iconOption: spaceIconOption, circular: isCircular)))
     }
     
     func onIconTapped() {
@@ -88,15 +78,63 @@ final class SpaceCreateViewModel: LocalObjectIconPickerOutput {
     }
     
     // MARK: - LocalObjectIconPickerOutput
-    
+
     func localFileDataDidChanged(_ data: FileData?) {
         fileData = data
+        let isCircular = self.data.channelType == nil && self.data.spaceUxType.isChat
         if let path = fileData?.path {
-            spaceIcon = .object(.space(.localPath(path, circular: self.data.spaceUxType.isChat)))
+            spaceIcon = .object(.space(.localPath(path, circular: isCircular)))
         } else {
-            spaceIcon = .object(.space(.name(name: spaceName, iconOption: spaceIconOption, circular: self.data.spaceUxType.isChat)))
+            spaceIcon = .object(.space(.name(name: spaceName, iconOption: spaceIconOption, circular: isCircular)))
         }
     }
-    
+
     // MARK: - Private
+
+    private func createChannel(channelType: ChannelType) async throws -> String {
+        let accessType: SpaceAccessType = channelType == .personal ? .private : .shared
+
+        let createResponse = try await workspaceService.createSpace(
+            name: spaceName,
+            iconOption: spaceIconOption,
+            accessType: accessType,
+            useCase: .none,
+            withChat: false,
+            uxType: .data
+        )
+
+        let spaceId = createResponse.spaceID
+
+        if channelType == .group {
+            do {
+                _ = try await workspaceService.makeSharable(spaceId: spaceId)
+                _ = try await workspaceService.generateInvite(spaceId: spaceId, inviteType: .withoutApprove, permissions: .writer)
+            } catch {}
+        }
+
+        return spaceId
+    }
+
+    private func createLegacySpace() async throws -> String {
+        let uxType = data.spaceUxType
+        let createResponse = try await workspaceService.createSpace(
+            name: spaceName,
+            iconOption: spaceIconOption,
+            accessType: .private,
+            useCase: uxType.useCase,
+            withChat: true,
+            uxType: uxType
+        )
+
+        let spaceId = createResponse.spaceID
+
+        if uxType.isChat {
+            do {
+                _ = try await workspaceService.makeSharable(spaceId: spaceId)
+                _ = try await workspaceService.generateInvite(spaceId: spaceId, inviteType: .withoutApprove, permissions: .writer)
+            } catch {}
+        }
+
+        return spaceId
+    }
 }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomePagePickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomePagePickerViewModel.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Services
 import AnytypeCore
-import Combine
 
 @MainActor
 @Observable
@@ -9,8 +8,8 @@ final class HomePagePickerViewModel {
 
     @ObservationIgnored @Injected(\.searchService)
     private var searchService: any SearchServiceProtocol
-    @ObservationIgnored @Injected(\.userDefaultsStorage)
-    private var userDefaults: any UserDefaultsStorageProtocol
+    @ObservationIgnored @Injected(\.workspaceService)
+    private var workspaceService: any WorkspaceServiceProtocol
 
     var searchText = ""
     var objects: [ObjectDetails] = []
@@ -29,7 +28,8 @@ final class HomePagePickerViewModel {
         let spaceView = Container.shared.spaceViewsStorage().spaceView(spaceId: spaceId)
         self.spaceUxType = spaceView?.uxType
         self.isChatSpace = spaceView?.initialScreenIsChat ?? false
-        self.currentObjectId = Container.shared.userDefaultsStorage().homeObjectId(spaceId: spaceId)
+        let homepage = spaceView?.homepage ?? ""
+        self.currentObjectId = homepage.isEmpty || homepage == "widgets" ? nil : homepage
     }
 
     var defaultOptionTitle: String {
@@ -54,13 +54,13 @@ final class HomePagePickerViewModel {
     }
 
     func onWidgetsSelected() async throws {
-        userDefaults.setHomeObjectId(spaceId: spaceId, objectId: nil)
+        try await workspaceService.setHomepage(spaceId: spaceId, homepage: "widgets")
         try await onFinish()
         dismiss = true
     }
 
     func onObjectSelected(_ details: ObjectDetails) async throws {
-        userDefaults.setHomeObjectId(spaceId: spaceId, objectId: details.id)
+        try await workspaceService.setHomepage(spaceId: spaceId, homepage: details.id)
         try await onFinish()
         dismiss = true
     }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
@@ -289,8 +289,8 @@ final class SpaceSettingsViewModel {
     }
 
     private func startHomeObjectTask() async {
-        for await _ in userDefaults.homeObjectIdPublisher(spaceId: workspaceInfo.accountSpaceId).values {
-            await loadHomePageState()
+        for await spaceView in spaceViewsStorage.spaceViewPublisher(spaceId: workspaceInfo.accountSpaceId).values {
+            await loadHomePageState(homepage: spaceView.homepage)
         }
     }
 
@@ -306,26 +306,18 @@ final class SpaceSettingsViewModel {
         }
     }
 
-    private func loadHomePageState() async {
-        let spaceId = workspaceInfo.accountSpaceId
-        guard let objectId = userDefaults.homeObjectId(spaceId: spaceId) else {
-            homePageState = .default(defaultHomePageTitle(spaceId: spaceId))
+    private func loadHomePageState(homepage: String) async {
+        if homepage.isEmpty || homepage == "widgets" {
+            homePageState = .default(Loc.SpaceSettings.HomePage.widgets)
             return
         }
 
-        let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [objectId]).first
+        let spaceId = workspaceInfo.accountSpaceId
+        let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [homepage]).first
         if let details, !details.isArchivedOrDeleted {
             homePageState = .object(icon: details.objectIconImage, name: details.name)
         } else {
-            homePageState = .default(defaultHomePageTitle(spaceId: spaceId))
-        }
-    }
-
-    private func defaultHomePageTitle(spaceId: String) -> String {
-        if let spaceView = spaceViewsStorage.spaceView(spaceId: spaceId), spaceView.initialScreenIsChat {
-            return Loc.chat
-        } else {
-            return Loc.SpaceSettings.HomePage.widgets
+            homePageState = .default(Loc.SpaceSettings.HomePage.widgets)
         }
     }
     

--- a/Anytype/Sources/ServiceLayer/HomepagePicker/HomepagePickerService.swift
+++ b/Anytype/Sources/ServiceLayer/HomepagePicker/HomepagePickerService.swift
@@ -34,7 +34,7 @@ final class HomepagePickerService: HomepagePickerServiceProtocol {
                 createdInContextRef: ""
             )
             try await setHomepage(spaceId: spaceId, homepageId: details.id)
-            return .object(id: details.id)
+            return .object(details: details)
         }
     }
 

--- a/Anytype/Sources/ServiceLayer/HomepagePicker/HomepageValue.swift
+++ b/Anytype/Sources/ServiceLayer/HomepagePicker/HomepageValue.swift
@@ -1,6 +1,7 @@
 import Foundation
+import Services
 
 enum HomepageValue {
     case widgets
-    case object(id: String)
+    case object(details: ObjectDetails)
 }

--- a/Anytype/Sources/Utilities/UserDefaults/UserDefaultsStorage.swift
+++ b/Anytype/Sources/Utilities/UserDefaults/UserDefaultsStorage.swift
@@ -20,10 +20,6 @@ protocol UserDefaultsStorageProtocol: AnyObject, Sendable {
     func wallpaper(spaceId: String) -> SpaceWallpaperType
     func setWallpaper(spaceId: String, wallpaper: SpaceWallpaperType)
 
-    func homeObjectId(spaceId: String) -> String?
-    func setHomeObjectId(spaceId: String, objectId: String?)
-    func homeObjectIdPublisher(spaceId: String) -> AnyPublisher<String?, Never>
-
     func cleanStateAfterLogout()
 }
 
@@ -101,33 +97,9 @@ final class UserDefaultsStorage: UserDefaultsStorageProtocol, @unchecked Sendabl
         _wallpapers[spaceId] = wallpaper
     }
 
-    // MARK: - Home Object
-    @UserDefault("UserData.HomeObjects", defaultValue: [:])
-    private var _homeObjects: [String: String] {
-        didSet { homeObjectsSubject.send(_homeObjects) }
-    }
-
-    private lazy var homeObjectsSubject = CurrentValueSubject<[String: String], Never>(_homeObjects)
-
-    func homeObjectId(spaceId: String) -> String? {
-        _homeObjects[spaceId]
-    }
-
-    func setHomeObjectId(spaceId: String, objectId: String?) {
-        _homeObjects[spaceId] = objectId
-    }
-
-    func homeObjectIdPublisher(spaceId: String) -> AnyPublisher<String?, Never> {
-        homeObjectsSubject
-            .map { $0[spaceId] }
-            .removeDuplicates()
-            .eraseToAnyPublisher()
-    }
-
     // MARK: - Cleanup
     func cleanStateAfterLogout() {
         showUnstableMiddlewareError = true
-        _homeObjects = [:]
         autoDownloadSizeLimitRawValue = -1
         autoDownloadUseCellular = false
     }


### PR DESCRIPTION
## Summary

- Add `ChannelType` enum (`.personal`, `.group`) to `SpaceCreateData` for branching old/new creation flows
- New channel flow: `useCase: .none`, `withChat: false`, group gets `makeSharable`/`generateInvite`
- Replace UserDefaults `homeObjectId` with `spaceView.homepage` from middleware everywhere
- Move homepage picker from SpaceHub/SpaceCreateCoordinator into `HomeWidgetsCoordinatorViewModel` — checks `homepage` on appear, shows picker if not set
- Handle chat objects as homepage in `homeObjectScreenData()` (not just editor)
- Navigate to created homepage object via `pageNavigation.open()` after picker selection
- Remove dead code: `HomePagePickerData`, closure chain, `pendingSpaceId`, UserDefaults `homeObjectId`