### PR TITLE
IOS-5971 Update Claude Code permissions and add safety hooks

### DIFF
--- a/.claude/hooks/bash-safety-guard.sh
+++ b/.claude/hooks/bash-safety-guard.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Bash Safety Guard (PreToolUse on Bash)
+# Blocks bash patterns that trigger un-bypassable Claude Code security prompts.
+
+set -euo pipefail
+
+# Read tool input from stdin
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Block find -exec with \; (triggers security prompt for backslash before shell operator)
+# Suggest using {} + or piping to xargs instead
+if [[ "$COMMAND" =~ \\\\?\; ]] && [[ "$COMMAND" =~ -exec ]]; then
+    cat <<'BLOCK'
+{
+  "decision": "block",
+  "reason": "find -exec with \\; triggers a security prompt. Use 'find ... -exec cmd {} +' (with + instead of \\;) or 'find ... | xargs cmd' instead."
+}
+BLOCK
+    exit 0
+fi
+
+exit 0

--- a/.claude/hooks/bash-safety-guard.sh
+++ b/.claude/hooks/bash-safety-guard.sh
@@ -3,11 +3,11 @@
 # Bash Safety Guard (PreToolUse on Bash)
 # Blocks bash patterns that trigger un-bypassable Claude Code security prompts.
 
-set -euo pipefail
+set -eo pipefail
 
 # Read tool input from stdin
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
 # Block find -exec with \; (triggers security prompt for backslash before shell operator)
 # Suggest using {} + or piping to xargs instead

--- a/.claude/hooks/dangerous-git-guard.sh
+++ b/.claude/hooks/dangerous-git-guard.sh
@@ -4,11 +4,11 @@
 # Catches dangerous git patterns that prefix-based deny rules miss,
 # e.g. "git push origin main --force" where --force is not right after push.
 
-set -euo pipefail
+set -eo pipefail
 
 # Read tool input from stdin
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
 # Skip non-git commands
 if [[ ! "$COMMAND" =~ ^[[:space:]]*git[[:space:]] ]]; then

--- a/.claude/hooks/dangerous-git-guard.sh
+++ b/.claude/hooks/dangerous-git-guard.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Dangerous Git Guard (PreToolUse on Bash)
+# Catches dangerous git patterns that prefix-based deny rules miss,
+# e.g. "git push origin main --force" where --force is not right after push.
+
+set -euo pipefail
+
+# Read tool input from stdin
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Skip non-git commands
+if [[ ! "$COMMAND" =~ ^[[:space:]]*git[[:space:]] ]]; then
+    exit 0
+fi
+
+# Check for force push flags anywhere in a git push command
+if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+push ]]; then
+    if [[ "$COMMAND" =~ --force|\ -f\ |\ -f$|--force-with-lease ]]; then
+        cat <<'BLOCK'
+{
+  "decision": "block",
+  "reason": "Force push is forbidden. Use regular git push instead."
+}
+BLOCK
+        exit 0
+    fi
+fi
+
+# Check for git reset anywhere (backup check for deny rules)
+if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+reset ]]; then
+    cat <<'BLOCK'
+{
+  "decision": "block",
+  "reason": "git reset is forbidden. Use git revert or create a new commit instead."
+}
+BLOCK
+    exit 0
+fi
+
+# Check for git clean
+if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+clean ]]; then
+    cat <<'BLOCK'
+{
+  "decision": "block",
+  "reason": "git clean is forbidden. Remove files manually instead."
+}
+BLOCK
+    exit 0
+fi
+
+# Check for destructive checkout (git checkout . or git checkout -- .)
+if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+checkout[[:space:]]+(--[[:space:]]+)?\.([[:space:]]|$) ]]; then
+    cat <<'BLOCK'
+{
+  "decision": "block",
+  "reason": "Destructive git checkout (discard all changes) is forbidden. Discard specific files instead."
+}
+BLOCK
+    exit 0
+fi
+
+# Check for destructive restore (git restore .)
+if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+restore[[:space:]]+\. ]]; then
+    cat <<'BLOCK'
+{
+  "decision": "block",
+  "reason": "git restore . (discard all changes) is forbidden. Restore specific files instead."
+}
+BLOCK
+    exit 0
+fi
+
+# Check for force branch delete
+if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+branch[[:space:]]+-D ]]; then
+    cat <<'BLOCK'
+{
+  "decision": "block",
+  "reason": "git branch -D (force delete) is forbidden. Use git branch -d for safe deletion."
+}
+BLOCK
+    exit 0
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -103,12 +103,7 @@
           {
             "type": "command",
             "command": ".claude/hooks/dangerous-git-guard.sh"
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
+          },
           {
             "type": "command",
             "command": ".claude/hooks/bash-safety-guard.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,21 @@
 
       "Bash(git checkout:*)",
       "Bash(git worktree:*)",
+      "Bash(git fetch:*)",
+      "Bash(git log:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git stash show:*)",
+      "Bash(git diff:*)",
+      "Bash(git status:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git stash:*)",
+      "Bash(git merge:*)",
+      "Bash(git cherry-pick:*)",
+      "Bash(git remote:*)",
 
       "Bash(find:*)",
       "Bash(grep:*)",
@@ -12,35 +27,37 @@
       "Bash(sed:*)",
       "Bash(cat:*)",
       "Bash(ls:*)",
+      "Bash(od:*)",
+      "Bash(awk:*)",
 
-      "Bash(make setup-middle:*)",
-      "Bash(make generate-middle:*)",
       "Bash(make:*)",
       "Bash(xcodebuild:*)",
       "Bash(open:*)",
       "Bash(true)",
 
       "Bash(gh pr view:*)",
-      "Bash(gh issue view:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr diff:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh pr review:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh api:*)",
+
+      "Bash(mv:*)",
+      "Bash(mkdir:*)",
+      "Bash(bash Scripts/:*)",
 
       "Bash(linctl:*)",
 
-      "SlashCommand(/codeReview)",
+      "Skill(codeReview)",
+      "Skill(cpp)",
+      "Skill(update-config)",
 
-      "Bash(gh pr list:*)",
-      "Bash(gh pr diff:*)",
-      "Bash(git fetch:*)",
-      "Bash(git log:*)",
-      "Bash(git rev-parse:*)",
-      "Bash(while read commit)",
-      "Bash(do git show --name-only --format=\"\" $commit)",
-      "Bash(echo \"Commit: $commit\")",
-      "Bash(done)",
-      "Bash(od:*)",
-      "Bash(awk:*)",
-      "Bash(git stash show:*)",
+      "mcp__linear-server__get_issue",
+      "mcp__linear-server__get_project",
+      "mcp__linear-server__save_comment",
+
       "mcp__figma-remote-mcp__get_screenshot",
       "mcp__figma-remote-mcp__get_design_context",
       "mcp__figma-remote-mcp__get_metadata",
@@ -49,7 +66,19 @@
       "mcp__figma-remote-mcp__create_design_system_rules",
       "mcp__figma-remote-mcp__whoami"
     ],
-    "deny": []
+    "deny": [
+      "Bash(git reset:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push --force-with-lease:*)",
+      "Bash(git clean:*)",
+      "Bash(git checkout .:*)",
+      "Bash(git checkout -- .:*)",
+      "Bash(git restore .:*)",
+      "Bash(git branch -D:*)",
+      "Bash(git stash drop:*)",
+      "Bash(git stash clear:*)"
+    ]
   },
   "attribution": {
     "commit": "",
@@ -65,6 +94,24 @@
           {
             "type": "command",
             "command": ".claude/hooks/branch-protection-pre-edit.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/dangerous-git-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/bash-safety-guard.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Consolidate permissions: add explicit git allow/deny rules, gh CLI (incl. pr create), Linear MCP, Skills, file operations
- Add deny rules for dangerous git commands (reset, force push, clean, destructive checkout, branch -D, stash drop/clear)
- Add `dangerous-git-guard.sh` PreToolUse hook — catches force push flags in any position (deny rules only match prefixes)
- Add `bash-safety-guard.sh` PreToolUse hook — blocks find-exec with backslash-semicolon pattern that triggers un-bypassable security prompt
- Clean up: remove duplicate entries, one-off commands, replace SlashCommand with Skill