### PR TITLE
IOS-5912 Remove chat type filtering for regular channels

### DIFF
--- a/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
+++ b/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
@@ -135,8 +135,13 @@ extension BundledPropertiesValueProvider {
     
     var isSupportedForOpening: Bool { resolvedLayoutValue.isSupportedForOpening }
 
+    @available(*, deprecated, message: "Use spaceType overload instead")
     func isVisibleLayout(spaceUxType: SpaceUxType?) -> Bool {
         DetailsLayout.visibleLayouts(spaceUxType: spaceUxType).contains(resolvedLayoutValue)
+    }
+
+    func isVisibleLayout(spaceType: SpaceType?) -> Bool {
+        DetailsLayout.visibleLayouts(spaceType: spaceType).contains(resolvedLayoutValue)
     }
 
     var displayName: String {

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchViewModel.swift
@@ -41,6 +41,8 @@ final class GlobalSearchViewModel {
     @ObservationIgnored
     private var spaceUxType: SpaceUxType?
     @ObservationIgnored
+    private var spaceType: SpaceType?
+    @ObservationIgnored
     private var searchResult = [SearchResultWithMeta]()
     @ObservationIgnored
     private var sectionChanged = false
@@ -113,7 +115,9 @@ final class GlobalSearchViewModel {
     }
     
     private func loadSpaceUxType() {
-        spaceUxType = spaceViewsStorage.spaceView(spaceId: moduleData.spaceId)?.uxType
+        let spaceView = spaceViewsStorage.spaceView(spaceId: moduleData.spaceId)
+        spaceUxType = spaceView?.uxType
+        spaceType = spaceView?.spaceType
     }
     
     private func updateSections() {
@@ -181,10 +185,18 @@ final class GlobalSearchViewModel {
     
     private func buildLayouts() -> [DetailsLayout] {
         return .builder {
-            if state.searchText.isEmpty {
-                state.section.supportedLayouts(spaceUxType: spaceUxType).filter { $0 != .participant }
+            if FeatureFlags.createChannelFlow {
+                if state.searchText.isEmpty {
+                    state.section.supportedLayouts(spaceType: spaceType).filter { $0 != .participant }
+                } else {
+                    state.section.supportedLayouts(spaceType: spaceType)
+                }
             } else {
-                state.section.supportedLayouts(spaceUxType: spaceUxType)
+                if state.searchText.isEmpty {
+                    state.section.supportedLayouts(spaceUxType: spaceUxType).filter { $0 != .participant }
+                } else {
+                    state.section.supportedLayouts(spaceUxType: spaceUxType)
+                }
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/Models/ObjectTypeSection.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/Models/ObjectTypeSection.swift
@@ -34,10 +34,28 @@ enum ObjectTypeSection: String, CaseIterable, Codable {
         }
     }
     
+    @available(*, deprecated, message: "Use spaceType overload instead")
     func supportedLayouts(spaceUxType: SpaceUxType?) -> [DetailsLayout] {
         switch self {
         case .all:
             DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType)
+        case .pages:
+            DetailsLayout.editorLayouts
+        case .lists:
+            DetailsLayout.listLayouts + [DetailsLayout.objectType]
+        case .files:
+            DetailsLayout.fileLayouts
+        case .media:
+            DetailsLayout.mediaLayouts
+        case .bookmarks:
+            [.bookmark]
+        }
+    }
+
+    func supportedLayouts(spaceType: SpaceType?) -> [DetailsLayout] {
+        switch self {
+        case .all:
+            DetailsLayout.visibleLayoutsWithFiles(spaceType: spaceType)
         case .pages:
             DetailsLayout.editorLayouts
         case .lists:

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/ObjectSearchWithMeta/ObjectSearchWithMetaViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/ObjectSearchWithMeta/ObjectSearchWithMetaViewModel.swift
@@ -118,8 +118,14 @@ final class ObjectSearchWithMetaViewModel {
     }
 
     private func supportedLayouts() -> [DetailsLayout] {
-        let spaceUxType = spaceViewsStorage.spaceView(spaceId: moduleData.spaceId)?.uxType
-        return ObjectTypeSection.pages.supportedLayouts(spaceUxType: spaceUxType) +
-               ObjectTypeSection.lists.supportedLayouts(spaceUxType: spaceUxType)
+        if FeatureFlags.createChannelFlow {
+            let spaceType = spaceViewsStorage.spaceView(spaceId: moduleData.spaceId)?.spaceType
+            return ObjectTypeSection.pages.supportedLayouts(spaceType: spaceType) +
+                   ObjectTypeSection.lists.supportedLayouts(spaceType: spaceType)
+        } else {
+            let spaceUxType = spaceViewsStorage.spaceView(spaceId: moduleData.spaceId)?.uxType
+            return ObjectTypeSection.pages.supportedLayouts(spaceUxType: spaceUxType) +
+                   ObjectTypeSection.lists.supportedLayouts(spaceUxType: spaceUxType)
+        }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/Date/Subscription/DateRelatedObjectsSubscriptionService.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Date/Subscription/DateRelatedObjectsSubscriptionService.swift
@@ -1,3 +1,4 @@
+import AnytypeCore
 import Foundation
 import Services
 
@@ -35,10 +36,19 @@ final class DateRelatedObjectsSubscriptionService: DateRelatedObjectsSubscriptio
         update: @escaping @MainActor ([ObjectDetails], Int) -> Void
     ) async {
         
-        let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
-        let filters: [DataviewFilter] = .builder {
-            SearchFiltersBuilder.build(isArchived: false, layouts: DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType), spaceUxType: spaceUxType)
-            filters
+        let allFilters: [DataviewFilter]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = spaceViewsStorage.spaceView(spaceId: spaceId)?.spaceType
+            allFilters = .builder {
+                SearchFiltersBuilder.build(isArchived: false, layouts: DetailsLayout.visibleLayoutsWithFiles(spaceType: spaceType), spaceType: spaceType)
+                filters
+            }
+        } else {
+            let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
+            allFilters = .builder {
+                SearchFiltersBuilder.build(isArchived: false, layouts: DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType), spaceUxType: spaceUxType)
+                filters
+            }
         }
         
         let keys = BundledPropertyKey.objectListKeys.map { $0.rawValue } + [ BundledPropertyKey.origin.rawValue ]
@@ -48,7 +58,7 @@ final class DateRelatedObjectsSubscriptionService: DateRelatedObjectsSubscriptio
                 identifier: subscriptionId,
                 spaceId: spaceId,
                 sorts: [sort],
-                filters: filters,
+                filters: allFilters,
                 limit: limit,
                 offset: 0,
                 keys: keys

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
@@ -175,8 +175,14 @@ final class HomeBottomNavigationPanelViewModel {
     
     private func typesSubscription() async {
         for await types in objectTypeProvider.objectTypesPublisher(spaceId: info.accountSpaceId).values {
-            let spaceUxType = spaceViewsStorage.spaceView(spaceId: info.accountSpaceId)?.uxType
-            let supportedLayouts = DetailsLayout.supportedForCreation(spaceUxType: spaceUxType)
+            let supportedLayouts: [DetailsLayout]
+            if FeatureFlags.createChannelFlow {
+                let spaceType = spaceViewsStorage.spaceView(spaceId: info.accountSpaceId)?.spaceType
+                supportedLayouts = DetailsLayout.supportedForCreation(spaceType: spaceType)
+            } else {
+                let spaceUxType = spaceViewsStorage.spaceView(spaceId: info.accountSpaceId)?.uxType
+                supportedLayouts = DetailsLayout.supportedForCreation(spaceUxType: spaceUxType)
+            }
             let types = types.filter { type in
                 supportedLayouts.contains { $0 == type.recommendedLayout }
                 && !type.isTemplateType

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -176,10 +176,16 @@ final class HomeWidgetsViewModel {
     
     private func startObjectTypesTask() async {
         let spaceId = spaceId
-        let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
-        let allowedLayouts = DetailsLayout.widgetTypeLayouts(spaceUxType: spaceUxType)
-
-        await objectTypesWithObjectsCreatedService.startSubscription(spaceId: spaceId, spaceUxType: spaceUxType)
+        let allowedLayouts: [DetailsLayout]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = workspaceStorage.spaceView(spaceId: spaceId)?.spaceType
+            allowedLayouts = DetailsLayout.widgetTypeLayouts(spaceType: spaceType)
+            await objectTypesWithObjectsCreatedService.startSubscription(spaceId: spaceId, spaceType: spaceType)
+        } else {
+            let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
+            allowedLayouts = DetailsLayout.widgetTypeLayouts(spaceUxType: spaceUxType)
+            await objectTypesWithObjectsCreatedService.startSubscription(spaceId: spaceId, spaceUxType: spaceUxType)
+        }
 
         let typesPublisher = objectTypeProvider.objectTypesPublisher(spaceId: spaceId)
         let objectsCreatedPublisher = objectTypesWithObjectsCreatedService.typeIdsWithObjectsCreatedPublisher

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
@@ -227,9 +227,22 @@ final class SetObjectWidgetInternalViewModel {
         
         guard setDocument.canStartSubscription() else { return }
 
-        let spaceUxType = spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.uxType
-        let subscriptionData = setSubscriptionDataBuilder.set(
-            SetSubscriptionData(
+        let setSubData: SetSubscriptionData
+        if FeatureFlags.createChannelFlow {
+            let spaceType = spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.spaceType
+            setSubData = SetSubscriptionData(
+                identifier: subscriptionId,
+                document: setDocument,
+                groupFilter: nil,
+                currentPage: 0,
+                numberOfRowsPerPage: widgetInfo.fixedLimit,
+                collectionId: setDocument.isCollection() ? setDocument.objectId : nil,
+                objectOrderIds: setDocument.objectOrderIds(for: setSubscriptionDataBuilder.subscriptionId),
+                spaceType: spaceType
+            )
+        } else {
+            let spaceUxType = spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.uxType
+            setSubData = SetSubscriptionData(
                 identifier: subscriptionId,
                 document: setDocument,
                 groupFilter: nil,
@@ -239,7 +252,8 @@ final class SetObjectWidgetInternalViewModel {
                 objectOrderIds: setDocument.objectOrderIds(for: setSubscriptionDataBuilder.subscriptionId),
                 spaceUxType: spaceUxType
             )
-        )
+        }
+        let subscriptionData = setSubscriptionDataBuilder.set(setSubData)
         
         try? await subscriptionStorage.startOrUpdateSubscription(data: subscriptionData) { [weak self] data in
             await self?.updateRowDetails(data: data)

--- a/Anytype/Sources/PresentationLayer/Modules/SharingExtension/SharingExtensionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SharingExtension/SharingExtensionViewModel.swift
@@ -56,7 +56,14 @@ final class SharingExtensionViewModel {
     }
     
     func onTapSpace(_ space: SpaceView) {
-        if !space.uxType.supportsMultiChats {
+        let isDirectChat: Bool
+        if FeatureFlags.createChannelFlow {
+            isDirectChat = space.isOneToOne
+        } else {
+            isDirectChat = !space.uxType.supportsMultiChats
+        }
+
+        if isDirectChat {
             selectedSpace = space == selectedSpace ? nil : space
         } else {
             selectedSpace = nil
@@ -68,7 +75,14 @@ final class SharingExtensionViewModel {
         sendInProgress = true
         defer { sendInProgress = false }
 
-        guard let selectedSpace, !selectedSpace.uxType.supportsMultiChats else { return }
+        guard let selectedSpace else { return }
+        let shouldSendDirectly: Bool
+        if FeatureFlags.createChannelFlow {
+            shouldSendDirectly = selectedSpace.isOneToOne
+        } else {
+            shouldSendDirectly = !selectedSpace.uxType.supportsMultiChats
+        }
+        guard shouldSendDirectly else { return }
         
         let content = try await contentManager.getSharedContent()
         

--- a/Anytype/Sources/PresentationLayer/Modules/SharingExtensionShareTo/SharingExtensionShareToViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SharingExtensionShareTo/SharingExtensionShareToViewModel.swift
@@ -46,7 +46,7 @@ final class SharingExtensionShareToViewModel {
     var sendToChatSelected: Bool { selectedObjectId == spaceView?.chatId }
     private var isMultiChatSpace: Bool {
         if FeatureFlags.createChannelFlow {
-            return spaceView?.spaceType != .oneToOne
+            return spaceView?.spaceType.map { $0 != .oneToOne } ?? false
         }
         return spaceView?.uxType.supportsMultiChats ?? false
     }

--- a/Anytype/Sources/PresentationLayer/Modules/SharingExtensionShareTo/SharingExtensionShareToViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SharingExtensionShareTo/SharingExtensionShareToViewModel.swift
@@ -1,3 +1,4 @@
+import AnytypeCore
 import SwiftUI
 import Services
 import SharedContentManager
@@ -43,7 +44,12 @@ final class SharingExtensionShareToViewModel {
     private var spaceView: SpaceView?
     var title: String { spaceView?.title ?? "" }
     var sendToChatSelected: Bool { selectedObjectId == spaceView?.chatId }
-    private var isMultiChatSpace: Bool { spaceView?.uxType.supportsMultiChats ?? false }
+    private var isMultiChatSpace: Bool {
+        if FeatureFlags.createChannelFlow {
+            return spaceView?.spaceType != .oneToOne
+        }
+        return spaceView?.uxType.supportsMultiChats ?? false
+    }
 
     // Returns the selected chat ID (either from generic chat row or from individual chat selection)
     private var selectedChatId: String? {
@@ -82,7 +88,12 @@ final class SharingExtensionShareToViewModel {
         await activeSpaceManager.prepareSpaceForPreview(spaceId: data.spaceId)
         
         do {
-            let layouts = DetailsLayout.supportedForSharingExtension(spaceUxType: spaceView?.uxType)
+            let layouts: [DetailsLayout]
+            if FeatureFlags.createChannelFlow {
+                layouts = DetailsLayout.supportedForSharingExtension(spaceType: spaceView?.spaceType)
+            } else {
+                layouts = DetailsLayout.supportedForSharingExtension(spaceUxType: spaceView?.uxType)
+            }
             let result = try await searchService.searchObjectsWithLayouts(
                 text: searchText,
                 layouts: layouts,

--- a/Anytype/Sources/PresentationLayer/ObjectCreationSettings/Views/Selection/Dataview/SetObjectCreationSettingsInteractor.swift
+++ b/Anytype/Sources/PresentationLayer/ObjectCreationSettings/Views/Selection/Dataview/SetObjectCreationSettingsInteractor.swift
@@ -154,9 +154,14 @@ final class SetObjectCreationSettingsInteractor: SetObjectCreationSettingsIntera
     
     private func updateObjectTypes() {
         Task {
-            let spaceUxType = spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.uxType
-            let chatTypeVisible = spaceUxType?.supportsMultiChats ?? true
-            let includeChat = chatTypeVisible
+            let includeChat: Bool
+            if FeatureFlags.createChannelFlow {
+                let spaceType = spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.spaceType
+                includeChat = spaceType != .oneToOne
+            } else {
+                let spaceUxType = spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.uxType
+                includeChat = spaceUxType?.supportsMultiChats ?? true
+            }
             objectTypes = try await typesService.searchObjectTypes(
                 text: "",
                 includePins: true,

--- a/Anytype/Sources/PresentationLayer/ObjectTypeSearch/ObjectTypeSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/ObjectTypeSearch/ObjectTypeSearchViewModel.swift
@@ -80,8 +80,14 @@ final class ObjectTypeSearchViewModel {
         searchTask?.cancel()
         
         searchTask = Task {
-            let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
-            let effectiveShowChat = settings.showChat && (spaceUxType?.supportsMultiChats ?? true)
+            let effectiveShowChat: Bool
+            if FeatureFlags.createChannelFlow {
+                let spaceType = spaceViewsStorage.spaceView(spaceId: spaceId)?.spaceType
+                effectiveShowChat = settings.showChat && spaceType != .oneToOne
+            } else {
+                let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
+                effectiveShowChat = settings.showChat && (spaceUxType?.supportsMultiChats ?? true)
+            }
 
             let pinnedTypes = settings.showPins ? try await typesService.searchPinnedTypes(text: text, spaceId: spaceId) : []
             let listTypes = settings.showLists ? try await typesService.searchListTypes(

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/Mention/MentionViewController/MentionsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/Mention/MentionViewController/MentionsViewModel.swift
@@ -54,8 +54,14 @@ final class MentionsViewModel {
                 updatedMentions.append(.selectDate)
             }
 
-            let spaceUxType = spaceViewsStorage.spaceView(spaceId: document.spaceId)?.uxType
-            let objectLayouts = DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType) - [.date]
+            let objectLayouts: [DetailsLayout]
+            if FeatureFlags.createChannelFlow {
+                let spaceType = spaceViewsStorage.spaceView(spaceId: document.spaceId)?.spaceType
+                objectLayouts = DetailsLayout.visibleLayoutsWithFiles(spaceType: spaceType) - [.date]
+            } else {
+                let spaceUxType = spaceViewsStorage.spaceView(spaceId: document.spaceId)?.uxType
+                objectLayouts = DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType) - [.date]
+            }
 
             let objectsMentions = try await mentionService.searchMentions(
                 spaceId: document.spaceId,

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectAction.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectAction.swift
@@ -16,6 +16,7 @@ enum ObjectAction: Hashable, Identifiable {
     case editInfo
 
     // When adding to case
+    @available(*, deprecated, message: "Use spaceType overload instead")
     static func buildActions(
         details: ObjectDetails,
         isLocked: Bool,
@@ -37,33 +38,99 @@ enum ObjectAction: Hashable, Identifiable {
             if canCreateWidget {
                 ObjectAction.pin(isPinned: isPinnedToWidgets)
             }
-            
+
             if permissions.canDuplicate {
                 ObjectAction.duplicate
             }
-            
+
             if permissions.canUndoRedo {
                 ObjectAction.undoRedo
             }
-            
+
             if permissions.canMakeAsTemplate {
                 ObjectAction.makeAsTemplate
             }
-            
+
             if permissions.canTemplateSetAsDefault, let targetObjectType = details.targetObjectTypeValue {
                 let isDefault = targetObjectType.defaultTemplateId == details.id
                 ObjectAction.templateToggleDefaultState(isDefault: isDefault)
             }
-            
+
             if permissions.canLinkItself {
                 ObjectAction.linkItself
             }
-            
+
             if permissions.canShare {
                 ObjectAction.copyLink
             }
 
             if details.resolvedLayoutValue.isChat && spaceUxType?.supportsMultiChats == true && !details.isArchived {
+                if permissions.canEditDetails {
+                    ObjectAction.editInfo
+                }
+                if isSpaceOwner {
+                    ObjectAction.inviteMembers
+                }
+            }
+
+            if permissions.canLock {
+                ObjectAction.locked(isLocked: isLocked)
+            }
+
+            if permissions.canDelete {
+                ObjectAction.delete
+            }
+        }
+    }
+
+    static func buildActions(
+        details: ObjectDetails,
+        isLocked: Bool,
+        isPinnedToWidgets: Bool,
+        permissions: ObjectPermissions,
+        spaceType: SpaceType?,
+        isSpaceOwner: Bool
+    ) -> [Self] {
+        let canCreateWidget = details.isVisibleLayout(spaceType: spaceType)
+            && !details.isTemplate
+            && details.resolvedLayoutValue != .participant
+            && permissions.canApplyUneditableActions
+
+        return .builder {
+            if permissions.canArchive {
+                ObjectAction.archive(isArchived: details.isArchived)
+            }
+
+            if canCreateWidget {
+                ObjectAction.pin(isPinned: isPinnedToWidgets)
+            }
+
+            if permissions.canDuplicate {
+                ObjectAction.duplicate
+            }
+
+            if permissions.canUndoRedo {
+                ObjectAction.undoRedo
+            }
+
+            if permissions.canMakeAsTemplate {
+                ObjectAction.makeAsTemplate
+            }
+
+            if permissions.canTemplateSetAsDefault, let targetObjectType = details.targetObjectTypeValue {
+                let isDefault = targetObjectType.defaultTemplateId == details.id
+                ObjectAction.templateToggleDefaultState(isDefault: isDefault)
+            }
+
+            if permissions.canLinkItself {
+                ObjectAction.linkItself
+            }
+
+            if permissions.canShare {
+                ObjectAction.copyLink
+            }
+
+            if details.resolvedLayoutValue.isChat && spaceType != .oneToOne && !details.isArchived {
                 if permissions.canEditDetails {
                     ObjectAction.editInfo
                 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/Model/ObjectSettingBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/Model/ObjectSettingBuilder.swift
@@ -2,13 +2,15 @@ import Services
 import AnytypeCore
 
 protocol ObjectSettingsBuilderProtocol {
+    @available(*, deprecated, message: "Use spaceType overload instead")
     func build(details: ObjectDetails, permissions: ObjectPermissions, spaceUxType: SpaceUxType?, chatNotificationMode: SpacePushNotificationsMode?) -> [ObjectSetting]
+    func build(details: ObjectDetails, permissions: ObjectPermissions, spaceType: SpaceType?, chatNotificationMode: SpacePushNotificationsMode?) -> [ObjectSetting]
 }
 
 final class ObjectSettingsBuilder: ObjectSettingsBuilderProtocol {
     @Injected(\.objectSettingsConflictManager)
     private var conflictManager: any ObjectSettingsPrimitivesConflictManagerProtocol
-    
+
     func build(details: ObjectDetails, permissions: ObjectPermissions, spaceUxType: SpaceUxType?, chatNotificationMode: SpacePushNotificationsMode?) -> [ObjectSetting] {
         let canShowVersionHistory = details.isVisibleLayout(spaceUxType: spaceUxType)
             && details.resolvedLayoutValue != .participant
@@ -20,12 +22,48 @@ final class ObjectSettingsBuilder: ObjectSettingsBuilderProtocol {
             && spaceUxType?.supportsMultiChats == true
             && !details.isArchived
 
-        return .builder {
-           
+        return buildSettings(
+            details: details,
+            permissions: permissions,
+            canShowVersionHistory: canShowVersionHistory,
+            canShowNotifications: canShowNotifications,
+            chatNotificationMode: chatNotificationMode
+        )
+    }
+
+    func build(details: ObjectDetails, permissions: ObjectPermissions, spaceType: SpaceType?, chatNotificationMode: SpacePushNotificationsMode?) -> [ObjectSetting] {
+        let canShowVersionHistory = details.isVisibleLayout(spaceType: spaceType)
+            && details.resolvedLayoutValue != .participant
+            && !details.resolvedLayoutValue.isChat
+            && !details.templateIsBundled
+            && !details.isObjectType
+
+        let canShowNotifications = details.resolvedLayoutValue.isChat
+            && spaceType != .oneToOne
+            && !details.isArchived
+
+        return buildSettings(
+            details: details,
+            permissions: permissions,
+            canShowVersionHistory: canShowVersionHistory,
+            canShowNotifications: canShowNotifications,
+            chatNotificationMode: chatNotificationMode
+        )
+    }
+
+    private func buildSettings(
+        details: ObjectDetails,
+        permissions: ObjectPermissions,
+        canShowVersionHistory: Bool,
+        canShowNotifications: Bool,
+        chatNotificationMode: SpacePushNotificationsMode?
+    ) -> [ObjectSetting] {
+        .builder {
+
             if permissions.canChangeIcon {
                 ObjectSetting.icon
             }
-            
+
             if permissions.canChangeCover {
                 ObjectSetting.cover
             }
@@ -42,11 +80,11 @@ final class ObjectSettingsBuilder: ObjectSettingsBuilderProtocol {
             if permissions.canShowRelations {
                 ObjectSetting.relations
             }
-            
+
             if conflictManager.haveLayoutConflicts(details: details) {
                 ObjectSetting.resolveConflict
             }
-            
+
             if permissions.canPublish {
                 ObjectSetting.webPublishing
             }
@@ -58,7 +96,7 @@ final class ObjectSettingsBuilder: ObjectSettingsBuilderProtocol {
             if canShowVersionHistory {
                 ObjectSetting.history
             }
-            
+
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
@@ -90,6 +90,7 @@ final class ObjectSettingsViewModel {
     var showConflictAlert = false
     var isChat = false
     let spaceUxType: SpaceUxType?
+    let spaceType: SpaceType?
 
     // MARK: - Actions State
 
@@ -109,7 +110,9 @@ final class ObjectSettingsViewModel {
         self.spaceId = spaceId
         self.output = output
 
-        spaceUxType = Container.shared.spaceViewsStorage().spaceView(spaceId: spaceId)?.uxType
+        let spaceView = Container.shared.spaceViewsStorage().spaceView(spaceId: spaceId)
+        spaceUxType = spaceView?.uxType
+        spaceType = spaceView?.spaceType
     }
 
     // MARK: - Subscriptions
@@ -152,12 +155,21 @@ final class ObjectSettingsViewModel {
 
     private func updateSettings() {
         if let details = document.details {
-            settings = settingsBuilder.build(
-                details: details,
-                permissions: document.permissions,
-                spaceUxType: spaceUxType,
-                chatNotificationMode: chatNotificationMode
-            )
+            if FeatureFlags.createChannelFlow {
+                settings = settingsBuilder.build(
+                    details: details,
+                    permissions: document.permissions,
+                    spaceType: spaceType,
+                    chatNotificationMode: chatNotificationMode
+                )
+            } else {
+                settings = settingsBuilder.build(
+                    details: details,
+                    permissions: document.permissions,
+                    spaceUxType: spaceUxType,
+                    chatNotificationMode: chatNotificationMode
+                )
+            }
             isChat = details.resolvedLayoutValue.isChat
         }
     }
@@ -168,14 +180,25 @@ final class ObjectSettingsViewModel {
             return
         }
 
-        objectActions = ObjectAction.buildActions(
-            details: details,
-            isLocked: document.isLocked,
-            isPinnedToWidgets: widgetObject?.widgetBlockIdFor(targetObjectId: objectId).isNotNil ?? false,
-            permissions: document.permissions,
-            spaceUxType: spaceUxType,
-            isSpaceOwner: isSpaceOwner
-        )
+        if FeatureFlags.createChannelFlow {
+            objectActions = ObjectAction.buildActions(
+                details: details,
+                isLocked: document.isLocked,
+                isPinnedToWidgets: widgetObject?.widgetBlockIdFor(targetObjectId: objectId).isNotNil ?? false,
+                permissions: document.permissions,
+                spaceType: spaceType,
+                isSpaceOwner: isSpaceOwner
+            )
+        } else {
+            objectActions = ObjectAction.buildActions(
+                details: details,
+                isLocked: document.isLocked,
+                isPinnedToWidgets: widgetObject?.widgetBlockIdFor(targetObjectId: objectId).isNotNil ?? false,
+                permissions: document.permissions,
+                spaceUxType: spaceUxType,
+                isSpaceOwner: isSpaceOwner
+            )
+        }
     }
     
     func onTapIconPicker() {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -567,18 +567,31 @@ final class EditorSetViewModel: ObservableObject {
         
         guard setDocument.canStartSubscription() else { return }
 
-        let data = setSubscriptionDataBuilder.set(
-            SetSubscriptionData(
+        let subscriptionData: SetSubscriptionData
+        if FeatureFlags.createChannelFlow {
+            subscriptionData = SetSubscriptionData(
                 identifier: subscriptionId,
                 document: setDocument,
                 groupFilter: groupFilter,
-                currentPage: currentPage, // show first page for empty request
+                currentPage: currentPage,
+                numberOfRowsPerPage: numberOfRowsPerPage,
+                collectionId: setDocument.isCollection() ? objectId : nil,
+                objectOrderIds: setDocument.objectOrderIds(for: subscriptionId),
+                spaceType: spaceView?.spaceType
+            )
+        } else {
+            subscriptionData = SetSubscriptionData(
+                identifier: subscriptionId,
+                document: setDocument,
+                groupFilter: groupFilter,
+                currentPage: currentPage,
                 numberOfRowsPerPage: numberOfRowsPerPage,
                 collectionId: setDocument.isCollection() ? objectId : nil,
                 objectOrderIds: setDocument.objectOrderIds(for: subscriptionId),
                 spaceUxType: spaceView?.uxType
             )
-        )
+        }
+        let data = setSubscriptionDataBuilder.set(subscriptionData)
         
         let subscription = subscriptionStorages[data.identifier] ?? subscriptionStorageProvider.createSubscriptionStorage(subId: data.identifier)
         subscriptionStorages[data.identifier] = subscription

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionData.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionData.swift
@@ -1,3 +1,4 @@
+import AnytypeCore
 import Foundation
 import Services
 
@@ -12,7 +13,8 @@ struct SetSubscriptionData: Hashable {
     let numberOfRowsPerPage: Int
     let collectionId: String?
     let spaceId: String
-    
+
+    @available(*, deprecated, message: "Use spaceType overload instead")
     init(
         identifier: String,
         document: some SetDocumentProtocol,
@@ -23,11 +25,57 @@ struct SetSubscriptionData: Hashable {
         objectOrderIds: [String],
         spaceUxType: SpaceUxType?
     ) {
+        let layoutFilter = SearchHelper.layoutFilter(DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType))
+        self.init(
+            identifier: identifier,
+            document: document,
+            groupFilter: groupFilter,
+            currentPage: currentPage,
+            numberOfRowsPerPage: numberOfRowsPerPage,
+            collectionId: collectionId,
+            objectOrderIds: objectOrderIds,
+            layoutFilter: layoutFilter
+        )
+    }
+
+    init(
+        identifier: String,
+        document: some SetDocumentProtocol,
+        groupFilter: DataviewFilter?,
+        currentPage: Int,
+        numberOfRowsPerPage: Int,
+        collectionId: String?,
+        objectOrderIds: [String],
+        spaceType: SpaceType?
+    ) {
+        let layoutFilter = SearchHelper.layoutFilter(DetailsLayout.visibleLayoutsWithFiles(spaceType: spaceType))
+        self.init(
+            identifier: identifier,
+            document: document,
+            groupFilter: groupFilter,
+            currentPage: currentPage,
+            numberOfRowsPerPage: numberOfRowsPerPage,
+            collectionId: collectionId,
+            objectOrderIds: objectOrderIds,
+            layoutFilter: layoutFilter
+        )
+    }
+
+    private init(
+        identifier: String,
+        document: some SetDocumentProtocol,
+        groupFilter: DataviewFilter?,
+        currentPage: Int,
+        numberOfRowsPerPage: Int,
+        collectionId: String?,
+        objectOrderIds: [String],
+        layoutFilter: DataviewFilter
+    ) {
         self.identifier = identifier
         self.source = document.details?.filteredSetOf
-        
+
         let view = document.activeView
-        
+
         // Sorts
         var sorts = view.sorts
         if objectOrderIds.isNotEmpty {
@@ -49,13 +97,13 @@ struct SetSubscriptionData: Hashable {
             ))
         }
         self.sorts = sorts
-        
+
         // Filters
         var filters = view.filters.removingUnsupportedFilters()
         if let groupFilter {
             filters.append(groupFilter)
         }
-        filters.append(SearchHelper.layoutFilter(DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType)))
+        filters.append(layoutFilter)
         filters.append(contentsOf: SearchHelper.notHiddenFilters())
         filters.append(SearchHelper.filterOutParticipantType())
         self.filters = filters

--- a/Anytype/Sources/ServiceLayer/Object/Search/SearchService.swift
+++ b/Anytype/Sources/ServiceLayer/Object/Search/SearchService.swift
@@ -15,8 +15,13 @@ final class SearchService: SearchServiceProtocol, Sendable {
     // MARK: - SearchServiceProtocol
     
     func search(text: String, spaceId: String) async throws -> [ObjectDetails] {
-        let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
-        return try await searchObjectsWithLayouts(text: text, layouts: DetailsLayout.visibleLayouts(spaceUxType: spaceUxType), excludedIds: [], spaceId: spaceId)
+        if FeatureFlags.createChannelFlow {
+            let spaceType = spaceViewsStorage.spaceView(spaceId: spaceId)?.spaceType
+            return try await searchObjectsWithLayouts(text: text, layouts: DetailsLayout.visibleLayouts(spaceType: spaceType), excludedIds: [], spaceId: spaceId)
+        } else {
+            let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
+            return try await searchObjectsWithLayouts(text: text, layouts: DetailsLayout.visibleLayouts(spaceUxType: spaceUxType), excludedIds: [], spaceId: spaceId)
+        }
     }
     
     func searchFiles(text: String, excludedFileIds: [String], spaceId: String) async throws -> [ObjectDetails] {
@@ -75,17 +80,32 @@ final class SearchService: SearchServiceProtocol, Sendable {
             relation: BundledPropertyKey.lastOpenedDate,
             type: .desc
         )
-        let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
-        let filters: [DataviewFilter] = .builder {
-            SearchHelper.excludedIdsFilter(excludedObjectIds)
-            if typeIds.isEmpty {
-                SearchFiltersBuilder.build(isArchived: false, layouts: DetailsLayout.visibleLayouts(spaceUxType: spaceUxType), spaceUxType: spaceUxType)
-            } else {
-                SearchFiltersBuilder.build(isArchived: false)
-                SearchHelper.typeFilter(typeIds)
+
+        let filters: [DataviewFilter]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = spaceViewsStorage.spaceView(spaceId: spaceId)?.spaceType
+            filters = .builder {
+                SearchHelper.excludedIdsFilter(excludedObjectIds)
+                if typeIds.isEmpty {
+                    SearchFiltersBuilder.build(isArchived: false, layouts: DetailsLayout.visibleLayouts(spaceType: spaceType), spaceType: spaceType)
+                } else {
+                    SearchFiltersBuilder.build(isArchived: false)
+                    SearchHelper.typeFilter(typeIds)
+                }
+            }
+        } else {
+            let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
+            filters = .builder {
+                SearchHelper.excludedIdsFilter(excludedObjectIds)
+                if typeIds.isEmpty {
+                    SearchFiltersBuilder.build(isArchived: false, layouts: DetailsLayout.visibleLayouts(spaceUxType: spaceUxType), spaceUxType: spaceUxType)
+                } else {
+                    SearchFiltersBuilder.build(isArchived: false)
+                    SearchHelper.typeFilter(typeIds)
+                }
             }
         }
-                
+
         return try await searchMiddleService.search(spaceId: spaceId, filters: filters, sorts: [sort], fullText: text)
     }
 
@@ -104,45 +124,73 @@ final class SearchService: SearchServiceProtocol, Sendable {
             relation: sortRelationKey ?? .lastOpenedDate,
             type: .desc
         )
-        let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
 
-        let filters: [DataviewFilter] = .builder {
-            SearchFiltersBuilder.build(isArchived: false, layouts: DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType), spaceUxType: spaceUxType)
-            SearchHelper.excludedIdsFilter(excludedObjectIds)
-            SearchHelper.excludedLayoutFilter(excludedLayouts)
+        let filters: [DataviewFilter]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = spaceViewsStorage.spaceView(spaceId: spaceId)?.spaceType
+            filters = .builder {
+                SearchFiltersBuilder.build(isArchived: false, layouts: DetailsLayout.visibleLayoutsWithFiles(spaceType: spaceType), spaceType: spaceType)
+                SearchHelper.excludedIdsFilter(excludedObjectIds)
+                SearchHelper.excludedLayoutFilter(excludedLayouts)
+            }
+        } else {
+            let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
+            filters = .builder {
+                SearchFiltersBuilder.build(isArchived: false, layouts: DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType), spaceUxType: spaceUxType)
+                SearchHelper.excludedIdsFilter(excludedObjectIds)
+                SearchHelper.excludedLayoutFilter(excludedLayouts)
+            }
         }
-        
+
         return try await searchMiddleService.search(spaceId: spaceId, filters: filters, sorts: [sort], fullText: text, limit: SearchDefaults.objectsLimit)
     }
 
     func searchRelationOptions(text: String, relationKey: String, excludedObjectIds: [String], spaceId: String) async throws -> [PropertyOption] {
-        let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
-        
-        var filters = SearchFiltersBuilder.build(
-            isArchived: false,
-            layouts: [DetailsLayout.relationOption],
-            spaceUxType: spaceUxType
-        )
+        var filters: [DataviewFilter]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = spaceViewsStorage.spaceView(spaceId: spaceId)?.spaceType
+            filters = SearchFiltersBuilder.build(
+                isArchived: false,
+                layouts: [DetailsLayout.relationOption],
+                spaceType: spaceType
+            )
+        } else {
+            let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
+            filters = SearchFiltersBuilder.build(
+                isArchived: false,
+                layouts: [DetailsLayout.relationOption],
+                spaceUxType: spaceUxType
+            )
+        }
         filters.append(SearchHelper.relationKey(relationKey))
         filters.append(SearchHelper.excludedIdsFilter(excludedObjectIds))
-        
+
         let sort = SearchHelper.sort(
             relation: BundledPropertyKey.name,
             type: .asc
         )
-        
+
         let details = try await searchMiddleService.search(spaceId: spaceId, filters: filters, sorts: [sort], fullText: text, limit: 0)
         return details.map { PropertyOption(details: $0) }
     }
 
     func searchRelationOptions(optionIds: [String], spaceId: String) async throws -> [PropertyOption] {
-        let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
-        
-        var filters = SearchFiltersBuilder.build(
-            isArchived: false,
-            layouts: [DetailsLayout.relationOption],
-            spaceUxType: spaceUxType
-        )
+        var filters: [DataviewFilter]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = spaceViewsStorage.spaceView(spaceId: spaceId)?.spaceType
+            filters = SearchFiltersBuilder.build(
+                isArchived: false,
+                layouts: [DetailsLayout.relationOption],
+                spaceType: spaceType
+            )
+        } else {
+            let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
+            filters = SearchFiltersBuilder.build(
+                isArchived: false,
+                layouts: [DetailsLayout.relationOption],
+                spaceUxType: spaceUxType
+            )
+        }
         filters.append(SearchHelper.includeIdsFilter(optionIds))
 
         let details = try await searchMiddleService.search(spaceId: spaceId, filters: filters, sorts: [], fullText: "")
@@ -155,12 +203,23 @@ final class SearchService: SearchServiceProtocol, Sendable {
             type: .desc
         )
 
-        let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
-        let filters: [DataviewFilter] = .builder {
-            SearchFiltersBuilder.build(isArchived: false, layouts: [DetailsLayout.relation], spaceUxType: spaceUxType)
-            SearchHelper.relationReadonlyValue(false)
-            SearchHelper.excludedRelationKeys(BundledPropertyKey.internalKeys.map(\.rawValue))
-            SearchHelper.excludedIdsFilter(excludedIds)
+        let filters: [DataviewFilter]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = spaceViewsStorage.spaceView(spaceId: spaceId)?.spaceType
+            filters = .builder {
+                SearchFiltersBuilder.build(isArchived: false, layouts: [DetailsLayout.relation], spaceType: spaceType)
+                SearchHelper.relationReadonlyValue(false)
+                SearchHelper.excludedRelationKeys(BundledPropertyKey.internalKeys.map(\.rawValue))
+                SearchHelper.excludedIdsFilter(excludedIds)
+            }
+        } else {
+            let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
+            filters = .builder {
+                SearchFiltersBuilder.build(isArchived: false, layouts: [DetailsLayout.relation], spaceUxType: spaceUxType)
+                SearchHelper.relationReadonlyValue(false)
+                SearchHelper.excludedRelationKeys(BundledPropertyKey.internalKeys.map(\.rawValue))
+                SearchHelper.excludedIdsFilter(excludedIds)
+            }
         }
 
         let details = try await searchMiddleService.search(spaceId: spaceId, filters: filters, sorts: [sort], fullText: text)
@@ -197,10 +256,19 @@ final class SearchService: SearchServiceProtocol, Sendable {
             type: .desc
         )
 
-        let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
-        let filters: [DataviewFilter] = .builder {
-            SearchFiltersBuilder.build(isArchived: false, layouts: layouts, spaceUxType: spaceUxType)
-            SearchHelper.excludedIdsFilter(excludedIds)
+        let filters: [DataviewFilter]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = spaceViewsStorage.spaceView(spaceId: spaceId)?.spaceType
+            filters = .builder {
+                SearchFiltersBuilder.build(isArchived: false, layouts: layouts, spaceType: spaceType)
+                SearchHelper.excludedIdsFilter(excludedIds)
+            }
+        } else {
+            let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
+            filters = .builder {
+                SearchFiltersBuilder.build(isArchived: false, layouts: layouts, spaceUxType: spaceUxType)
+                SearchHelper.excludedIdsFilter(excludedIds)
+            }
         }
 
         return try await searchMiddleService.search(spaceId: spaceId, filters: filters, sorts: [sort], fullText: text, limit: SearchDefaults.objectsLimit)

--- a/Anytype/Sources/ServiceLayer/Object/TypesService/SearchHelper+Extension.swift
+++ b/Anytype/Sources/ServiceLayer/Object/TypesService/SearchHelper+Extension.swift
@@ -2,6 +2,7 @@ import Services
 
 extension SearchHelper {
 
+    @available(*, deprecated, message: "Use spaceType overload instead")
     static func defaultObjectTypeSort(spaceUxType: SpaceUxType?) -> [DataviewSort] {
         let nameSort = SearchHelper.sort(relation: .name, type: .asc)
 
@@ -34,9 +35,47 @@ extension SearchHelper {
                 ObjectTypeUniqueKey.video.value,
                 ObjectTypeUniqueKey.audio.value
             ])
-        
+
         let orderIdSort = SearchHelper.sort(relation: .orderId, type: .asc, emptyPlacement: .end)
-        
+
+        return [orderIdSort, customSort, nameSort]
+    }
+
+    static func defaultObjectTypeSort(spaceType: SpaceType?) -> [DataviewSort] {
+        let nameSort = SearchHelper.sort(relation: .name, type: .asc)
+
+        let isOneToOne = spaceType == .oneToOne
+        let customSort = isOneToOne
+            ? SearchHelper.customSort(relationKey: BundledPropertyKey.uniqueKey.rawValue, values: [
+                ObjectTypeUniqueKey.image.value,
+                ObjectTypeUniqueKey.bookmark.value,
+                ObjectTypeUniqueKey.file.value,
+                ObjectTypeUniqueKey.page.value,
+                ObjectTypeUniqueKey.note.value,
+                ObjectTypeUniqueKey.task.value,
+                ObjectTypeUniqueKey.collection.value,
+                ObjectTypeUniqueKey.set.value,
+                ObjectTypeUniqueKey.project.value,
+                ObjectTypeUniqueKey.video.value,
+                ObjectTypeUniqueKey.audio.value
+            ])
+            : SearchHelper.customSort(relationKey: BundledPropertyKey.uniqueKey.rawValue, values: [
+                ObjectTypeUniqueKey.page.value,
+                ObjectTypeUniqueKey.note.value,
+                ObjectTypeUniqueKey.task.value,
+                ObjectTypeUniqueKey.chatDerived.value,
+                ObjectTypeUniqueKey.collection.value,
+                ObjectTypeUniqueKey.set.value,
+                ObjectTypeUniqueKey.bookmark.value,
+                ObjectTypeUniqueKey.project.value,
+                ObjectTypeUniqueKey.image.value,
+                ObjectTypeUniqueKey.file.value,
+                ObjectTypeUniqueKey.video.value,
+                ObjectTypeUniqueKey.audio.value
+            ])
+
+        let orderIdSort = SearchHelper.sort(relation: .orderId, type: .asc, emptyPlacement: .end)
+
         return [orderIdSort, customSort, nameSort]
     }
 }

--- a/Anytype/Sources/ServiceLayer/Object/TypesService/TypesService.swift
+++ b/Anytype/Sources/ServiceLayer/Object/TypesService/TypesService.swift
@@ -1,7 +1,7 @@
+import AnytypeCore
 import ProtobufMessages
 import SwiftProtobuf
 import Services
-import AnytypeCore
 
 
 final class TypesService: TypesServiceProtocol, Sendable {
@@ -56,10 +56,18 @@ final class TypesService: TypesServiceProtocol, Sendable {
     ) async throws -> [ObjectDetails] {
         let excludedTypeIds = includePins ? [] : try await searchPinnedTypes(text: "", spaceId: spaceId).map { $0.id }
 
-        let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
-        let sort = SearchHelper.defaultObjectTypeSort(spaceUxType: spaceUxType)
+        let sort: [DataviewSort]
+        var layouts: [DetailsLayout]
 
-        var layouts = includeFiles ? DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType) : DetailsLayout.visibleLayouts(spaceUxType: spaceUxType)
+        if FeatureFlags.createChannelFlow {
+            let spaceType = workspaceStorage.spaceView(spaceId: spaceId)?.spaceType
+            sort = SearchHelper.defaultObjectTypeSort(spaceType: spaceType)
+            layouts = includeFiles ? DetailsLayout.visibleLayoutsWithFiles(spaceType: spaceType) : DetailsLayout.visibleLayouts(spaceType: spaceType)
+        } else {
+            let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
+            sort = SearchHelper.defaultObjectTypeSort(spaceUxType: spaceUxType)
+            layouts = includeFiles ? DetailsLayout.visibleLayoutsWithFiles(spaceUxType: spaceUxType) : DetailsLayout.visibleLayouts(spaceUxType: spaceUxType)
+        }
 
         if !includeLists {
             layouts.removeAll(where: { $0.isList })
@@ -101,8 +109,14 @@ final class TypesService: TypesServiceProtocol, Sendable {
     ) async throws -> [ObjectType] {
         let excludedTypeIds = includePins ? [] : try await searchPinnedTypes(text: "", spaceId: spaceId).map { $0.id }
 
-        let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
-        let sort = SearchHelper.defaultObjectTypeSort(spaceUxType: spaceUxType)
+        let sort: [DataviewSort]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = workspaceStorage.spaceView(spaceId: spaceId)?.spaceType
+            sort = SearchHelper.defaultObjectTypeSort(spaceType: spaceType)
+        } else {
+            let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
+            sort = SearchHelper.defaultObjectTypeSort(spaceUxType: spaceUxType)
+        }
 
         let filters: [DataviewFilter] = .builder {
             SearchFiltersBuilder.build(isArchived: false)
@@ -110,20 +124,29 @@ final class TypesService: TypesServiceProtocol, Sendable {
             SearchHelper.recomendedLayoutFilter(DetailsLayout.listLayouts)
             SearchHelper.excludedIdsFilter(excludedTypeIds)
         }
-        
+
         return try await searchMiddleService.search(spaceId: spaceId, filters: filters, sorts: sort, fullText: text)
             .map { ObjectType(details: $0) }
     }
-    
+
     func searchLibraryObjectTypes(text: String, includeInstalledTypes: Bool, spaceId: String) async throws -> [ObjectDetails] {
         let excludedIds = includeInstalledTypes ? [] : typeProvider.objectTypes(spaceId: spaceId).map(\.sourceObject)
 
-        let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
-        let sort = SearchHelper.defaultObjectTypeSort(spaceUxType: spaceUxType)
+        let sort: [DataviewSort]
+        let layoutsForFilter: [DetailsLayout]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = workspaceStorage.spaceView(spaceId: spaceId)?.spaceType
+            sort = SearchHelper.defaultObjectTypeSort(spaceType: spaceType)
+            layoutsForFilter = DetailsLayout.visibleLayouts(spaceType: spaceType)
+        } else {
+            let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
+            sort = SearchHelper.defaultObjectTypeSort(spaceUxType: spaceUxType)
+            layoutsForFilter = DetailsLayout.visibleLayouts(spaceUxType: spaceUxType)
+        }
 
         let filters = Array.builder {
             SearchHelper.layoutFilter([DetailsLayout.objectType])
-            SearchHelper.recomendedLayoutFilter(DetailsLayout.visibleLayouts(spaceUxType: spaceUxType))
+            SearchHelper.recomendedLayoutFilter(layoutsForFilter)
             SearchHelper.excludedIdsFilter(excludedIds)
         }
         

--- a/Anytype/Sources/ServiceLayer/Subscriptions/ObjectTypesWithObjectsCreatedService.swift
+++ b/Anytype/Sources/ServiceLayer/Subscriptions/ObjectTypesWithObjectsCreatedService.swift
@@ -5,7 +5,9 @@ import AnytypeCore
 
 @MainActor
 protocol ObjectTypesWithObjectsCreatedServiceProtocol: AnyObject {
+    @available(*, deprecated, message: "Use spaceType overload instead")
     func startSubscription(spaceId: String, spaceUxType: SpaceUxType?) async
+    func startSubscription(spaceId: String, spaceType: SpaceType?) async
     func stopSubscription() async
     var typeIdsWithObjectsCreatedPublisher: AnyPublisher<Set<String>, Never> { get }
 }
@@ -43,6 +45,25 @@ final class ObjectTypesWithObjectsCreatedService: ObjectTypesWithObjectsCreatedS
             SearchHelper.templateScheme(include: false)
         }
 
+        await startSubscriptionWithFilters(storage: storage, spaceId: spaceId, filters: filters)
+    }
+
+    func startSubscription(spaceId: String, spaceType: SpaceType?) async {
+        guard subscriptionStorage == nil else { return }
+
+        let storage = subscriptionStorageProvider.createSubscriptionStorage(subId: subscriptionId)
+        subscriptionStorage = storage
+
+        let filters: [DataviewFilter] = .builder {
+            SearchHelper.notHiddenFilters()
+            SearchHelper.layoutFilter(DetailsLayout.widgetTypeLayouts(spaceType: spaceType))
+            SearchHelper.templateScheme(include: false)
+        }
+
+        await startSubscriptionWithFilters(storage: storage, spaceId: spaceId, filters: filters)
+    }
+
+    private func startSubscriptionWithFilters(storage: any SubscriptionStorageProtocol, spaceId: String, filters: [DataviewFilter]) async {
         let data = SubscriptionData.search(SubscriptionData.Search(
             identifier: subscriptionId,
             spaceId: spaceId,

--- a/Anytype/Sources/ServiceLayer/Subscriptions/RecentSubscriptionService.swift
+++ b/Anytype/Sources/ServiceLayer/Subscriptions/RecentSubscriptionService.swift
@@ -41,13 +41,24 @@ final class RecentSubscriptionService: RecentSubscriptionServiceProtocol {
     ) async {
         
         let sort = makeSort(type: type)
-        let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
 
-        let filters: [DataviewFilter] = .builder {
-            SearchHelper.notHiddenFilters()
-            SearchHelper.layoutFilter(DetailsLayout.visibleLayouts(spaceUxType: spaceUxType))
-            SearchHelper.templateScheme(include: false)
-            makeDateFilter(type: type, spaceId: spaceId)
+        let filters: [DataviewFilter]
+        if FeatureFlags.createChannelFlow {
+            let spaceType = workspaceStorage.spaceView(spaceId: spaceId)?.spaceType
+            filters = .builder {
+                SearchHelper.notHiddenFilters()
+                SearchHelper.layoutFilter(DetailsLayout.visibleLayouts(spaceType: spaceType))
+                SearchHelper.templateScheme(include: false)
+                makeDateFilter(type: type, spaceId: spaceId)
+            }
+        } else {
+            let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
+            filters = .builder {
+                SearchHelper.notHiddenFilters()
+                SearchHelper.layoutFilter(DetailsLayout.visibleLayouts(spaceUxType: spaceUxType))
+                SearchHelper.templateScheme(include: false)
+                makeDateFilter(type: type, spaceId: spaceId)
+            }
         }
         
         let keys: [BundledPropertyKey] = .builder {

--- a/Modules/Services/Sources/Models/Extensions/DetailsLayoutExtension.swift
+++ b/Modules/Services/Sources/Models/Extensions/DetailsLayoutExtension.swift
@@ -23,36 +23,76 @@ public extension DetailsLayout {
     private static let chatLayouts: [DetailsLayout] = [.chatDerived]
 }
 
-// MARK: - Space-aware filtering
+// MARK: - Space-aware filtering (SpaceUxType) — deprecated
 
 public extension DetailsLayout {
+    @available(*, deprecated, message: "Use spaceType overload instead")
     static func visibleLayouts(spaceUxType: SpaceUxType?) -> [DetailsLayout] {
         guard spaceUxType.supportsMultiChats else { return visibleLayoutsBase }
         return visibleLayoutsBase + chatLayouts
     }
 
+    @available(*, deprecated, message: "Use spaceType overload instead")
     static func visibleLayoutsWithFiles(spaceUxType: SpaceUxType?) -> [DetailsLayout] {
         guard spaceUxType.supportsMultiChats else { return visibleLayoutsWithFilesBase }
         return visibleLayoutsWithFilesBase + chatLayouts
     }
 
+    @available(*, deprecated, message: "Use spaceType overload instead")
     static func supportedForCreation(spaceUxType: SpaceUxType?) -> [DetailsLayout] {
         guard spaceUxType.supportsMultiChats else { return supportedForCreationBase }
         return supportedForCreationBase + chatLayouts
     }
 
+    @available(*, deprecated, message: "Use spaceType overload instead")
     static func supportedForCreationInSets(spaceUxType: SpaceUxType?) -> [DetailsLayout] {
         guard spaceUxType.supportsMultiChats else { return supportedForCreationInSetsBase }
         return supportedForCreationInSetsBase + chatLayouts
     }
 
+    @available(*, deprecated, message: "Use spaceType overload instead")
     static func widgetTypeLayouts(spaceUxType: SpaceUxType?) -> [DetailsLayout] {
         guard spaceUxType.supportsMultiChats else { return widgetTypeLayoutsBase }
         return widgetTypeLayoutsBase + chatLayouts
     }
 
+    @available(*, deprecated, message: "Use spaceType overload instead")
     static func supportedForSharingExtension(spaceUxType: SpaceUxType?) -> [DetailsLayout] {
         guard spaceUxType.supportsMultiChats else { return supportedForSharingExtensionBase }
+        return supportedForSharingExtensionBase + chatLayouts
+    }
+}
+
+// MARK: - Space-aware filtering (SpaceType)
+
+public extension DetailsLayout {
+    static func visibleLayouts(spaceType: SpaceType?) -> [DetailsLayout] {
+        guard spaceType != .oneToOne else { return visibleLayoutsBase }
+        return visibleLayoutsBase + chatLayouts
+    }
+
+    static func visibleLayoutsWithFiles(spaceType: SpaceType?) -> [DetailsLayout] {
+        guard spaceType != .oneToOne else { return visibleLayoutsWithFilesBase }
+        return visibleLayoutsWithFilesBase + chatLayouts
+    }
+
+    static func supportedForCreation(spaceType: SpaceType?) -> [DetailsLayout] {
+        guard spaceType != .oneToOne else { return supportedForCreationBase }
+        return supportedForCreationBase + chatLayouts
+    }
+
+    static func supportedForCreationInSets(spaceType: SpaceType?) -> [DetailsLayout] {
+        guard spaceType != .oneToOne else { return supportedForCreationInSetsBase }
+        return supportedForCreationInSetsBase + chatLayouts
+    }
+
+    static func widgetTypeLayouts(spaceType: SpaceType?) -> [DetailsLayout] {
+        guard spaceType != .oneToOne else { return widgetTypeLayoutsBase }
+        return widgetTypeLayoutsBase + chatLayouts
+    }
+
+    static func supportedForSharingExtension(spaceType: SpaceType?) -> [DetailsLayout] {
+        guard spaceType != .oneToOne else { return supportedForSharingExtensionBase }
         return supportedForSharingExtensionBase + chatLayouts
     }
 }
@@ -84,12 +124,22 @@ public extension DetailsLayout {
 // MARK: - Instance functions
 
 public extension DetailsLayout {
+    @available(*, deprecated, message: "Use spaceType overload instead")
     func isSupportedForCreation(spaceUxType: SpaceUxType?) -> Bool {
         Self.supportedForCreation(spaceUxType: spaceUxType).contains(self)
     }
 
+    @available(*, deprecated, message: "Use spaceType overload instead")
     func isSupportedForCreationInSets(spaceUxType: SpaceUxType?) -> Bool {
         Self.supportedForCreationInSets(spaceUxType: spaceUxType).contains(self)
+    }
+
+    func isSupportedForCreation(spaceType: SpaceType?) -> Bool {
+        Self.supportedForCreation(spaceType: spaceType).contains(self)
+    }
+
+    func isSupportedForCreationInSets(spaceType: SpaceType?) -> Bool {
+        Self.supportedForCreationInSets(spaceType: spaceType).contains(self)
     }
 }
 

--- a/Modules/Services/Sources/Services/SearchService/SearchFiltersBuilder.swift
+++ b/Modules/Services/Sources/Services/SearchService/SearchFiltersBuilder.swift
@@ -6,11 +6,23 @@ public final class SearchFiltersBuilder {
         }
     }
 
+    @available(*, deprecated, message: "Use spaceType overload instead")
     public static func build(isArchived: Bool, layouts: [DetailsLayout], spaceUxType: SpaceUxType?) -> [DataviewFilter] {
         var filters = build(isArchived: isArchived)
         filters.append(SearchHelper.layoutFilter(layouts))
         filters.append(SearchHelper.templateScheme(include: false))
         if !spaceUxType.supportsMultiChats {
+            filters.append(SearchHelper.filterOutChatType())
+        }
+        filters.append(SearchHelper.filterOutParticipantType())
+        return filters
+    }
+
+    public static func build(isArchived: Bool, layouts: [DetailsLayout], spaceType: SpaceType?) -> [DataviewFilter] {
+        var filters = build(isArchived: isArchived)
+        filters.append(SearchHelper.layoutFilter(layouts))
+        filters.append(SearchHelper.templateScheme(include: false))
+        if spaceType == .oneToOne {
             filters.append(SearchHelper.filterOutChatType())
         }
         filters.append(SearchHelper.filterOutParticipantType())


### PR DESCRIPTION
## Summary

- Under `createChannelFlow` toggle, replace `spaceUxType.supportsMultiChats` checks with `spaceType != .oneToOne` across all type filtering and object visibility points
- Add `SpaceType`-based overloads to `DetailsLayout`, `SearchFiltersBuilder`, `SearchHelper`, `ObjectAction`, `ObjectSettingBuilder`, and related types
- Mark old `SpaceUxType`-based methods as deprecated
- Chat object type now available in creation menus, search, sets, and editor actions for all regular channels (personal and group), while remaining filtered in oneToOne spaces