### PR TITLE
IOS-5810 Update notification settings entry points — design review fixes

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/ChatHeader/ChatHeaderView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/ChatHeader/ChatHeaderView.swift
@@ -120,7 +120,7 @@ struct ChatHeaderView: View {
                         Label {
                             Text(Loc.Chat.channelSettings)
                         } icon: {
-                            Image(asset: .X24.spaceSettings)
+                            Image(systemName: "gearshape")
                         }
                     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderView.swift
@@ -80,7 +80,7 @@ private struct WidgetsHeaderMenuContent: View {
         Button {
             model.onChannelSettingsTap()
         } label: {
-            Label(Loc.Chat.channelSettings, systemImage: "gear")
+            Label(Loc.Chat.channelSettings, systemImage: "gearshape")
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderView.swift
@@ -88,7 +88,7 @@ private struct WidgetsHeaderMenuContent: View {
         Button {
             model.onMembersTap()
         } label: {
-            Label(Loc.members, systemImage: "person.2.fill")
+            Label(Loc.members, systemImage: "person.2")
         }
     }
 
@@ -110,7 +110,7 @@ private struct WidgetsHeaderMenuContent: View {
         Button {
             model.onInviteMembersTap()
         } label: {
-            Label(Loc.Chat.inviteMembers, systemImage: "person.fill.badge.plus")
+            Label(Loc.Chat.inviteMembers, systemImage: "person.badge.plus")
         }
     }
 
@@ -126,7 +126,7 @@ private struct WidgetsHeaderMenuContent: View {
         Button {
             model.onCopyInviteLinkTap()
         } label: {
-            Label(Loc.copyInviteLink, systemImage: "document.on.document.fill")
+            Label(Loc.copyInviteLink, systemImage: "document.on.document")
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/SpaceCard.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/SpaceCard.swift
@@ -106,7 +106,7 @@ struct SpaceCard: View {
         Button {
             onTapSettings()
         } label: {
-            Text(Loc.SpaceSettings.title)
+            Text(Loc.Chat.channelSettings)
             Spacer()
             Image(systemName: "gearshape")
         }
@@ -116,7 +116,7 @@ struct SpaceCard: View {
         Button(role: .destructive) {
             onTapDelete()
         } label: {
-            Text(Loc.SpaceSettings.deleteButton)
+            Text(Loc.Chat.deleteChannel)
                 .tint(.red)
             Spacer()
             Image(systemName: "trash")
@@ -128,7 +128,7 @@ struct SpaceCard: View {
         Button(role: .destructive) {
             onTapLeave()
         } label: {
-            Text(Loc.SpaceSettings.leaveButton)
+            Text(Loc.Chat.leaveChannel)
                 .tint(.red)
             Spacer()
             Image(systemName: "trash")

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceNotificationsSettings/NotificationModeMenu.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceNotificationsSettings/NotificationModeMenu.swift
@@ -26,7 +26,7 @@ struct NotificationModeMenu: View {
             Label {
                 Text(Loc.notifications)
             } icon: {
-                Image(systemName: "bell.fill")
+                Image(systemName: "bell")
             }
         }
     }

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -1432,8 +1432,10 @@ public enum Loc {
   }
   public enum Chat {
     public static let channelSettings = Loc.tr("Workspace", "Chat.ChannelSettings", fallback: "Channel Settings")
+    public static let deleteChannel = Loc.tr("Workspace", "Chat.DeleteChannel", fallback: "Delete channel")
     public static let editMessage = Loc.tr("Workspace", "Chat.EditMessage", fallback: "Edit Message")
     public static let inviteMembers = Loc.tr("Workspace", "Chat.InviteMembers", fallback: "Invite members")
+    public static let leaveChannel = Loc.tr("Workspace", "Chat.LeaveChannel", fallback: "Leave channel")
     public static let newMessages = Loc.tr("Workspace", "Chat.NewMessages", fallback: "New Messages")
     public static func replyTo(_ p1: Any) -> String {
       return Loc.tr("Workspace", "Chat.ReplyTo", String(describing: p1), fallback: "Reply to %@")

--- a/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
@@ -1744,6 +1744,28 @@
         }
       }
     },
+    "Chat.DeleteChannel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete channel"
+          }
+        }
+      }
+    },
+    "Chat.LeaveChannel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leave channel"
+          }
+        }
+      }
+    },
     "Chat.Create.namePlaceholder" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## Summary
- Fix notification icon: use outline `bell` instead of filled `bell.fill` in all context menus
- Rename vault context menu labels: "Space Settings" → "Channel Settings", "Delete space" → "Delete channel", "Leave space" → "Leave channel"
- Unify settings gear icon to `gearshape` across all context menus (vault, widgets header, chat header)
- Use outline SF Symbol icons for Members, Invite Members, and Copy Invite Link in widgets header menu

Resolves IOS-5810, IOS-5989