### PR TITLE
IOS-5955: Replace homepage String with SpaceHomepage enum

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
@@ -29,10 +29,10 @@ final class HomeWidgetsCoordinatorViewModel: HomeWidgetsModuleOutput, SetObjectC
 
     func onAppear() {
         let spaceView = Container.shared.spaceViewsStorage().spaceView(spaceId: spaceInfo.accountSpaceId)
-        var homepageNotSet = spaceView?.homepage.isEmpty == true
+        var homepageNotSet = spaceView?.homepage == .empty
         #if DEBUG
         // TODO: Remove when middleware stops setting "widgets" as default homepage for new spaces
-        homepageNotSet = homepageNotSet || spaceView?.homepage == "widgets"
+        homepageNotSet = homepageNotSet || spaceView?.homepage == .widgets
         #endif
         if homepageNotSet, !showHomepagePicker {
             showHomepagePicker = true

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -288,29 +288,28 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
         }
 
         // Read homepage from middleware-synced SpaceView
-        let homepage = spaceView?.homepage ?? ""
+        let homepage = spaceView?.homepage ?? .empty
 
-        if homepage == "widgets" || homepage.isEmpty {
+        switch homepage {
+        case .empty, .widgets:
+            return HomeWidgetData(spaceId: spaceId)
+        case .object(let objectId):
+            let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [objectId]).first
+            if let details, !details.isArchivedOrDeleted {
+                switch details.screenData() {
+                case .editor(let editorData):
+                    return editorData
+                case .chat(let chatData):
+                    return chatData
+                case .discussion(let discussionData):
+                    return discussionData
+                default:
+                    break
+                }
+            }
+            // Fallback: object not found or deleted → widgets
             return HomeWidgetData(spaceId: spaceId)
         }
-
-        // Homepage is an object ID — validate and open it
-        let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [homepage]).first
-        if let details, !details.isArchivedOrDeleted {
-            switch details.screenData() {
-            case .editor(let editorData):
-                return editorData
-            case .chat(let chatData):
-                return chatData
-            case .discussion(let discussionData):
-                return discussionData
-            default:
-                break
-            }
-        }
-
-        // Fallback: object not found or deleted → widgets
-        return HomeWidgetData(spaceId: spaceId)
     }
 
     private func showSpace(spaceId: String, spaceUxType: SpaceUxType? = nil) async {

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomePagePickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomePagePickerViewModel.swift
@@ -28,8 +28,13 @@ final class HomePagePickerViewModel {
         let spaceView = Container.shared.spaceViewsStorage().spaceView(spaceId: spaceId)
         self.spaceUxType = spaceView?.uxType
         self.isChatSpace = spaceView?.initialScreenIsChat ?? false
-        let homepage = spaceView?.homepage ?? ""
-        self.currentObjectId = homepage.isEmpty || homepage == "widgets" ? nil : homepage
+        let homepage = spaceView?.homepage ?? .empty
+        switch homepage {
+        case .empty, .widgets:
+            self.currentObjectId = nil
+        case .object(let objectId):
+            self.currentObjectId = objectId
+        }
     }
 
     var defaultOptionTitle: String {
@@ -54,7 +59,7 @@ final class HomePagePickerViewModel {
     }
 
     func onWidgetsSelected() async throws {
-        try await workspaceService.setHomepage(spaceId: spaceId, homepage: "widgets")
+        try await workspaceService.setHomepage(spaceId: spaceId, homepage: SpaceHomepage.widgets.rawValue)
         try await onFinish()
         dismiss = true
     }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
@@ -306,18 +306,18 @@ final class SpaceSettingsViewModel {
         }
     }
 
-    private func loadHomePageState(homepage: String) async {
-        if homepage.isEmpty || homepage == "widgets" {
+    private func loadHomePageState(homepage: SpaceHomepage) async {
+        switch homepage {
+        case .empty, .widgets:
             homePageState = .default(Loc.SpaceSettings.HomePage.widgets)
-            return
-        }
-
-        let spaceId = workspaceInfo.accountSpaceId
-        let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [homepage]).first
-        if let details, !details.isArchivedOrDeleted {
-            homePageState = .object(icon: details.objectIconImage, name: details.name)
-        } else {
-            homePageState = .default(Loc.SpaceSettings.HomePage.widgets)
+        case .object(let objectId):
+            let spaceId = workspaceInfo.accountSpaceId
+            let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [objectId]).first
+            if let details, !details.isArchivedOrDeleted {
+                homePageState = .object(icon: details.objectIconImage, name: details.name)
+            } else {
+                homePageState = .default(Loc.SpaceSettings.HomePage.widgets)
+            }
         }
     }
     

--- a/Anytype/Sources/PreviewMocks/Mocks/Models/SpaceViewMock.swift
+++ b/Anytype/Sources/PreviewMocks/Mocks/Models/SpaceViewMock.swift
@@ -33,7 +33,7 @@ extension SpaceView {
             forceMuteIds: [],
             forceMentionIds: [],
             oneToOneIdentity: "oneToOneIdentity",
-            homepage: .widgets
+            homepage: .empty
         )
     }
 }

--- a/Anytype/Sources/PreviewMocks/Mocks/Models/SpaceViewMock.swift
+++ b/Anytype/Sources/PreviewMocks/Mocks/Models/SpaceViewMock.swift
@@ -33,7 +33,7 @@ extension SpaceView {
             forceMuteIds: [],
             forceMentionIds: [],
             oneToOneIdentity: "oneToOneIdentity",
-            homepage: ""
+            homepage: .widgets
         )
     }
 }

--- a/Anytype/Sources/ServiceLayer/HomepagePicker/HomepagePickerService.swift
+++ b/Anytype/Sources/ServiceLayer/HomepagePicker/HomepagePickerService.swift
@@ -5,8 +5,6 @@ import AnytypeCore
 
 final class HomepagePickerService: HomepagePickerServiceProtocol {
 
-    private static let widgetsHomepageId = "widgets"
-
     private let objectActionsService: any ObjectActionsServiceProtocol
     private let workspaceService: any WorkspaceServiceProtocol
 
@@ -18,7 +16,7 @@ final class HomepagePickerService: HomepagePickerServiceProtocol {
     func createHomepage(spaceId: String, option: HomepagePickerOption) async throws -> HomepageValue {
         switch option {
         case .widgets:
-            try await setHomepage(spaceId: spaceId, homepageId: Self.widgetsHomepageId)
+            try await setHomepage(spaceId: spaceId, homepageId: SpaceHomepage.widgets.rawValue)
             return .widgets
         case .object(let type):
             let details = try await objectActionsService.createObject(

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceHomepage.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceHomepage.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum SpaceHomepage: Equatable, Hashable {
+    case empty
+    case widgets
+    case object(objectId: String)
+
+    init(rawValue: String) {
+        switch rawValue {
+        case "": self = .empty
+        case "widgets": self = .widgets
+        default: self = .object(objectId: rawValue)
+        }
+    }
+
+    var rawValue: String {
+        switch self {
+        case .empty: return ""
+        case .widgets: return "widgets"
+        case .object(let id): return id
+        }
+    }
+}

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
@@ -24,7 +24,7 @@ struct SpaceView: Identifiable, Equatable, Hashable {
     let forceMuteIds: [String]
     let forceMentionIds: [String]
     let oneToOneIdentity: String
-    let homepage: String
+    let homepage: SpaceHomepage
 }
 
 extension SpaceView: DetailsModel {
@@ -50,7 +50,7 @@ extension SpaceView: DetailsModel {
         self.forceMuteIds = details.spacePushNotificationForceMuteIds
         self.forceMentionIds = details.spacePushNotificationForceMentionIds
         self.oneToOneIdentity = details.oneToOneIdentity
-        self.homepage = details.homepage
+        self.homepage = SpaceHomepage(rawValue: details.homepage)
     }
     
     static let subscriptionKeys: [BundledPropertyKey] = .builder {


### PR DESCRIPTION
## Summary

- Introduce `SpaceHomepage` enum (`.empty`, `.widgets`, `.object(objectId:)`) to replace raw `String` homepage field on `SpaceView`
- Parse middleware string at the boundary in `SpaceView.init(details:)`, eliminating all hardcoded `"widgets"` comparisons across 6 files
- Remove `HomepagePickerService.widgetsHomepageId` private constant in favor of the enum