### PR TITLE
IOS-5977: Hide create object FAB for Viewer role

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -44,8 +44,10 @@ private struct HomeBottomNavigationPanelViewInternal: View {
                             .glassEffectIDIOS26("search", in: glassNamespace)
                     }
                     Spacer()
-                    createButton
-                        .glassEffectIDIOS26("create", in: glassNamespace)
+                    if model.canCreateObject {
+                        createButton
+                            .glassEffectIDIOS26("create", in: glassNamespace)
+                    }
                 }
             }
             .padding(.horizontal, 24)
@@ -164,7 +166,6 @@ private struct HomeBottomNavigationPanelViewInternal: View {
             .frame(width: 48, height: 48)
             .glassEffectInteractiveIOS26(in: Circle())
             .menuOrder(.fixed)
-            .disabled(!model.canCreateObject)
         } else {
             Button {
                 model.onTapNewObject()
@@ -175,7 +176,6 @@ private struct HomeBottomNavigationPanelViewInternal: View {
             }
             .frame(width: 48, height: 48)
             .glassEffectInteractiveIOS26(in: Circle())
-            .disabled(!model.canCreateObject)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Hide the Home FAB create button for users with Viewer (reader) role instead of showing a disabled button that does nothing when tapped
- Remove redundant `.disabled(!model.canCreateObject)` modifiers since the button is no longer rendered at all for Viewers