### PR TITLE
IOS-5942 Comment bubble layout polish

### DIFF
--- a/Anytype/Sources/Helpers/Formatters/MessageTimestampFormatter.swift
+++ b/Anytype/Sources/Helpers/Formatters/MessageTimestampFormatter.swift
@@ -4,6 +4,18 @@ final class MessageTimestampFormatter: Sendable {
 
     private let calendar = Calendar.current
 
+    private let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        return formatter
+    }()
+
     func string(for date: Date) -> String {
         let now = Date()
         let startOfToday = calendar.startOfDay(for: now)
@@ -13,20 +25,16 @@ final class MessageTimestampFormatter: Sendable {
 
         switch dayDiff {
         case 0:
-            let formatter = DateFormatter()
-            formatter.dateStyle = .none
-            formatter.timeStyle = .short
-            return formatter.string(from: date)
+            return timeFormatter.string(from: date)
         case 1:
             return Loc.yesterday
         default:
-            let formatter = DateFormatter()
             if calendar.isDate(date, equalTo: now, toGranularity: .year) {
-                formatter.setLocalizedDateFormatFromTemplate("MMM d")
+                dateFormatter.setLocalizedDateFormatFromTemplate("MMM d")
             } else {
-                formatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
+                dateFormatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
             }
-            return formatter.string(from: date)
+            return dateFormatter.string(from: date)
         }
     }
 }

--- a/Anytype/Sources/Helpers/Formatters/MessageTimestampFormatter.swift
+++ b/Anytype/Sources/Helpers/Formatters/MessageTimestampFormatter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class MessageTimestampFormatter: Sendable {
+final class MessageTimestampFormatter {
 
     private let calendar = Calendar.current
 

--- a/Anytype/Sources/Helpers/Formatters/MessageTimestampFormatter.swift
+++ b/Anytype/Sources/Helpers/Formatters/MessageTimestampFormatter.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+final class MessageTimestampFormatter: Sendable {
+
+    private let calendar = Calendar.current
+
+    func string(for date: Date) -> String {
+        let now = Date()
+        let startOfToday = calendar.startOfDay(for: now)
+        let startOfDate = calendar.startOfDay(for: date)
+
+        let dayDiff = calendar.dateComponents([.day], from: startOfDate, to: startOfToday).day ?? 0
+
+        switch dayDiff {
+        case 0:
+            let formatter = DateFormatter()
+            formatter.dateStyle = .none
+            formatter.timeStyle = .short
+            return formatter.string(from: date)
+        case 1:
+            return Loc.yesterday
+        default:
+            let formatter = DateFormatter()
+            if calendar.isDate(date, equalTo: now, toGranularity: .year) {
+                formatter.setLocalizedDateFormatFromTemplate("MMM d")
+            } else {
+                formatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
+            }
+            return formatter.string(from: date)
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessageBuilder.swift
@@ -83,7 +83,7 @@ actor ChatMessageBuilder: ChatMessageBuilderProtocol, Sendable {
                 authorName: authorParticipant?.title ?? "",
                 authorIcon: authorParticipant?.icon.map { .object($0) } ?? Icon.object(.profile(.placeholder)),
                 authorId: authorParticipant?.id,
-                createDate: message.createdAtDate.formatted(date: .omitted, time: .shortened),
+                timestampLabel: message.createdAtDate.formatted(date: .omitted, time: .shortened),
                 messageString: messageTextBuilder.makeMessage(content: message.message, spaceId: spaceId, position: position),
                 discussionBlocks: [],
                 replyModel: mapReply(
@@ -109,7 +109,6 @@ actor ChatMessageBuilder: ChatMessageBuilderProtocol, Sendable {
                 canEdit: isYourMessage && canEdit,
                 showMessageSyncIndicator: isYourMessage,
                 isMember: false,
-                isEdited: false,
                 showTopDivider: false,
                 message: message,
                 attachmentsDetails: fullMessage.attachments,

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessageBuilder.swift
@@ -108,6 +108,9 @@ actor ChatMessageBuilder: ChatMessageBuilderProtocol, Sendable {
                 canDelete: isYourMessage && canEdit,
                 canEdit: isYourMessage && canEdit,
                 showMessageSyncIndicator: isYourMessage,
+                isMember: false,
+                isEdited: false,
+                showTopDivider: false,
                 message: message,
                 attachmentsDetails: fullMessage.attachments,
                 reply: fullMessage.reply

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageBottomInfoView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageBottomInfoView.swift
@@ -14,7 +14,7 @@ private struct MessageBottomInfoViewBuilder {
     let synced: Bool
     let edited: Bool
     let showSyncIndicator: Bool
-    let createDate: String
+    let timestampLabel: String
     
     var body: Text {
         infoText
@@ -23,7 +23,7 @@ private struct MessageBottomInfoViewBuilder {
     
     private var infoText: Text {
         let editText = edited ? Loc.Message.edited + " " : ""
-        return Text("  ") + syncIndicator + Text(editText + createDate)
+        return Text("  ") + syncIndicator + Text(editText + timestampLabel)
     }
     
     private var syncIndicator: Text {
@@ -51,7 +51,7 @@ private extension MessageBottomInfoViewBuilder {
             synced: data.message.synced,
             edited: data.message.modifiedAtDate != nil,
             showSyncIndicator: data.showMessageSyncIndicator,
-            createDate: data.createDate
+            timestampLabel: data.timestampLabel
         )
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageViewData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageViewData.swift
@@ -10,7 +10,7 @@ struct MessageViewData: Identifiable, Equatable, Hashable {
     let authorName: String
     let authorIcon: Icon
     let authorId: String?
-    let createDate: String
+    let timestampLabel: String
     let messageString: AttributedString
     let discussionBlocks: [DiscussionBlockItem]
     let replyModel: MessageReplyModel?
@@ -26,7 +26,6 @@ struct MessageViewData: Identifiable, Equatable, Hashable {
     let canEdit: Bool
     let showMessageSyncIndicator: Bool
     let isMember: Bool
-    let isEdited: Bool
     let showTopDivider: Bool
 
     // Raw data for action logic

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageViewData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageViewData.swift
@@ -25,7 +25,10 @@ struct MessageViewData: Identifiable, Equatable, Hashable {
     let canDelete: Bool
     let canEdit: Bool
     let showMessageSyncIndicator: Bool
-    
+    let isMember: Bool
+    let isEdited: Bool
+    let showTopDivider: Bool
+
     // Raw data for action logic
     let message: ChatMessage
     let attachmentsDetails: [ObjectDetails]

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
@@ -66,7 +66,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                 authorName: authorParticipant?.title ?? "",
                 authorIcon: authorParticipant?.icon.map { .object($0) } ?? Icon.object(.profile(.placeholder)),
                 authorId: authorParticipant?.id,
-                createDate: timestampFormatter.string(for: message.createdAtDate),
+                timestampLabel: makeTimestampLabel(message: message),
                 messageString: AttributedString(),
                 discussionBlocks: message.resolvedDiscussionBlocks(
                     spaceId: spaceId,
@@ -97,7 +97,6 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                 canEdit: isYourMessage && canEdit,
                 showMessageSyncIndicator: isYourMessage,
                 isMember: authorParticipant?.globalName.isNotEmpty ?? false,
-                isEdited: message.modifiedAtDate != nil,
                 showTopDivider: !isFirstMessageInSection,
                 message: message,
                 attachmentsDetails: fullMessage.attachments,
@@ -132,6 +131,14 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
         }
 
         return newMessageBlocks
+    }
+
+    private func makeTimestampLabel(message: ChatMessage) -> String {
+        let timestamp = timestampFormatter.string(for: message.createdAtDate)
+        if message.modifiedAtDate != nil {
+            return "\(timestamp) (\(Loc.Message.edited))"
+        }
+        return timestamp
     }
 
     private func dayDate(for date: Date) -> Date {

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
@@ -19,7 +19,8 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
     private let spaceId: String
     private let chatId: String
 
-    private let dateFormatter = HistoryDateFormatter()
+    private let sectionDateFormatter = HistoryDateFormatter()
+    private let timestampFormatter = MessageTimestampFormatter()
 
     init(spaceId: String, chatId: String) {
         self.spaceId = spaceId
@@ -44,6 +45,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
         var newMessageBlocks: [MessageSectionData] = []
 
         var sectionDateDay: Date?
+        var isFirstMessageInSection = true
 
         for messageIndex in 0..<messages.count {
 
@@ -64,7 +66,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                 authorName: authorParticipant?.title ?? "",
                 authorIcon: authorParticipant?.icon.map { .object($0) } ?? Icon.object(.profile(.placeholder)),
                 authorId: authorParticipant?.id,
-                createDate: message.createdAtDate.formatted(date: .abbreviated, time: .omitted),
+                createDate: timestampFormatter.string(for: message.createdAtDate),
                 messageString: AttributedString(),
                 discussionBlocks: message.resolvedDiscussionBlocks(
                     spaceId: spaceId,
@@ -94,6 +96,9 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                 canDelete: isYourMessage && canEdit,
                 canEdit: isYourMessage && canEdit,
                 showMessageSyncIndicator: isYourMessage,
+                isMember: authorParticipant?.globalName.isNotEmpty ?? false,
+                isEdited: message.modifiedAtDate != nil,
+                showTopDivider: !isFirstMessageInSection,
                 message: message,
                 attachmentsDetails: fullMessage.attachments,
                 reply: fullMessage.reply
@@ -106,17 +111,19 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                     newMessageBlocks.append(currentSectionData)
                 }
                 currentSectionData = MessageSectionData(
-                    header: dateFormatter.localizedDateString(for: createDateDay),
+                    header: sectionDateFormatter.localizedDateString(for: createDateDay),
                     id: createDateDay.hashValue,
                     items: []
                 )
                 sectionDateDay = createDateDay
+                isFirstMessageInSection = true
             }
 
             if let unreadItem {
                 currentSectionData?.items.append(unreadItem)
             }
             currentSectionData?.items.append(.message(messageModel))
+            isFirstMessageInSection = false
 
         }
 

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
@@ -60,6 +60,19 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
             let position: MessageHorizontalPosition = .left
             let isUnread = message.orderID == firstUnreadMessageOrderId
 
+            if firstInSection {
+                if let currentSectionData {
+                    newMessageBlocks.append(currentSectionData)
+                }
+                currentSectionData = MessageSectionData(
+                    header: sectionDateFormatter.localizedDateString(for: createDateDay),
+                    id: createDateDay.hashValue,
+                    items: []
+                )
+                sectionDateDay = createDateDay
+                isFirstMessageInSection = true
+            }
+
             let messageModel = MessageViewData(
                 spaceId: spaceId,
                 chatId: chatId,
@@ -104,19 +117,6 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
             )
 
             let unreadItem: MessageSectionItem? = isUnread ? .unread(id: "\(message.id)-unread", messageId: message.id, messageOrderId: message.orderID) : nil
-
-            if firstInSection {
-                if let currentSectionData {
-                    newMessageBlocks.append(currentSectionData)
-                }
-                currentSectionData = MessageSectionData(
-                    header: sectionDateFormatter.localizedDateString(for: createDateDay),
-                    id: createDateDay.hashValue,
-                    items: []
-                )
-                sectionDateDay = createDateDay
-                isFirstMessageInSection = true
-            }
 
             if let unreadItem {
                 currentSectionData?.items.append(unreadItem)

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -59,49 +59,66 @@ struct DiscussionMessageView: View {
 
     private var messageBody: some View {
         VStack(alignment: .leading, spacing: 0) {
-            header
-            reply
-            messageContent
-            reactions
+            if data.showTopDivider {
+                Divider()
+                    .foregroundStyle(Color.Shape.tertiary)
+            }
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                    .padding(.bottom, 8)
+                reply
+                messageContent
+                reactions
+            }
+            .padding(.horizontal, Constants.messageHorizontalPadding)
+            .padding(.vertical, 12)
         }
-        .padding(.horizontal, Constants.messageHorizontalPadding)
-        // In discussions every comment is independent — no small/medium grouping spacing from chat
-        .padding(.bottom, 16)
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Divider()
-                .foregroundStyle(Color.Shape.tertiary)
-                .padding(.top, 4)
+        HStack(spacing: 0) {
+            Button {
+                if let authorId = data.authorId {
+                    output?.didSelectAuthor(authorId: authorId)
+                }
+            } label: {
+                HStack(spacing: 0) {
+                    IconView(icon: data.authorIcon)
+                        .frame(width: 28, height: 28)
 
-            HStack(spacing: 8) {
-                Button {
-                    if let authorId = data.authorId {
-                        output?.didSelectAuthor(authorId: authorId)
-                    }
-                } label: {
-                    HStack(spacing: 8) {
-                        IconView(icon: data.authorIcon)
-                            .frame(width: 28, height: 28)
+                    Spacer().frame(width: 6)
 
-                        Text(data.authorName.isNotEmpty ? data.authorName : " ")
-                            .anytypeStyle(.caption1Medium)
-                            .lineLimit(1)
-                            .foregroundStyle(Color.Text.primary)
+                    Text(data.authorName.isNotEmpty ? data.authorName : " ")
+                        .anytypeStyle(.caption1Medium)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .foregroundStyle(Color.Text.primary)
+
+                    if data.isMember {
+                        Spacer().frame(width: 4)
+                        Image(asset: .X18.membershipBadge)
                     }
                 }
-                .buttonStyle(.plain)
-
-                Spacer()
-
-                Text(data.createDate)
-                    .anytypeStyle(.caption2Regular)
-                    .foregroundStyle(Color.Text.secondary)
             }
-            .padding(.top, 12)
-            .padding(.bottom, 4)
+            .buttonStyle(.plain)
+            .layoutPriority(-1)
+
+            Spacer().frame(width: 8)
+
+            timestampLabel
+                .fixedSize()
         }
+        .frame(height: 32)
+    }
+
+    private var timestampLabel: some View {
+        let text: String = data.isEdited
+            ? "\(data.createDate) (\(Loc.Message.edited))"
+            : data.createDate
+        return Text(text)
+            .anytypeStyle(.caption2Regular)
+            .foregroundStyle(Color.Text.secondary)
+            .lineLimit(1)
     }
 
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -112,10 +112,7 @@ struct DiscussionMessageView: View {
     }
 
     private var timestampLabel: some View {
-        let text: String = data.isEdited
-            ? "\(data.createDate) (\(Loc.Message.edited))"
-            : data.createDate
-        return Text(text)
+        Text(data.timestampLabel)
             .anytypeStyle(.caption2Regular)
             .foregroundStyle(Color.Text.secondary)
             .lineLimit(1)


### PR DESCRIPTION
## Summary
- Rework discussion message header: left-aligned flow with avatar → name → membership badge → timestamp (+ "(edited)" label)
- Add `MessageTimestampFormatter` with locale-aware formatting (time today, "Yesterday", "Mar 8", "Mar 8, 2025")
- Edge-to-edge dividers between messages, corrected spacing (h:16, v:12, header height 32)