### PR TITLE
IOS-5928 Hide sender name in 1-1 chat preview for attachments

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/NewSpaceCardLastMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/NewSpaceCardLastMessageView.swift
@@ -66,7 +66,7 @@ struct NewSpaceCardLastMessageView: View {
             }
 
             HStack(spacing: 2) {
-                if let creatorTitle = model.creatorTitle {
+                if showsMessageAuthor, let creatorTitle = model.creatorTitle {
                     AnytypeText("\(creatorTitle):", style: .chatPreviewRegular)
                         .foregroundStyle(previewTextColor)
                         .lineLimit(1)


### PR DESCRIPTION
## Summary
- Fixed sender name showing in 1-1 chat previews when message has attachments
- Added `showsMessageAuthor` check to `messageWithAttachements` path, matching the existing check in `messageWithoutAttachements`