### PR TITLE
IOS-5902 Add participantsAdd stub to WorkspaceServiceProtocol

### DIFF
--- a/Modules/Services/Sources/Services/Workspace/WorkspaceService.swift
+++ b/Modules/Services/Sources/Services/Workspace/WorkspaceService.swift
@@ -26,6 +26,7 @@ public protocol WorkspaceServiceProtocol: Sendable {
     func requestDecline(spaceId: String, identity: String) async throws
     func participantPermissionsChange(spaceId: String, identity: String, permissions: ParticipantPermissions) async throws
     func participantRemove(spaceId: String, identity: String) async throws
+    func participantsAdd(spaceId: String, identities: [String]) async throws
     func leaveApprove(spaceId: String, identity: String) async throws
     func pushNotificationSetSpaceMode(spaceId: String, mode: SpacePushNotificationsMode) async throws
     func pushNotificationResetIds(spaceId: String, chatIds: [String]) async throws
@@ -226,7 +227,13 @@ final class WorkspaceService: WorkspaceServiceProtocol {
             $0.identities = [identity]
         }).invoke()
     }
-    
+
+    public func participantsAdd(spaceId: String, identities: [String]) async throws {
+        // TODO: IOS-5902 — replace with ClientCommands.spaceParticipantsAddList
+        // once middleware Lib.xcframework is updated
+        anytypeAssertionFailure("participantsAdd not yet wired to middleware")
+    }
+
     public func leaveApprove(spaceId: String, identity: String) async throws {
         try await ClientCommands.spaceLeaveApprove(.with {
             $0.spaceID = spaceId

--- a/Modules/Services/Sources/Services/Workspace/WorkspaceService.swift
+++ b/Modules/Services/Sources/Services/Workspace/WorkspaceService.swift
@@ -231,7 +231,7 @@ final class WorkspaceService: WorkspaceServiceProtocol {
     public func participantsAdd(spaceId: String, identities: [String]) async throws {
         // TODO: IOS-5902 — replace with ClientCommands.spaceParticipantsAddList
         // once middleware Lib.xcframework is updated
-        anytypeAssertionFailure("participantsAdd not yet wired to middleware")
+        throw anytypeAssertionFailureWithError("participantsAdd not yet wired to middleware")
     }
 
     public func leaveApprove(spaceId: String, identity: String) async throws {


### PR DESCRIPTION
## Summary
- Add `participantsAdd(spaceId:identities:)` to `WorkspaceServiceProtocol` and `WorkspaceService`
- Stub implementation throws via `anytypeAssertionFailureWithError` until middleware binary includes `SpaceParticipantsAddList` RPC (GO-6946, anyproto/anytype-heart#3048)
- Will be wired to `ClientCommands.spaceParticipantsAddList` once middleware is updated