### PR TITLE
IOS-5749 Show reaction badge as muted for Mention Only notification mode

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
@@ -83,7 +83,7 @@ enum SpacePreviewCountersBuilder {
             }
             if preview.hasUnreadReactions {
                 hasUnreadReactions = true
-                if effectiveMode == .all || effectiveMode == .mentions {
+                if effectiveMode == .all {
                     hasHighlightedReaction = true
                 }
             }
@@ -121,7 +121,7 @@ enum SpacePreviewCountersBuilder {
         case .all:
             return (unread: .highlighted, mention: .highlighted, reaction: .highlighted)
         case .mentions:
-            return (unread: .muted, mention: .highlighted, reaction: .highlighted)
+            return (unread: .muted, mention: .highlighted, reaction: .muted)
         case .nothing, .UNRECOGNIZED:
             return (unread: .muted, mention: .muted, reaction: .muted)
         }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/MessagePreviewModel+Presentation.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/MessagePreviewModel+Presentation.swift
@@ -17,7 +17,7 @@ extension MessagePreviewModel {
     }
 
     var reactionStyle: BadgeStyle {
-        notificationMode.mentionCounterStyle
+        notificationMode.reactionCounterStyle
     }
 
     var messagePreviewText: String {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceNotificationsSettings/SpaceNotificationsSettingsMode.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceNotificationsSettings/SpaceNotificationsSettingsMode.swift
@@ -57,6 +57,15 @@ extension SpacePushNotificationsMode {
         }
     }
 
+    var reactionCounterStyle: BadgeStyle {
+        switch self {
+        case .all:
+            return .highlighted
+        case .mentions, .nothing, .UNRECOGNIZED:
+            return .muted
+        }
+    }
+
     var analyticsValue: String {
         switch self {
         case .all: return "All"


### PR DESCRIPTION
## Summary
- Reaction heart badge now shows gray (muted) for "Mention Only" and "Muted" notification modes — previously it showed red in both cases
- Added `reactionCounterStyle` to `SpacePushNotificationsMode` that only highlights for `.all` mode
- Fixed both code paths: `SpacePreviewCountersBuilder` (space hub cards) and `MessagePreviewModel` (widget rows, set views)