### PR TITLE
IOS-5900 Add spaceType field to SpaceView, deprecate uxType

### DIFF
--- a/Anytype/Sources/PreviewMocks/Mocks/Models/SpaceViewMock.swift
+++ b/Anytype/Sources/PreviewMocks/Mocks/Models/SpaceViewMock.swift
@@ -27,6 +27,7 @@ extension SpaceView {
             chatId: Bool.random() ? "123" : "",
             spaceOrder: "",
             uxType: .allCases.randomElement()!,
+            spaceType: .regular,
             pushNotificationEncryptionKey: "",
             pushNotificationMode: .allCases.randomElement()!,
             forceAllIds: [],

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
@@ -17,7 +17,9 @@ struct SpaceView: Identifiable, Equatable, Hashable {
     let writersLimit: Int?
     let chatId: String
     let spaceOrder: String
+    @available(*, deprecated, message: "Use spaceType instead")
     let uxType: SpaceUxType
+    let spaceType: SpaceType
     let pushNotificationEncryptionKey: String
     let pushNotificationMode: SpacePushNotificationsMode
     let forceAllIds: [String]
@@ -44,6 +46,7 @@ extension SpaceView: DetailsModel {
         self.chatId = details.chatId
         self.spaceOrder = details.spaceOrder
         self.uxType = details.spaceUxTypeValue ?? .data
+        self.spaceType = details.spaceTypeValue ?? .regular
         self.pushNotificationEncryptionKey = details.spacePushNotificationEncryptionKey
         self.pushNotificationMode = details.spacePushNotificationModeValue ?? .all
         self.forceAllIds = details.spacePushNotificationForceAllIds
@@ -70,6 +73,7 @@ extension SpaceView: DetailsModel {
         BundledPropertyKey.chatId
         BundledPropertyKey.spaceOrder
         BundledPropertyKey.spaceUxType
+        BundledPropertyKey.spaceType
         BundledPropertyKey.spacePushNotificationEncryptionKey
         BundledPropertyKey.spacePushNotificationMode
         BundledPropertyKey.spacePushNotificationForceAllIds
@@ -111,14 +115,21 @@ extension SpaceView {
         return spaceIsLoading && spaceIsNotDeleted && spaceIsNotJoining
     }
     
+    var isOneToOne: Bool {
+        spaceType == .oneToOne
+    }
+
+    @available(*, deprecated, message: "Use homepage to determine initial screen")
     var initialScreenIsChat: Bool {
         uxType.initialScreenIsChat
     }
-    
+
+    @available(*, deprecated, message: "Will be reworked with homepage logic")
     var canAddChatWidget: Bool {
         !initialScreenIsChat && isShared && hasChat
     }
 
+    @available(*, deprecated, message: "Will be reworked with homepage logic")
     var canShowChatWidget: Bool {
         !uxType.supportsMultiChats
     }

--- a/Modules/Services/Sources/Models/Details/BundledPropertyValueProvider+CustomProperties.swift
+++ b/Modules/Services/Sources/Models/Details/BundledPropertyValueProvider+CustomProperties.swift
@@ -105,7 +105,12 @@ extension BundledPropertiesValueProvider {
         guard let spaceUxType else { return nil }
         return SpaceUxType(rawValue: spaceUxType)
     }
-    
+
+    public var spaceTypeValue: SpaceType? {
+        guard let spaceType else { return nil }
+        return SpaceType(rawValue: spaceType)
+    }
+
     public var customIcon: CustomIcon? {
         CustomIcon(fromString: iconName)
     }

--- a/Modules/Services/Sources/Models/Space/SpaceAliases.swift
+++ b/Modules/Services/Sources/Models/Space/SpaceAliases.swift
@@ -4,6 +4,7 @@ import AnytypeCore
 
 public typealias SpaceStatus = Anytype_Model_SpaceStatus
 public typealias SpaceUxType = Anytype_Model_SpaceUxType
+public typealias SpaceType = Anytype_Model_SpaceType
 public typealias InviteType = Anytype_Model_InviteType
 public typealias InvitePermissions = Anytype_Model_ParticipantPermissions
 public typealias SpacePushNotificationsMode = Anytype_Rpc.PushNotification.Mode


### PR DESCRIPTION
## Summary
- Add `SpaceType` typealias and `spaceTypeValue` accessor for the new middleware-derived `spaceType` relation
- Add `spaceType` field and `isOneToOne` computed property to `SpaceView`
- Mark `uxType`, `initialScreenIsChat`, `canAddChatWidget`, `canShowChatWidget` as deprecated