### PR TITLE
IOS-5987 Add channel creation flow analytics events

### DIFF
--- a/Anytype/Sources/Analytics/AnalyticsConstants.swift
+++ b/Anytype/Sources/Analytics/AnalyticsConstants.swift
@@ -522,3 +522,15 @@ enum ScreenChatImageStatus: String {
     case success = "Success"
     case failure = "Failure"
 }
+
+enum ScreenSettingsSpaceCreateStatus: String {
+    case online = "Online"
+    case offline = "Offline"
+}
+
+enum CreateHomePageType: String {
+    case chat = "Chat"
+    case page = "Page"
+    case collection = "Collection"
+    case empty = "Empty"
+}

--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -965,8 +965,10 @@ extension AnytypeAnalytics {
         )
     }
     
-    func logScreenSettingsSpaceCreate() {
-        logEvent("ScreenSettingsSpaceCreate")
+    func logScreenSettingsSpaceCreate(status: ScreenSettingsSpaceCreateStatus) {
+        logEvent("ScreenSettingsSpaceCreate", withEventProperties: [
+            AnalyticsEventsPropertiesKey.status: status.rawValue
+        ])
     }
     
     func logCreateSpace(spaceId: String, spaceUxType: SpaceUxType, route: CreateSpaceRoute) {
@@ -1829,5 +1831,37 @@ extension AnytypeAnalytics {
 
     func logClickNavigationScreenHome() {
         logEvent("ClickNavigationScreenHome")
+    }
+
+    func logClickVaultCreateMenuJoin() {
+        logEvent("ClickVaultCreateMenuJoin")
+    }
+
+    func logChangeSpaceDashboard() {
+        logEvent("ChangeSpaceDashboard")
+    }
+
+    func logMemberSearchInput() {
+        logEvent("MemberSearchInput")
+    }
+
+    func logScreenAddMember() {
+        logEvent("ScreenAddMember")
+    }
+
+    func logAddMember(count: Int) {
+        logEvent("AddMember", withEventProperties: [
+            AnalyticsEventsPropertiesKey.count: count
+        ])
+    }
+
+    func logCreateHomePage(type: CreateHomePageType) {
+        logEvent("CreateHomePage", withEventProperties: [
+            AnalyticsEventsPropertiesKey.type: type.rawValue
+        ])
+    }
+
+    func logScreenHitShareSpaceLimit() {
+        logEvent("ScreenHitShareSpaceLimit")
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/HomepageCreatePickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/HomepageCreatePickerViewModel.swift
@@ -24,6 +24,7 @@ final class HomepageCreatePickerViewModel {
     }
 
     func onCreate() async throws {
+        AnytypeAnalytics.instance().logCreateHomePage(type: selectedOption.analyticsType)
         let homepageValue = try await homepagePickerService.createHomepage(
             spaceId: spaceId,
             option: selectedOption

--- a/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/HomepagePickerOption.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/HomepagePickerOption.swift
@@ -23,6 +23,20 @@ enum HomepagePickerOption: Identifiable, Equatable {
     }
 }
 
+extension HomepagePickerOption {
+    var analyticsType: CreateHomePageType {
+        switch self {
+        case .widgets: return .empty
+        case .object(let type):
+            switch type {
+            case .chat: return .chat
+            case .page: return .page
+            case .collection: return .collection
+            }
+        }
+    }
+}
+
 enum ObjectHomepageType: String, CaseIterable {
     case chat
     case page

--- a/Anytype/Sources/PresentationLayer/Modules/SelectMembers/SelectMembersView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SelectMembers/SelectMembersView.swift
@@ -23,6 +23,12 @@ struct SelectMembersView: View {
             }
         }
         .searchable(text: $model.searchText)
+        .onAppear {
+            AnytypeAnalytics.instance().logScreenAddMember()
+        }
+        .onChange(of: model.searchText) {
+            AnytypeAnalytics.instance().logMemberSearchInput()
+        }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {

--- a/Anytype/Sources/PresentationLayer/Modules/SharedChannelLimit/SharedChannelLimitView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SharedChannelLimit/SharedChannelLimitView.swift
@@ -25,5 +25,8 @@ struct SharedChannelLimitView: View {
                 onManageChannels()
             }
         }
+        .onAppear {
+            AnytypeAnalytics.instance().logScreenHitShareSpaceLimit()
+        }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
@@ -73,8 +73,8 @@ final class SpaceCreateViewModel: LocalObjectIconPickerOutput {
     }
     
     func onAppear() {
-        AnytypeAnalytics.instance().logScreenSettingsSpaceCreate(status: isConnected ? .online : .offline)
         isConnected = networkStatusProvider.isConnected
+        AnytypeAnalytics.instance().logScreenSettingsSpaceCreate(status: isConnected ? .online : .offline)
     }
 
     func startNetworkObservation() async {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
@@ -66,11 +66,14 @@ final class SpaceCreateViewModel: LocalObjectIconPickerOutput {
 
         UINotificationFeedbackGenerator().notificationOccurred(.success)
         AnytypeAnalytics.instance().logCreateSpace(spaceId: spaceId, spaceUxType: data.spaceUxType, route: .navigation)
+        if let channelType = data.channelType, channelType == .group {
+            AnytypeAnalytics.instance().logAddMember(count: data.selectedContacts.count)
+        }
         try await output?.onSpaceCreated(spaceId: spaceId)
     }
     
     func onAppear() {
-        AnytypeAnalytics.instance().logScreenSettingsSpaceCreate()
+        AnytypeAnalytics.instance().logScreenSettingsSpaceCreate(status: isConnected ? .online : .offline)
         isConnected = networkStatusProvider.isConnected
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -59,14 +59,17 @@ final class SpaceHubViewModel {
     }
 
     func onTapCreatePersonalChannel() {
+        AnytypeAnalytics.instance().logClickVaultCreateMenuSpace()
         output?.onSelectCreatePersonalChannel()
     }
 
     func onTapCreateGroupChannel() {
+        AnytypeAnalytics.instance().logClickVaultCreateMenuChat()
         output?.onSelectCreateGroupChannel()
     }
 
     func onTapJoinViaQrCode() {
+        AnytypeAnalytics.instance().logClickVaultCreateMenuJoin()
         output?.onSelectQrCodeJoin()
     }
     

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/HomePage/HomepageSettingsPickerViewModel.swift
@@ -54,11 +54,13 @@ final class HomepageSettingsPickerViewModel {
 
     func onEmptySelected() async throws {
         try await homepagePickerService.setHomepage(spaceId: spaceId, homepage: .widgets)
+        AnytypeAnalytics.instance().logChangeSpaceDashboard()
         dismiss = true
     }
 
     func onObjectSelected(_ details: ObjectDetails) async throws {
         try await homepagePickerService.setHomepage(spaceId: spaceId, homepage: .object(objectId: details.id))
+        AnytypeAnalytics.instance().logChangeSpaceDashboard()
         dismiss = true
     }
 }


### PR DESCRIPTION
## Summary
- Add new analytics events for the channel creation flow: `ClickVaultCreateMenuJoin`, `ChangeSpaceDashboard`, `MemberSearchInput`, `ScreenAddMember`, `AddMember`, `CreateHomePage`, `ScreenHitShareSpaceLimit`
- Add `status` (Online/Offline) property to existing `ScreenSettingsSpaceCreate` event
- Wire up existing `ClickVaultCreateMenuChat` and `ClickVaultCreateMenuSpace` events in the new create channel menu flow