### PR TITLE
IOS-5965: Remove debug workaround for widgets as default homepage

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
@@ -29,11 +29,7 @@ final class HomeWidgetsCoordinatorViewModel: HomeWidgetsModuleOutput, SetObjectC
 
     func onAppear() {
         let spaceView = Container.shared.spaceViewsStorage().spaceView(spaceId: spaceInfo.accountSpaceId)
-        var homepageNotSet = spaceView?.homepage == .empty
-        #if DEBUG
-        // TODO: Remove when middleware stops setting "widgets" as default homepage for new spaces
-        homepageNotSet = homepageNotSet || spaceView?.homepage == .widgets
-        #endif
+        let homepageNotSet = spaceView?.homepage == .empty
         if homepageNotSet, !showHomepagePicker {
             showHomepagePicker = true
         }


### PR DESCRIPTION
## Summary

- Remove `#if DEBUG` workaround in `HomeWidgetsCoordinatorViewModel.onAppear()` that treated `widgets` homepage as "not set"
- Middleware now returns empty string as default homepage for new spaces, making the workaround unnecessary