### PR TITLE
IOS-5522 Fix invite.any.coop auto-open for existing members

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceJoin/SpaceJoinViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceJoin/SpaceJoinViewModel.swift
@@ -158,8 +158,7 @@ final class SpaceJoinViewModel {
             self.inviteView = inviteView
 
             if let spaceView = workspaceStorage.allSpaceViews.first(where: { $0.targetSpaceId == inviteView.spaceId }) {
-                switch spaceView.accountStatus {
-                case .spaceActive:
+                if spaceView.isActive {
                     // IOS-5522: Auto-open space for existing members
                     do {
                         try await activeSpaceManager.setActiveSpace(spaceId: inviteView.spaceId)
@@ -170,16 +169,14 @@ final class SpaceJoinViewModel {
                         state = .data
                         return
                     }
-                case .unknown:
-                    dataState = .alreadyJoined
-                    state = .data
-                    return
-                case .spaceJoining:
+                } else if spaceView.isJoining {
                     dataState = .requestSent
                     state = .data
                     return
-                default:
-                    break
+                } else {
+                    dataState = .alreadyJoined
+                    state = .data
+                    return
                 }
             }
 


### PR DESCRIPTION
## Summary
- Fix auto-open not working for `invite.any.coop` links when user is already a space member
- Replace direct `accountStatus` enum switch with `SpaceView.isActive`/`isJoining` properties — the canonical way to check space state used throughout the codebase
- Root cause: middleware can return `.unknown` (protobuf default) instead of `.spaceActive` for active spaces, which bypassed the auto-open logic