### PR TITLE
IOS-5964 Fix spaces not reappearing after clearing no-results search

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubView.swift
@@ -58,9 +58,9 @@ struct SpaceHubView: View {
                 .toolbar { toolbarItems }
                 .if(!isEmptyState) { view in
                     view.searchable(text: $model.searchText)
-                        .onChange(of: model.searchText) {
-                            model.searchTextUpdated()
-                        }
+                }
+                .onChange(of: model.searchText) {
+                    model.searchTextUpdated()
                 }
         }.tint(Color.Text.secondary)
     }


### PR DESCRIPTION
## Summary
- Move `.onChange(of: model.searchText)` outside the conditional `.if(!isEmptyState)` block in `SpaceHubView`
- Previously, when clearing search with no results, `isEmptyState` became `true` which removed the `.onChange` modifier before it could fire, so `searchTextUpdated()` was never called and spaces never restored
- Now the observer always fires regardless of the empty state condition