### PR TITLE
IOS-5972 Fallback to widgets when homepage is set to graph

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -291,7 +291,7 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
         let homepage = spaceView?.homepage ?? .empty
 
         switch homepage {
-        case .empty, .widgets:
+        case .empty, .widgets, .graph:
             return HomeWidgetData(spaceId: spaceId)
         case .object(let objectId):
             let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [objectId]).first

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerViewModel.swift
@@ -26,7 +26,7 @@ final class HomepageSettingsPickerViewModel {
         let spaceView = Container.shared.spaceViewsStorage().spaceView(spaceId: spaceId)
         let homepage = spaceView?.homepage ?? .empty
         switch homepage {
-        case .empty, .widgets:
+        case .empty, .widgets, .graph:
             self.currentObjectId = nil
         case .object(let objectId):
             self.currentObjectId = objectId

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
@@ -308,7 +308,7 @@ final class SpaceSettingsViewModel {
 
     private func loadHomePageState(homepage: SpaceHomepage) async {
         switch homepage {
-        case .empty, .widgets:
+        case .empty, .widgets, .graph:
             homePageState = .empty
         case .object(let objectId):
             let spaceId = workspaceInfo.accountSpaceId

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceHomepage.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceHomepage.swift
@@ -3,12 +3,14 @@ import Foundation
 enum SpaceHomepage: Equatable, Hashable {
     case empty
     case widgets
+    case graph
     case object(objectId: String)
 
     init(rawValue: String) {
         switch rawValue {
         case "": self = .empty
         case "widgets": self = .widgets
+        case "graph": self = .graph
         default: self = .object(objectId: rawValue)
         }
     }
@@ -17,6 +19,7 @@ enum SpaceHomepage: Equatable, Hashable {
         switch self {
         case .empty: return ""
         case .widgets: return "widgets"
+        case .graph: return "graph"
         case .object(let id): return id
         }
     }


### PR DESCRIPTION
## Summary
- Add `.graph` case to `SpaceHomepage` enum to handle desktop's graph homepage option
- Treat graph as widgets on mobile — show widgets view, highlight "Empty" in settings picker
- Preserve `"graph"` rawValue so desktop's setting isn't overwritten