### PR TITLE
IOS-5982 Polish channel creation flow on iOS 18

### DIFF
--- a/Anytype/Sources/FrameworkExtensions/SwiftUI/View+iOS26.swift
+++ b/Anytype/Sources/FrameworkExtensions/SwiftUI/View+iOS26.swift
@@ -65,6 +65,16 @@ extension View {
     }
 
     @ViewBuilder
+    public func toolbarNavigationBarOpaqueBackgroundLegacy() -> some View {
+        if #available(iOS 26.0, *) {
+            self
+        } else {
+            self
+                .toolbarBackground(Color.Background.primary, for: .navigationBar)
+        }
+    }
+
+    @ViewBuilder
     public func matchedTransitionSourceIOS26<ID: Hashable>(id: ID, in namespace: Namespace.ID?) -> some View {
         if let namespace, #available(iOS 26.0, *), FeatureFlags.matchedTransitionSource {
             self.matchedTransitionSource(id: id, in: namespace)

--- a/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorView.swift
@@ -11,6 +11,7 @@ struct GroupChannelCreateCoordinatorView: View {
                     SpaceCreateCoordinatorView(data: data, embedInNavigationStack: false)
                 }
         }
+        .tint(Color.Text.secondary)
     }
 
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/Modules/SelectMembers/SelectMembersView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SelectMembers/SelectMembersView.swift
@@ -24,6 +24,7 @@ struct SelectMembersView: View {
         }
         .searchable(text: $model.searchText)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarNavigationBarOpaqueBackgroundLegacy()
         .toolbar {
             ToolbarItem(placement: .principal) {
                 VStack(spacing: 0) {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/ChannelCreateView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/ChannelCreateView.swift
@@ -41,6 +41,7 @@ struct ChannelCreateView: View {
         }
         .navigationTitle(Loc.Channel.Create.newChannel)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarNavigationBarOpaqueBackgroundLegacy()
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
@@ -56,12 +57,15 @@ struct ChannelCreateView: View {
                 } label: {
                     if isCreating {
                         ProgressView()
+                            .tint(.white)
                     } else {
                         Text(Loc.create)
                     }
                 }
                 .buttonStyle(.borderedProminent)
                 .buttonBorderShape(.capsule)
+                .tint(Color.Control.accent100)
+                .foregroundStyle(.white)
                 .disabled(isCreating || model.spaceName.isEmpty || model.spaceName.count > ThresholdCounterUsecase.spaceName.threshold)
             }
         }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/Coordinator/SpaceCreateCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/Coordinator/SpaceCreateCoordinatorView.swift
@@ -18,6 +18,7 @@ struct SpaceCreateCoordinatorView: View {
                     NavigationStack {
                         ChannelCreateView(data: model.data, output: model)
                     }
+                    .tint(Color.Text.secondary)
                 } else {
                     ChannelCreateView(data: model.data, output: model)
                 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceTypePicker/CreateChannelMenuItems.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceTypePicker/CreateChannelMenuItems.swift
@@ -8,16 +8,36 @@ struct CreateChannelMenuItems: View {
 
     var body: some View {
         Group {
-            Button { onTapJoinQR() } label: {
-                Label(Loc.Qr.Join.title, systemImage: "qrcode")
-            }
-            Button { onTapGroup() } label: {
-                Label(Loc.Channel.Create.group, systemImage: "person.2.fill")
-            }
-            Button { onTapPersonal() } label: {
-                Label(Loc.Channel.Create.personal, systemImage: "person.fill")
+            if #available(iOS 26.0, *) {
+                // iOS 26 reverses menu items for bottom bar placement
+                qrButton
+                groupButton
+                personalButton
+            } else {
+                // iOS 18 does not reverse — specify desired visual order directly
+                personalButton
+                groupButton
+                qrButton
             }
         }
         .tint(Color.Control.primary)
+    }
+
+    private var personalButton: some View {
+        Button { onTapPersonal() } label: {
+            Label(Loc.Channel.Create.personal, systemImage: "person.fill")
+        }
+    }
+
+    private var groupButton: some View {
+        Button { onTapGroup() } label: {
+            Label(Loc.Channel.Create.group, systemImage: "person.2.fill")
+        }
+    }
+
+    private var qrButton: some View {
+        Button { onTapJoinQR() } label: {
+            Label(Loc.Qr.Join.title, systemImage: "qrcode")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fix navigation bar appearance on iOS 18: white background on scroll instead of system gray (via `toolbarNavigationBarOpaqueBackgroundLegacy` helper)
- Gray tint for back button and search cancel button on both channel creation screens
- Create button: blue capsule with white text on iOS 18 (`.tint(Color.Control.accent100)` + `.foregroundStyle(.white)`)
- Fix context menu item order: conditional by iOS version since iOS 26 auto-reverses bottom bar menus