### PR TITLE
IOS-5964 Fix empty state shown after clearing no-results search on SpaceHub

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -14,8 +14,11 @@ final class SpaceHubViewModel {
     var searchText: String = ""
     var filteredSpaces: [SpaceCardModel] = []
     var animationsEnabled = false
-    
+
     var wallpapers: [String: SpaceWallpaperType] = [:]
+
+    @ObservationIgnored
+    private var allSpaceCardModels: [SpaceCardModel] = []
 
     var notificationsNotDetermined = false
     var spaceMuteData: SpaceMuteData?
@@ -125,6 +128,9 @@ final class SpaceHubViewModel {
     }
     
     func searchTextUpdated() {
+        if searchText.isEmpty {
+            filteredSpaces = allSpaceCardModels
+        }
         Task {
             await updateFilteredSpaces()
         }
@@ -217,9 +223,10 @@ final class SpaceHubViewModel {
     private func updateFilteredSpaces() async {
         guard let spaces else {
             filteredSpaces = []
+            allSpaceCardModels = []
             return
         }
-        
+
         let spacesToFilter: [ParticipantSpaceViewDataWithPreview]
         if searchText.isEmpty {
             spacesToFilter = spaces
@@ -228,7 +235,13 @@ final class SpaceHubViewModel {
                 space.spaceView.name.localizedCaseInsensitiveContains(searchText)
             }
         }
-        
-        self.filteredSpaces = await spaceCardModelBuilder.build(from: spacesToFilter, wallpapers: wallpapers)
+
+        let models = await spaceCardModelBuilder.build(from: spacesToFilter, wallpapers: wallpapers)
+
+        if searchText.isEmpty {
+            allSpaceCardModels = models
+        }
+
+        self.filteredSpaces = models
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubList.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubList.swift
@@ -10,12 +10,14 @@ struct SpaceHubList: View {
     @State private var draggedInitialIndex: Int?
 
     var body: some View {
-        if model.filteredSpaces.isEmpty && model.searchText.isEmpty {
-            emptyStateView
-        } else if model.filteredSpaces.isNotEmpty {
+        if model.filteredSpaces.isNotEmpty {
             scrollView
-        } else {
+        } else if model.searchText.isNotEmpty {
             SpaceHubSearchEmptySpaceView()
+        } else if model.spaces?.isEmpty ?? true {
+            emptyStateView
+        } else {
+            scrollView
         }
     }
     


### PR DESCRIPTION
## Summary
- Cache the full spaces card model list and restore it synchronously when search is cleared, eliminating the race condition between search text update and async model rebuild
- Reorder view conditions in SpaceHubList to check the source `spaces` array when deciding whether to show the "no spaces" empty state

Release