### PR TITLE
IOS-5908 Add participantsAdd to group channel creation flow

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SharingExtensionShareTo/SharingExtensionShareToViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SharingExtensionShareTo/SharingExtensionShareToViewModel.swift
@@ -46,7 +46,7 @@ final class SharingExtensionShareToViewModel {
     var sendToChatSelected: Bool { selectedObjectId == spaceView?.chatId }
     private var isMultiChatSpace: Bool {
         if FeatureFlags.createChannelFlow {
-            return spaceView?.spaceType.map { $0 != .oneToOne } ?? false
+            return spaceView.map { $0.spaceType != .oneToOne } ?? false
         }
         return spaceView?.uxType.supportsMultiChats ?? false
     }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
@@ -109,6 +109,7 @@ final class SpaceCreateViewModel: LocalObjectIconPickerOutput {
             do {
                 _ = try await workspaceService.makeSharable(spaceId: spaceId)
                 _ = try await workspaceService.generateInvite(spaceId: spaceId, inviteType: .withoutApprove, permissions: .writer)
+                // TODO: IOS-5911 Move participantsAdd to a separate do/catch with error handling
                 let identities = data.selectedContacts.map(\.identity)
                 if identities.isNotEmpty {
                     try await workspaceService.participantsAdd(spaceId: spaceId, identities: identities)

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
@@ -109,6 +109,10 @@ final class SpaceCreateViewModel: LocalObjectIconPickerOutput {
             do {
                 _ = try await workspaceService.makeSharable(spaceId: spaceId)
                 _ = try await workspaceService.generateInvite(spaceId: spaceId, inviteType: .withoutApprove, permissions: .writer)
+                let identities = data.selectedContacts.map(\.identity)
+                if identities.isNotEmpty {
+                    try await workspaceService.participantsAdd(spaceId: spaceId, identities: identities)
+                }
             } catch {}
         }
 

--- a/Modules/Services/Sources/Services/Workspace/WorkspaceService.swift
+++ b/Modules/Services/Sources/Services/Workspace/WorkspaceService.swift
@@ -229,9 +229,8 @@ final class WorkspaceService: WorkspaceServiceProtocol {
     }
 
     public func participantsAdd(spaceId: String, identities: [String]) async throws {
-        // TODO: IOS-5902 — replace with ClientCommands.spaceParticipantsAddList
-        // once middleware Lib.xcframework is updated
-        throw anytypeAssertionFailureWithError("participantsAdd not yet wired to middleware")
+        // TODO: IOS-5908 — Wire to ClientCommands.spaceParticipantsAddList when GO-6946 is merged
+        anytypeAssertionFailure("participantsAdd not yet available in middleware")
     }
 
     public func leaveApprove(spaceId: String, identity: String) async throws {


### PR DESCRIPTION
## Summary
- Add `participantsAdd` call to group channel creation chain after `makeSharable` → `generateInvite`
- Change `WorkspaceService.participantsAdd()` from throwing stub to non-throwing (awaiting GO-6946 middleware merge)
- Fix compilation bug in `SharingExtensionShareToViewModel` where `.map` was called on `SpaceType` instead of `Optional<SpaceView>`