### PR TITLE
IOS-5909: Homepage Setting in Space Settings

### DIFF
--- a/Anytype/Sources/PresentationLayer/Debug/Flows/InternalDebug/DebugMenuView.swift
+++ b/Anytype/Sources/PresentationLayer/Debug/Flows/InternalDebug/DebugMenuView.swift
@@ -77,7 +77,7 @@ struct DebugMenuView: View {
         .sheet(isPresented: $showObjectIcons) { ObjectIconExample() }
         .sheet(isPresented: $showMembershipDebug) { MembershipDebugView() }
         .sheet(isPresented: $showHomepagePicker) {
-            HomepagePickerView(spaceId: "") { result in
+            HomepageCreatePickerView(spaceId: "") { result in
                 print("HomepagePicker result: \(result)")
             }
             .interactiveDismissDisabled(true)

--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorView.swift
@@ -75,7 +75,7 @@ private struct HomeWidgetsCoordinatorInternalView: View {
                 QrCodeView(title: Loc.joinSpace, data: $0.value.absoluteString, analyticsType: .inviteSpace, route: .inviteLink)
             }
             .sheet(isPresented: $model.showHomepagePicker) {
-                HomepagePickerView(spaceId: model.spaceInfo.accountSpaceId) { result in
+                HomepageCreatePickerView(spaceId: model.spaceInfo.accountSpaceId) { result in
                     model.onHomepagePickerFinished(result: result)
                 }
                 .interactiveDismissDisabled(true)

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/NAVIGATION_GUIDE.md
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/NAVIGATION_GUIDE.md
@@ -202,11 +202,10 @@ Stored in UserDefaults via `homeObjectId(spaceId:)`:
 - Falls back to default if invalid
 - Changed via **Space Settings → Home Page**
 
-### HomePagePicker
+### HomepageSettingsPicker
 
-The `HomePagePickerView` allows users to customize their home screen for a space:
-- For **data spaces**: Shows "Widgets" as default option
-- For **chat spaces**: Shows "Chat" as default option
+The `HomepageSettingsPickerView` allows users to customize their home screen for a space:
+- Shows "Empty" as default option (resets homepage to widgets)
 - Users can select any valid object to open instead
 
 ---
@@ -336,8 +335,8 @@ enum ScreenData: Hashable, Identifiable, Sendable {
 | `AnytypeDestinationBuilderHolder.swift` | Type → View builder registry using reflection |
 | `ScreenData.swift` | High-level screen enum for navigation requests |
 | `UserDefaultsStorage.swift` | homeObjectId persistence |
-| `HomePagePickerView.swift` | UI for selecting custom home screen per space |
-| `HomePagePickerViewModel.swift` | Home screen selection logic |
+| `HomepageSettingsPickerView.swift` | UI for selecting custom home screen per space |
+| `HomepageSettingsPickerViewModel.swift` | Home screen selection logic |
 
 ### Builder Registration Location
 

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceSettings/SpaceSettingsCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceSettings/SpaceSettingsCoordinatorView.swift
@@ -58,7 +58,7 @@ fileprivate struct SpaceSettingInternalsCoordinator: View {
                 SpaceTypeChangeView(data: $0)
             }
             .sheet(item: $model.homePagePickerSpaceId) {
-                HomePagePickerView(spaceId: $0.value)
+                HomepageSettingsPickerView(spaceId: $0.value)
             }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/HomepageCreatePickerView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/HomepageCreatePickerView.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 import DesignKit
 
-struct HomepagePickerView: View {
+struct HomepageCreatePickerView: View {
 
-    @State private var model: HomepagePickerViewModel
+    @State private var model: HomepageCreatePickerViewModel
     @State private var contentHeight: CGFloat = 516
     @Environment(\.dismiss) private var dismiss
 
     init(spaceId: String, onFinish: @escaping (HomepagePickerResult) async throws -> Void) {
-        _model = State(initialValue: HomepagePickerViewModel(spaceId: spaceId, onFinish: onFinish))
+        _model = State(initialValue: HomepageCreatePickerViewModel(spaceId: spaceId, onFinish: onFinish))
     }
 
     var body: some View {
@@ -85,7 +85,7 @@ struct HomepagePickerView: View {
 }
 
 #Preview {
-    HomepagePickerView(spaceId: "") { result in
+    HomepageCreatePickerView(spaceId: "") { result in
         print("Result: \(result)")
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/HomepageCreatePickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/HomepageCreatePickerViewModel.swift
@@ -3,7 +3,7 @@ import Services
 
 @MainActor
 @Observable
-final class HomepagePickerViewModel {
+final class HomepageCreatePickerViewModel {
 
     @ObservationIgnored @Injected(\.homepagePickerService)
     private var homepagePickerService: any HomepagePickerServiceProtocol

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
@@ -16,9 +16,6 @@ struct HomepageSettingsPickerView: View {
             TitleView(title: Loc.SpaceSettings.HomePage.chooseHome)
 
             SearchBar(text: $model.searchText, focused: false, placeholder: Loc.search)
-                .padding(.horizontal, 16)
-
-            emptyOption
 
             content
         }
@@ -29,6 +26,20 @@ struct HomepageSettingsPickerView: View {
         .onChange(of: model.dismiss) {
             dismiss()
         }
+    }
+
+    private var content: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                emptyOption
+
+                ForEach(model.objects) { object in
+                    objectRow(object)
+                }
+            }
+            .padding(.horizontal, 20)
+        }
+        .scrollIndicators(.never)
     }
 
     private var emptyOption: some View {
@@ -50,30 +61,8 @@ struct HomepageSettingsPickerView: View {
                         .foregroundStyle(Color.Control.secondary)
                 }
             }
-            .padding(.horizontal, 20)
             .padding(.vertical, 14)
         }
-    }
-
-    @ViewBuilder
-    private var content: some View {
-        if model.objects.isEmpty {
-            Spacer()
-        } else {
-            objectsList
-        }
-    }
-
-    private var objectsList: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(model.objects) { object in
-                    objectRow(object)
-                }
-            }
-            .padding(.horizontal, 20)
-        }
-        .scrollIndicators(.never)
     }
 
     private func objectRow(_ details: ObjectDetails) -> some View {

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
@@ -28,18 +28,23 @@ struct HomepageSettingsPickerView: View {
         }
     }
 
+    @ViewBuilder
     private var content: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                emptyOption
+        if model.isSearchCompleted {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    emptyOption
 
-                ForEach(model.objects) { object in
-                    objectRow(object)
+                    ForEach(model.objects) { object in
+                        objectRow(object)
+                    }
                 }
+                .padding(.horizontal, 16)
             }
-            .padding(.horizontal, 16)
+            .scrollIndicators(.never)
+        } else {
+            Spacer()
         }
-        .scrollIndicators(.never)
     }
 
     private var emptyOption: some View {

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
@@ -37,7 +37,7 @@ struct HomepageSettingsPickerView: View {
                     objectRow(object)
                 }
             }
-            .padding(.horizontal, 20)
+            .padding(.horizontal, 16)
         }
         .scrollIndicators(.never)
     }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
@@ -1,24 +1,24 @@
 import SwiftUI
 import Services
 
-struct HomePagePickerView: View {
+struct HomepageSettingsPickerView: View {
 
-    @State private var model: HomePagePickerViewModel
+    @State private var model: HomepageSettingsPickerViewModel
     @Environment(\.dismiss) private var dismiss
 
-    init(spaceId: String, onFinish: @escaping () async throws -> Void = {}) {
-        _model = State(initialValue: HomePagePickerViewModel(spaceId: spaceId, onFinish: onFinish))
+    init(spaceId: String) {
+        _model = State(initialValue: HomepageSettingsPickerViewModel(spaceId: spaceId))
     }
 
     var body: some View {
         VStack(spacing: 0) {
             DragIndicator()
-            TitleView(title: Loc.SpaceSettings.HomePage.title)
-
-            widgetsOption
+            TitleView(title: Loc.SpaceSettings.HomePage.chooseHome)
 
             SearchBar(text: $model.searchText, focused: false, placeholder: Loc.search)
                 .padding(.horizontal, 16)
+
+            emptyOption
 
             content
         }
@@ -31,15 +31,16 @@ struct HomePagePickerView: View {
         }
     }
 
-    private var widgetsOption: some View {
+    private var emptyOption: some View {
         AsyncButton {
-            try await model.onWidgetsSelected()
+            try await model.onEmptySelected()
         } label: {
             HStack(spacing: 12) {
-                Image(systemName: model.isChatSpace ? "bubble.left.and.bubble.right" : "house")
+                Image(systemName: "minus.circle")
                     .foregroundStyle(Color.Control.primary)
+                    .frame(width: 24, height: 24)
 
-                AnytypeText(model.defaultOptionTitle, style: .uxBodyRegular)
+                AnytypeText(Loc.empty, style: .uxBodyRegular)
                     .foregroundStyle(Color.Text.primary)
 
                 Spacer()

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
@@ -61,7 +61,7 @@ struct HomepageSettingsPickerView: View {
                         .foregroundStyle(Color.Control.secondary)
                 }
             }
-            .padding(.vertical, 14)
+            .frame(height: 72)
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerView.swift
@@ -33,7 +33,9 @@ struct HomepageSettingsPickerView: View {
         if model.isSearchCompleted {
             ScrollView {
                 LazyVStack(spacing: 0) {
-                    emptyOption
+                    if model.searchText.isEmpty {
+                        emptyOption
+                    }
 
                     ForEach(model.objects) { object in
                         objectRow(object)

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerViewModel.swift
@@ -4,30 +4,25 @@ import AnytypeCore
 
 @MainActor
 @Observable
-final class HomePagePickerViewModel {
+final class HomepageSettingsPickerViewModel {
 
     @ObservationIgnored @Injected(\.searchService)
     private var searchService: any SearchServiceProtocol
-    @ObservationIgnored @Injected(\.workspaceService)
-    private var workspaceService: any WorkspaceServiceProtocol
+    @ObservationIgnored @Injected(\.homepagePickerService)
+    private var homepagePickerService: any HomepagePickerServiceProtocol
 
     var searchText = ""
     var objects: [ObjectDetails] = []
     var dismiss = false
 
-    @ObservationIgnored
-    private let onFinish: () async throws -> Void
-    private let spaceId: String
-    private let spaceUxType: SpaceUxType?
     let currentObjectId: String?
-    let isChatSpace: Bool
 
-    init(spaceId: String, onFinish: @escaping () async throws -> Void = {}) {
+    @ObservationIgnored
+    private let spaceId: String
+
+    init(spaceId: String) {
         self.spaceId = spaceId
-        self.onFinish = onFinish
         let spaceView = Container.shared.spaceViewsStorage().spaceView(spaceId: spaceId)
-        self.spaceUxType = spaceView?.uxType
-        self.isChatSpace = spaceView?.initialScreenIsChat ?? false
         let homepage = spaceView?.homepage ?? .empty
         switch homepage {
         case .empty, .widgets:
@@ -37,14 +32,10 @@ final class HomePagePickerViewModel {
         }
     }
 
-    var defaultOptionTitle: String {
-        isChatSpace ? Loc.chat : Loc.SpaceSettings.HomePage.widgets
-    }
-
     func search() async {
         do {
             try await Task.sleep(for: .milliseconds(300))
-            let layouts: [DetailsLayout] = DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType)
+            let layouts: [DetailsLayout] = DetailsLayout.visibleLayoutsWithFiles(spaceUxType: nil)
             objects = try await searchService.searchObjectsWithLayouts(
                 text: searchText,
                 layouts: layouts,
@@ -58,15 +49,13 @@ final class HomePagePickerViewModel {
         }
     }
 
-    func onWidgetsSelected() async throws {
-        try await workspaceService.setHomepage(spaceId: spaceId, homepage: SpaceHomepage.widgets.rawValue)
-        try await onFinish()
+    func onEmptySelected() async throws {
+        try await homepagePickerService.setHomepage(spaceId: spaceId, homepage: .widgets)
         dismiss = true
     }
 
     func onObjectSelected(_ details: ObjectDetails) async throws {
-        try await workspaceService.setHomepage(spaceId: spaceId, homepage: details.id)
-        try await onFinish()
+        try await homepagePickerService.setHomepage(spaceId: spaceId, homepage: .object(objectId: details.id))
         dismiss = true
     }
 }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerViewModel.swift
@@ -14,6 +14,7 @@ final class HomepageSettingsPickerViewModel {
     var searchText = ""
     var objects: [ObjectDetails] = []
     var dismiss = false
+    var isSearchCompleted = false
 
     let currentObjectId: String?
 
@@ -42,6 +43,7 @@ final class HomepageSettingsPickerViewModel {
                 excludedIds: [],
                 spaceId: spaceId
             ).filter { !$0.isArchivedOrDeleted }
+            isSearchCompleted = true
         } catch is CancellationError {
             // Ignore
         } catch {

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerViewModel.swift
@@ -48,6 +48,7 @@ final class HomepageSettingsPickerViewModel {
             // Ignore
         } catch {
             objects = []
+            isSearchCompleted = true
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
@@ -3,14 +3,14 @@ import Services
 import UIKit
 import AnytypeCore
 
-enum HomePageState {
-    case `default`(String)
+enum HomepageSettingsState {
+    case empty
     case object(icon: Icon?, name: String)
 
     var buttonDecoration: RoundedButtonDecoration {
         switch self {
-        case .default(let title):
-            return .caption(title)
+        case .empty:
+            return .chevron
         case .object(let icon, let name):
             return .object(icon: icon, name: name)
         }
@@ -87,7 +87,7 @@ final class SpaceSettingsViewModel {
     var membershipUpgradeReason: MembershipUpgradeReason?
     var storageInfo = RemoteStorageSegmentInfo()
     var defaultObjectType: ObjectType?
-    var homePageState: HomePageState = .default("")
+    var homePageState: HomepageSettingsState = .empty
     var showIconPickerSpaceId: StringIdentifiable?
     var editingData: SettingsInfoEditingViewData?
     var pushNotificationsSettingsMode: SpacePushNotificationsMode = .all
@@ -309,14 +309,14 @@ final class SpaceSettingsViewModel {
     private func loadHomePageState(homepage: SpaceHomepage) async {
         switch homepage {
         case .empty, .widgets:
-            homePageState = .default(Loc.SpaceSettings.HomePage.widgets)
+            homePageState = .empty
         case .object(let objectId):
             let spaceId = workspaceInfo.accountSpaceId
             let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [objectId]).first
             if let details, !details.isArchivedOrDeleted {
                 homePageState = .object(icon: details.objectIconImage, name: details.name)
             } else {
-                homePageState = .default(Loc.SpaceSettings.HomePage.widgets)
+                homePageState = .empty
             }
         }
     }

--- a/Anytype/Sources/ServiceLayer/HomepagePicker/HomepagePickerService.swift
+++ b/Anytype/Sources/ServiceLayer/HomepagePicker/HomepagePickerService.swift
@@ -13,10 +13,14 @@ final class HomepagePickerService: HomepagePickerServiceProtocol {
         self.workspaceService = Container.shared.workspaceService()
     }
 
+    func setHomepage(spaceId: String, homepage: SpaceHomepage) async throws {
+        try await workspaceService.setHomepage(spaceId: spaceId, homepage: homepage.rawValue)
+    }
+
     func createHomepage(spaceId: String, option: HomepagePickerOption) async throws -> HomepageValue {
         switch option {
         case .widgets:
-            try await setHomepage(spaceId: spaceId, homepageId: SpaceHomepage.widgets.rawValue)
+            try await setHomepage(spaceId: spaceId, homepage: .widgets)
             return .widgets
         case .object(let type):
             let details = try await objectActionsService.createObject(
@@ -31,13 +35,9 @@ final class HomepagePickerService: HomepagePickerServiceProtocol {
                 createdInContext: "",
                 createdInContextRef: ""
             )
-            try await setHomepage(spaceId: spaceId, homepageId: details.id)
+            try await setHomepage(spaceId: spaceId, homepage: .object(objectId: details.id))
             return .object(details: details)
         }
-    }
-
-    private func setHomepage(spaceId: String, homepageId: String) async throws {
-        try await workspaceService.setHomepage(spaceId: spaceId, homepage: homepageId)
     }
 }
 

--- a/Anytype/Sources/ServiceLayer/HomepagePicker/HomepagePickerServiceProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/HomepagePicker/HomepagePickerServiceProtocol.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 protocol HomepagePickerServiceProtocol: Sendable {
+    /// Sets homepage to an existing value (widgets or object ID). No object creation.
+    func setHomepage(spaceId: String, homepage: SpaceHomepage) async throws
+
     /// Creates the homepage object (if needed) and sets it as homepage.
     func createHomepage(spaceId: String, option: HomepagePickerOption) async throws -> HomepageValue
 }

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -2349,7 +2349,7 @@ public enum Loc {
     }
     public enum HomePage {
       public static let chooseHome = Loc.tr("Workspace", "SpaceSettings.HomePage.ChooseHome", fallback: "Choose Home")
-      public static let title = Loc.tr("Workspace", "SpaceSettings.HomePage.Title", fallback: "Home page")
+      public static let title = Loc.tr("Workspace", "SpaceSettings.HomePage.Title", fallback: "Home")
       public static let widgets = Loc.tr("Workspace", "SpaceSettings.HomePage.Widgets", fallback: "Widgets")
     }
     public enum LeaveAlert {

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -2348,6 +2348,7 @@ public enum Loc {
       }
     }
     public enum HomePage {
+      public static let chooseHome = Loc.tr("Workspace", "SpaceSettings.HomePage.ChooseHome", fallback: "Choose Home")
       public static let title = Loc.tr("Workspace", "SpaceSettings.HomePage.Title", fallback: "Home page")
       public static let widgets = Loc.tr("Workspace", "SpaceSettings.HomePage.Widgets", fallback: "Widgets")
     }

--- a/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
@@ -64238,7 +64238,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Home page"
+            "value" : "Home"
           }
         },
         "es" : {

--- a/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
@@ -64197,6 +64197,17 @@
         }
       }
     },
+    "SpaceSettings.HomePage.ChooseHome" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Home"
+          }
+        }
+      }
+    },
     "SpaceSettings.HomePage.Title" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## Summary

- Refactor homepage pickers: rename `HomepagePickerView` → `HomepageCreatePickerView` (creation flow) and `HomePagePickerView` → `HomepageSettingsPickerView` (settings flow) for clarity
- Add `setHomepage(spaceId:homepage:)` to `HomepagePickerService` for setting existing objects as homepage without creating new ones
- Update settings picker UI: replace "Widgets/Chat" first option with "Empty" (resets to widgets), add "Choose Home" title, fix paddings to match Figma design
- Rename `HomePageState` → `HomepageSettingsState`, empty state shows chevron only