### PR TITLE
IOS-5852 Fix advanced filters with relative dates

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Group/SetGroupSubscriptionDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Group/SetGroupSubscriptionDataBuilder.swift
@@ -17,7 +17,9 @@ final class SetGroupSubscriptionDataBuilder: SetGroupSubscriptionDataBuilderProt
     nonisolated init() {}
     
     func groupsData(_ setDocument: some SetDocumentProtocol) -> GroupsSubscriptionData {
-        var filters = setDocument.activeView.filters.removingUnsupportedFilters()
+        var filters = setDocument.activeView.filters
+            .enrichingFormats(with: setDocument.dataViewRelationsDetails)
+            .removingUnsupportedFilters()
         filters.append(SearchHelper.filterOutParticipantType())
         return GroupsSubscriptionData(
             spaceId: setDocument.spaceId,

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionData.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionData.swift
@@ -51,7 +51,9 @@ struct SetSubscriptionData: Hashable {
         self.sorts = sorts
         
         // Filters
-        var filters = view.filters.removingUnsupportedFilters()
+        var filters = view.filters
+            .enrichingFormats(with: document.dataViewRelationsDetails)
+            .removingUnsupportedFilters()
         if let groupFilter {
             filters.append(groupFilter)
         }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/DataviewFilter+Condition.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/DataviewFilter+Condition.swift
@@ -31,6 +31,20 @@ extension DataviewFilter {
 }
 
 extension Array where Element == DataviewFilter {
+    func enrichingFormats(with relationsDetails: [PropertyDetails]) -> [DataviewFilter] {
+        map { filter in
+            var enriched = filter
+            if !filter.relationKey.isEmpty,
+               let details = relationsDetails.first(where: { $0.key == filter.relationKey }) {
+                enriched.format = details.format.asMiddleware
+            }
+            if filter.operator != .no {
+                enriched.nestedFilters = filter.nestedFilters.enrichingFormats(with: relationsDetails)
+            }
+            return enriched
+        }
+    }
+
     func removingUnsupportedFilters() -> [DataviewFilter] {
         compactMap { filter in
             // Advanced filter: recursively clean nested filters


### PR DESCRIPTION
## Summary
- Enriches filter formats from relation details before subscription validation, matching the pattern already used for sorts
- Fixes advanced filters with relative dates (today, yesterday, etc.) not being applied on iOS when set on desktop
- Root cause: nested filters in advanced groups had format defaulting to `.longtext` (protobuf default) instead of `.date`, causing the relative date validation check to fail