### PR TITLE
IOS-5958 Remove date pill from discussions

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatView.swift
@@ -185,7 +185,8 @@ struct ChatView: View {
             scrollProxy: model.collectionViewScrollProxy,
             bottomPanel: bottomPanel,
             emptyView: emptyView,
-            showEmptyState: model.showEmptyState
+            showEmptyState: model.showEmptyState,
+            showSectionHeaders: true
         ) {
             cell(data: $0)
         } headerBuilder: {

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatCollectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatCollectionView.swift
@@ -17,6 +17,7 @@ struct ChatCollectionView<
     let bottomPanel: BottomPanel
     let emptyView: EmptyView
     let showEmptyState: Bool
+    let showSectionHeaders: Bool
     let itemBuilder: (Item) -> ItemView
     let headerBuilder: (Section.Header) -> HeaderView
     @ViewBuilder
@@ -28,24 +29,26 @@ struct ChatCollectionView<
     let onTapCollectionBackground: () -> Void
     
     func makeUIViewController(context: Context) -> ChatCollectionViewContainer<BottomPanel, EmptyView, ActionView> {
+        let showSectionHeaders = showSectionHeaders
         let layout = UICollectionViewCompositionalLayout { sectionIndex, layoutEnvironment -> NSCollectionLayoutSection? in
             var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
             configuration.showsSeparators = false
-            
+
             let section = NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: layoutEnvironment)
             section.interGroupSpacing = 0
             section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
             section.decorationItems = [] // Delete section background
-            
-            let header = NSCollectionLayoutBoundarySupplementaryItem(
-                layoutSize: .init(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(50)),
-                elementKind: UICollectionView.elementKindSectionHeader,
-                alignment: .top
-            )
-            header.pinToVisibleBounds = true
-            
-            section.boundarySupplementaryItems = [header]
-            
+
+            if showSectionHeaders {
+                let header = NSCollectionLayoutBoundarySupplementaryItem(
+                    layoutSize: .init(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(50)),
+                    elementKind: UICollectionView.elementKindSectionHeader,
+                    alignment: .top
+                )
+                header.pinToVisibleBounds = true
+                section.boundarySupplementaryItems = [header]
+            }
+
             return section
         }
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
@@ -97,6 +100,6 @@ struct ChatCollectionView<
     }
     
     func makeCoordinator() -> ChatCollectionViewCoordinator<Section, Item, ItemView, HeaderView> {
-        ChatCollectionViewCoordinator<Section, Item, ItemView, HeaderView>()
+        ChatCollectionViewCoordinator<Section, Item, ItemView, HeaderView>(showSectionHeaders: showSectionHeaders)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatCollectionViewCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatCollectionViewCoordinator.swift
@@ -24,7 +24,13 @@ final class ChatCollectionViewCoordinator<
     private var dataSource: UICollectionViewDiffableDataSource<Section.ID, Item>?
     // From iOS 17.4 replace to collectionView.isScrollAnimating
     private var isProgrammaticAnimatedScroll = false
-    
+    private let showSectionHeaders: Bool
+
+    init(showSectionHeaders: Bool) {
+        self.showSectionHeaders = showSectionHeaders
+        super.init()
+    }
+
     var scrollToTop: (() async -> Void)?
     var scrollToBottom: (() async -> Void)?
     var decelerating = false
@@ -36,33 +42,40 @@ final class ChatCollectionViewCoordinator<
     var onTapCollectionBackground: (() -> Void)?
     
     func setupDataSource(collectionView: UICollectionView) {
-        let sectionRegistration = UICollectionView.SupplementaryRegistration<UICollectionViewCell>(elementKind: UICollectionView.elementKindSectionHeader)
-        { [weak self] view, _, indexPath in
-            guard let header = self?.sections[safe: indexPath.section]?.header else { return }
-            view.contentConfiguration = UIHostingConfiguration {
-                self?.headerBuilder?(header)
+        let sectionRegistration: UICollectionView.SupplementaryRegistration<UICollectionViewCell>?
+
+        if showSectionHeaders {
+            sectionRegistration = UICollectionView.SupplementaryRegistration<UICollectionViewCell>(elementKind: UICollectionView.elementKindSectionHeader)
+            { [weak self] view, _, indexPath in
+                guard let header = self?.sections[safe: indexPath.section]?.header else { return }
+                view.contentConfiguration = UIHostingConfiguration {
+                    self?.headerBuilder?(header)
+                }
+                .margins(.all, 0)
+                view.layer.zPosition = 1
             }
-            .margins(.all, 0)
-            view.layer.zPosition = 1
+        } else {
+            sectionRegistration = nil
         }
-        
+
         let itemRegistration = UICollectionView.CellRegistration<ChatContainerCell<Item, DataView>, Item> { [weak self] cell, indexPath, item in
             cell.setItem(item, builder: self?.itemBuilder)
         }
-        
-    
+
         let dataSource = UICollectionViewDiffableDataSource<Section.ID, Item>(collectionView: collectionView) { (collectionView, indexPath, item) -> UICollectionViewCell in
             let cell = collectionView.dequeueConfiguredReusableCell(using: itemRegistration, for: indexPath, item: item)
             cell.backgroundConfiguration = UIBackgroundConfiguration.clear()
             return cell
         }
-        
-        dataSource.supplementaryViewProvider = { (collectionView, kind, indexPath) -> UICollectionReusableView in
-            let cell = collectionView.dequeueConfiguredReusableSupplementary(using: sectionRegistration, for: indexPath)
-            cell.backgroundConfiguration = UIBackgroundConfiguration.clear()
-            return cell
+
+        if let sectionRegistration {
+            dataSource.supplementaryViewProvider = { (collectionView, kind, indexPath) -> UICollectionReusableView in
+                let cell = collectionView.dequeueConfiguredReusableSupplementary(using: sectionRegistration, for: indexPath)
+                cell.backgroundConfiguration = UIBackgroundConfiguration.clear()
+                return cell
+            }
         }
-        
+
         self.dataSource = dataSource
     }
     
@@ -294,6 +307,7 @@ final class ChatCollectionViewCoordinator<
     }
     
     private func updateHeaders(collectionView: UICollectionView, animated: Bool = true) {
+        guard showSectionHeaders else { return }
         let headers = collectionView.visibleSupplementaryViews(ofKind: UICollectionView.elementKindSectionHeader)
         let cells = collectionView.visibleCells
         let visibleBounds = collectionView.bounds.inset(by: collectionView.adjustedContentInset)

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -185,7 +185,8 @@ struct DiscussionView: View {
             scrollProxy: model.collectionViewScrollProxy,
             bottomPanel: bottomPanel,
             emptyView: emptyView,
-            showEmptyState: model.showEmptyState
+            showEmptyState: model.showEmptyState,
+            showSectionHeaders: false
         ) {
             cell(data: $0)
         } headerBuilder: {

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
@@ -19,7 +19,6 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
     private let spaceId: String
     private let chatId: String
 
-    private let sectionDateFormatter = HistoryDateFormatter()
     private let timestampFormatter = MessageTimestampFormatter()
 
     init(spaceId: String, chatId: String) {
@@ -41,37 +40,17 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
         let canEdit = (participant?.canEdit ?? false) && !isChatDeletedOrArchived
         let yourProfileIdentity = participant?.identity
 
-        var currentSectionData: MessageSectionData?
-        var newMessageBlocks: [MessageSectionData] = []
-
-        var sectionDateDay: Date?
-        var isFirstMessageInSection = true
+        var items: [MessageSectionItem] = []
 
         for messageIndex in 0..<messages.count {
 
             let fullMessage = messages[messageIndex]
             let message = fullMessage.message
 
-            let createDateDay = dayDate(for: message.createdAtDate)
-
-            let firstInSection = sectionDateDay.map { $0.timeIntervalSince1970 < createDateDay.timeIntervalSince1970 } ?? true
             let isYourMessage = message.creator == yourProfileIdentity
             let authorParticipant = participants.first { $0.identity == message.creator }
             let position: MessageHorizontalPosition = .left
             let isUnread = message.orderID == firstUnreadMessageOrderId
-
-            if firstInSection {
-                if let currentSectionData {
-                    newMessageBlocks.append(currentSectionData)
-                }
-                currentSectionData = MessageSectionData(
-                    header: sectionDateFormatter.localizedDateString(for: createDateDay),
-                    id: createDateDay.hashValue,
-                    items: []
-                )
-                sectionDateDay = createDateDay
-                isFirstMessageInSection = true
-            }
 
             let messageModel = MessageViewData(
                 spaceId: spaceId,
@@ -110,7 +89,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                 canEdit: isYourMessage && canEdit,
                 showMessageSyncIndicator: isYourMessage,
                 isMember: authorParticipant?.globalName.isNotEmpty ?? false,
-                showTopDivider: !isFirstMessageInSection,
+                showTopDivider: messageIndex > 0,
                 message: message,
                 attachmentsDetails: fullMessage.attachments,
                 reply: fullMessage.reply
@@ -119,18 +98,16 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
             let unreadItem: MessageSectionItem? = isUnread ? .unread(id: "\(message.id)-unread", messageId: message.id, messageOrderId: message.orderID) : nil
 
             if let unreadItem {
-                currentSectionData?.items.append(unreadItem)
+                items.append(unreadItem)
             }
-            currentSectionData?.items.append(.message(messageModel))
-            isFirstMessageInSection = false
-
+            items.append(.message(messageModel))
         }
 
-        if let currentSectionData {
-            newMessageBlocks.append(currentSectionData)
-        }
+        guard items.isNotEmpty else { return [] }
 
-        return newMessageBlocks
+        // Discussions don't use section headers (date pill) — each comment shows its own timestamp.
+        // Single section with empty header and static id since there's no day-based grouping.
+        return [MessageSectionData(header: "", id: 0, items: items)]
     }
 
     private func makeTimestampLabel(message: ChatMessage) -> String {
@@ -139,12 +116,6 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
             return "\(timestamp) (\(Loc.Message.edited))"
         }
         return timestamp
-    }
-
-    private func dayDate(for date: Date) -> Date {
-        let calendar = Calendar.current
-        let dateComponents = calendar.dateComponents([.year, .month, .day], from: date)
-        return calendar.date(from: dateComponents) ?? date
     }
 
     private func mapReactions(


### PR DESCRIPTION
## Summary
- Add `showSectionHeaders` flag to `ChatCollectionView` to conditionally disable pinned date pill headers
- Simplify `DiscussionMessageBuilder` to use a single section instead of day-based grouping (redundant since each comment shows its own timestamp)
- Pass `showSectionHeaders: false` from `DiscussionView`