### PR TITLE
IOS-5962 Fix ScreenSearch analytics event not fired when restored state equals default

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchViewModel.swift
@@ -160,9 +160,8 @@ final class GlobalSearchViewModel {
             return
         }
         state = restoredState
-        if restoredState.searchText.isNotEmpty {
-            AnytypeAnalytics.instance().logScreenSearch(type: .saved)
-        }
+        let type: ScreenSearchType = restoredState == GlobalSearchState() ? .empty : .saved
+        AnytypeAnalytics.instance().logScreenSearch(type: type)
     }
     
     private func storeState() {


### PR DESCRIPTION
## Summary
- Fixed `ScreenSearch` analytics event not firing when Global Search is opened with a saved state that has empty search text
- Compare restored state against default `GlobalSearchState()` instead of checking `searchText.isNotEmpty` — fires `.empty` when state matches default, `.saved` when it has meaningful content (non-default sort, section, or search text)