### PR TITLE
IOS-5956: Send discussion attachments as MessageBlockLink blocks

### DIFF
--- a/Anytype/Sources/ServiceLayer/ChatActionService/ChatActionService.swift
+++ b/Anytype/Sources/ServiceLayer/ChatActionService/ChatActionService.swift
@@ -86,53 +86,84 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
         for linkedObject in linkedObjects {
             switch linkedObject {
             case .uploadedObject(let objectDetails):
-                var attachment = ChatMessageAttachment()
-                attachment.target = objectDetails.id
-                attachment.type = .link
-                chatMessage.attachments.append(attachment)
+                if useBlocksFormat {
+                    var linkBlock = ChatMessage.MessageBlockLink()
+                    linkBlock.targetObjectID = objectDetails.id
+                    linkBlock.type = objectDetails.resolvedLayoutValue.blockLinkType
+                    var block = ChatMessage.MessageBlock()
+                    block.content = .link(linkBlock)
+                    chatMessage.blocks.append(block)
+                } else {
+                    var attachment = ChatMessageAttachment()
+                    attachment.target = objectDetails.id
+                    attachment.type = .link
+                    chatMessage.attachments.append(attachment)
+                }
             case .localPhotosFile(let chatLocalFile):
                 guard let data = chatLocalFile.data else { continue }
-                if let attachment = try? await uploadFile(spaceId: spaceId, data: data.data, preloadFileId: chatLocalFile.data?.preloadFileId, createdInContext: chatId) {
+                guard let fileDetails = try? await uploadFile(spaceId: spaceId, data: data.data, preloadFileId: chatLocalFile.data?.preloadFileId, createdInContext: chatId) else { continue }
+                if useBlocksFormat {
+                    var linkBlock = ChatMessage.MessageBlockLink()
+                    linkBlock.targetObjectID = fileDetails.id
+                    linkBlock.type = fileDetails.blockLinkType
+                    var block = ChatMessage.MessageBlock()
+                    block.content = .link(linkBlock)
+                    chatMessage.blocks.append(block)
+                } else {
+                    var attachment = ChatMessageAttachment()
+                    attachment.target = fileDetails.id
                     chatMessage.attachments.append(attachment)
                 }
             case .localBinaryFile(let binaryFile):
-                if let attachment = try? await uploadFile(spaceId: spaceId, data: binaryFile.data, preloadFileId: binaryFile.preloadFileId, createdInContext: chatId) {
+                guard let fileDetails = try? await uploadFile(spaceId: spaceId, data: binaryFile.data, preloadFileId: binaryFile.preloadFileId, createdInContext: chatId) else { continue }
+                if useBlocksFormat {
+                    var linkBlock = ChatMessage.MessageBlockLink()
+                    linkBlock.targetObjectID = fileDetails.id
+                    linkBlock.type = fileDetails.blockLinkType
+                    var block = ChatMessage.MessageBlock()
+                    block.content = .link(linkBlock)
+                    chatMessage.blocks.append(block)
+                } else {
+                    var attachment = ChatMessageAttachment()
+                    attachment.target = fileDetails.id
                     chatMessage.attachments.append(attachment)
                 }
             case .localBookmark(let data):
                 guard let url = AnytypeURL(string: data.url) else { continue }
                 let type = try? typeProvider.objectType(uniqueKey: ObjectTypeUniqueKey.bookmark, spaceId: spaceId)
 
-                if let bookmark = try? await bookmarkService.createBookmarkObject(
+                guard let bookmark = try? await bookmarkService.createBookmarkObject(
                     spaceId: spaceId,
                     url: url,
                     templateId: type?.defaultTemplateId,
                     origin: .none,
                     createdInContext: chatId,
                     createdInContextRef: ""
-                ) {
+                ) else { continue }
+
+                if useBlocksFormat {
+                    var linkBlock = ChatMessage.MessageBlockLink()
+                    linkBlock.targetObjectID = bookmark.id
+                    linkBlock.type = .bookmark
+                    var block = ChatMessage.MessageBlock()
+                    block.content = .link(linkBlock)
+                    chatMessage.blocks.append(block)
+                } else {
                     var attachment = ChatMessageAttachment()
                     attachment.target = bookmark.id
                     chatMessage.attachments.append(attachment)
                 }
-                break
             }
         }
 
         return chatMessage
     }
 
-    private func uploadFile(spaceId: String, data: FileData, preloadFileId: String?, createdInContext: String) async throws -> ChatMessageAttachment {
-        let fileDetails: FileDetails
-
-        if let preloadFileId = preloadFileId {
-            fileDetails = try await fileActionsService.uploadPreloadedFileObject(fileId: preloadFileId, spaceId: spaceId, data: data, origin: .none, createdInContext: createdInContext, createdInContextRef: "")
+    private func uploadFile(spaceId: String, data: FileData, preloadFileId: String?, createdInContext: String) async throws -> FileDetails {
+        if let preloadFileId {
+            return try await fileActionsService.uploadPreloadedFileObject(fileId: preloadFileId, spaceId: spaceId, data: data, origin: .none, createdInContext: createdInContext, createdInContextRef: "")
         } else {
-            fileDetails = try await fileActionsService.uploadFileObject(spaceId: spaceId, data: data, origin: .none, createdInContext: createdInContext, createdInContextRef: "")
+            return try await fileActionsService.uploadFileObject(spaceId: spaceId, data: data, origin: .none, createdInContext: createdInContext, createdInContextRef: "")
         }
-
-        var attachment = ChatMessageAttachment()
-        attachment.target = fileDetails.id
-        return attachment
     }
 }

--- a/Modules/Services/Sources/Models/Details/FileDetails.swift
+++ b/Modules/Services/Sources/Models/Details/FileDetails.swift
@@ -51,7 +51,7 @@ public struct FileDetails: Sendable {
 extension DetailsLayout {
     var fileContentType: FileContentType {
         switch self {
-        case .file:
+        case .file, .pdf:
             return .file
         case .image:
             return .image

--- a/Modules/Services/Sources/Models/Details/FileDetails.swift
+++ b/Modules/Services/Sources/Models/Details/FileDetails.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProtobufMessages
 
 public struct FileDetails: Sendable {
     
@@ -30,7 +31,15 @@ public struct FileDetails: Sendable {
         let fileName = name.isEmpty ? id : name
         return FileDetails.formattedFileName(fileName, fileExt: fileExt)
     }
-    
+
+    public var blockLinkType: Anytype_Model_ChatMessage.MessageBlockLink.LinkType {
+        switch fileContentType {
+        case .image: return .image
+        case .file, .audio, .video: return .file
+        case .none: return .object
+        }
+    }
+
     static func formattedFileName(_ name: String, fileExt: String) -> String {
         let formattedFileExt = ".\(fileExt)"
         let fileSuffix = fileExt.isNotEmpty && !name.hasSuffix(formattedFileExt) ? formattedFileExt : ""

--- a/Modules/Services/Sources/Models/Extensions/DetailsLayoutExtension.swift
+++ b/Modules/Services/Sources/Models/Extensions/DetailsLayoutExtension.swift
@@ -1,3 +1,5 @@
+import ProtobufMessages
+
 public extension DetailsLayout {
     
     static let editorLayouts: [DetailsLayout] = [ .note, .basic, .profile, .todo ]
@@ -79,6 +81,15 @@ public extension DetailsLayout {
 
     var isObjectType: Bool { self == .objectType }
     var isChat: Bool { Self.chatLayouts.contains(self) }
+
+    var blockLinkType: Anytype_Model_ChatMessage.MessageBlockLink.LinkType {
+        switch self {
+        case .image: return .image
+        case .file, .pdf, .audio, .video: return .file
+        case .bookmark: return .bookmark
+        default: return .object
+        }
+    }
 }
 
 // MARK: - Instance functions


### PR DESCRIPTION
## Summary
- When `useBlocksFormat: true` (discussions), attachments are now sent as `MessageBlockLink` entries in `blocks[]` instead of `ChatMessageAttachment` in `attachments[]`
- Refactored `uploadFile()` to return `FileDetails` for flexible block/attachment construction
- Added `blockLinkType` mapping to `DetailsLayout` and `FileDetails` (image→.image, file/pdf/audio/video→.file, bookmark→.bookmark, default→.object)