### PR TITLE
IOS-5976 Use _final_score for global search and mentions search

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchViewModel.swift
@@ -194,10 +194,8 @@ final class GlobalSearchViewModel {
             if state.searchText.isEmpty {
                 state.sort.asDataviewSort()
             } else {
-                SearchHelper.sort(
-                    relation: BundledPropertyKey.lastOpenedDate,
-                    type: .desc
-                )
+                SearchHelper.sort(relation: .finalScore, type: .desc)
+                SearchHelper.sort(relation: BundledPropertyKey.lastOpenedDate, type: .desc)
             }
         }
     }

--- a/Anytype/Sources/ServiceLayer/Block/Mention/MentionObjectsService.swift
+++ b/Anytype/Sources/ServiceLayer/Block/Mention/MentionObjectsService.swift
@@ -12,10 +12,10 @@ final class MentionObjectsService: MentionObjectsServiceProtocol, Sendable {
     private let spaceViewsStorage: any SpaceViewsStorageProtocol = Container.shared.spaceViewsStorage()
 
     func searchMentions(spaceId: String, text: String, excludedObjectIds: [String], limitLayout: [DetailsLayout]) async throws -> [MentionObject] {
-        let sort = SearchHelper.sort(
-            relation: .lastOpenedDate,
-            type: .desc
-        )
+        let sorts: [DataviewSort] = .builder {
+            SearchHelper.sort(relation: .finalScore, type: .desc)
+            SearchHelper.sort(relation: .lastOpenedDate, type: .desc)
+        }
 
         let spaceUxType = spaceViewsStorage.spaceView(spaceId: spaceId)?.uxType
         let filters: [DataviewFilter] = .builder {
@@ -23,7 +23,7 @@ final class MentionObjectsService: MentionObjectsServiceProtocol, Sendable {
             SearchHelper.excludedIdsFilter(excludedObjectIds)
         }
 
-        let details = try await searchMiddleService.search(spaceId: spaceId, filters: filters, sorts: [sort], fullText: text)
+        let details = try await searchMiddleService.search(spaceId: spaceId, filters: filters, sorts: sorts, fullText: text)
 
         return details.map { MentionObject(details: $0) }
     }

--- a/Modules/ProtobufMessages/Sources/Loc/Generated/Error+Localization.swift
+++ b/Modules/ProtobufMessages/Sources/Loc/Generated/Error+Localization.swift
@@ -1163,6 +1163,8 @@ extension Anytype_Rpc.Block.Paste.Response.Error: LocalizedError {
                 return ""
             case .badInput:
                 return LocHelper.tr(table: "LocalizableError", key: "Block.Paste.badInput")
+            case .allSlotsEmpty:
+                return LocHelper.tr(table: "LocalizableError", key: "Block.Paste.allSlotsEmpty")
             case .UNRECOGNIZED:
                 return ""
         }

--- a/Modules/ProtobufMessages/Sources/Protocol/Commands/Anytype_Rpc.Block.Paste.swift
+++ b/Modules/ProtobufMessages/Sources/Protocol/Commands/Anytype_Rpc.Block.Paste.swift
@@ -120,9 +120,8 @@ extension Anytype_Rpc.Block {
             public typealias RawValue = Int
             case null // = 0
             case unknownError // = 1
-
-            /// ...
             case badInput // = 2
+            case allSlotsEmpty // = 3
             case UNRECOGNIZED(Int)
 
             public init() {
@@ -134,6 +133,7 @@ extension Anytype_Rpc.Block {
               case 0: self = .null
               case 1: self = .unknownError
               case 2: self = .badInput
+              case 3: self = .allSlotsEmpty
               default: self = .UNRECOGNIZED(rawValue)
               }
             }
@@ -143,6 +143,7 @@ extension Anytype_Rpc.Block {
               case .null: return 0
               case .unknownError: return 1
               case .badInput: return 2
+              case .allSlotsEmpty: return 3
               case .UNRECOGNIZED(let i): return i
               }
             }
@@ -152,6 +153,7 @@ extension Anytype_Rpc.Block {
               .null,
               .unknownError,
               .badInput,
+              .allSlotsEmpty,
             ]
 
           }
@@ -397,7 +399,7 @@ extension Anytype_Rpc.Block.Paste.Response.Error: SwiftProtobuf.Message, SwiftPr
 }
 
 extension Anytype_Rpc.Block.Paste.Response.Error.Code: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0NULL\0\u{1}UNKNOWN_ERROR\0\u{1}BAD_INPUT\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0NULL\0\u{1}UNKNOWN_ERROR\0\u{1}BAD_INPUT\0\u{1}ALL_SLOTS_EMPTY\0")
 }
 
 // If the compiler emits an error on this type, it is because this file

--- a/Modules/Services/Sources/Generated/BundledPropertiesValueProvider.swift
+++ b/Modules/Services/Sources/Generated/BundledPropertiesValueProvider.swift
@@ -191,6 +191,7 @@ public protocol BundledPropertiesValueProvider {
     var analyticsChatId: String { get }
     var analyticsSpaceId: String { get }
     var score: Int? { get }
+    var finalScore: Int? { get }
     var migrationObjectContext: Int? { get }
     var templateNamePrefillType: Int? { get }
     var spaceType: Int? { get }
@@ -897,6 +898,10 @@ public extension BundledPropertiesValueProvider where Self: PropertyValueProvide
     /// Fulltext search score
     var score: Int? {
         return value(for: BundledPropertyKey.score.rawValue)
+    }
+    /// Fulltext search final score (BM25 + recency + name boost)
+    var finalScore: Int? {
+        return value(for: BundledPropertyKey.finalScore.rawValue)
     }
     /// Version of file context migration completed for this space
     var migrationObjectContext: Int? {

--- a/Modules/Services/Sources/Generated/BundledPropertyKey.swift
+++ b/Modules/Services/Sources/Generated/BundledPropertyKey.swift
@@ -523,6 +523,9 @@ public enum BundledPropertyKey: String, Sendable {
     /// Fulltext search score
     case score = "_score"
 
+    /// Fulltext search final score (BM25 + recency + name boost)
+    case finalScore = "_final_score"
+
     /// Version of file context migration completed for this space
     case migrationObjectContext = "migrationObjectContext"
 


### PR DESCRIPTION
## Summary
- Added `_final_score` as the primary sort key — a blended backend score combining `ln(1 + BM25) + recency + name_boost`, where recency is exponential decay (30-day half-life) on `lastOpenedDate`/`lastModifiedDate`
- `lastOpenedDate` kept as fallback (won't be needed in practice since recency is already factored in)
- Regenerated middleware with new `BundledPropertyKey.finalScore` case