### PR TITLE
IOS-5947 Fix reaction toggle and long-press disabled when limits reached

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessageBuilder.swift
@@ -101,6 +101,7 @@ actor ChatMessageBuilder: ChatMessageBuilderProtocol, Sendable {
                     position: position
                 ),
                 canAddReaction: canEdit && limits.canAddReaction(message: fullMessage.message, yourProfileIdentity: yourProfileIdentity ?? ""),
+                canToggleReaction: canEdit,
                 canReply: canEdit,
                 nextSpacing: (lastInSection || nextIsUnread) ? .disable : (lastForCurrentUser || nextDateIntervalIsBig ? .medium : .small),
                 authorIconMode: (isYourMessage || !showsMessageAuthor) ? .hidden : (lastForCurrentUser || lastInSection || nextDateIntervalIsBig ? .show : .empty),

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageView.swift
@@ -187,7 +187,7 @@ struct MessageView: View {
             MessageReactionList(
                 rows: data.reactions,
                 canAddReaction: data.canAddReaction,
-                canToggleReaction: data.canReply,
+                canToggleReaction: data.canToggleReaction,
                 position: data.position,
                 onTapRow: { reaction in
                     try await output?.didTapOnReaction(data: data, emoji: reaction.emoji)

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageView.swift
@@ -187,7 +187,7 @@ struct MessageView: View {
             MessageReactionList(
                 rows: data.reactions,
                 canAddReaction: data.canAddReaction,
-                canToggleReaction: data.canAddReaction,
+                canToggleReaction: data.canReply,
                 position: data.position,
                 onTapRow: { reaction in
                     try await output?.didTapOnReaction(data: data, emoji: reaction.emoji)

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageViewData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageViewData.swift
@@ -18,6 +18,7 @@ struct MessageViewData: Identifiable, Equatable, Hashable {
     let linkedObjects: MessageLinkedObjectsLayout?
     let reactions: [MessageReactionModel]
     let canAddReaction: Bool
+    let canToggleReaction: Bool
     let canReply: Bool
     let nextSpacing: MessageViewSpacing
     let authorIconMode: MessageAuthorIconMode

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
@@ -81,6 +81,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                     position: position
                 ),
                 canAddReaction: canEdit && limits.canAddReaction(message: fullMessage.message, yourProfileIdentity: yourProfileIdentity ?? ""),
+                canToggleReaction: canEdit,
                 canReply: canEdit,
                 nextSpacing: .disable,
                 authorIconMode: .show,

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -188,7 +188,7 @@ struct DiscussionMessageView: View {
             MessageReactionList(
                 rows: data.reactions,
                 canAddReaction: data.canAddReaction,
-                canToggleReaction: data.canReply,
+                canToggleReaction: data.canToggleReaction,
                 position: data.position,
                 onTapRow: { reaction in
                     try await output?.didTapOnReaction(data: data, emoji: reaction.emoji)

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -188,7 +188,7 @@ struct DiscussionMessageView: View {
             MessageReactionList(
                 rows: data.reactions,
                 canAddReaction: data.canAddReaction,
-                canToggleReaction: data.canAddReaction,
+                canToggleReaction: data.canReply,
                 position: data.position,
                 onTapRow: { reaction in
                     try await output?.didTapOnReaction(data: data, emoji: reaction.emoji)


### PR DESCRIPTION
## Summary

- Decouple `canToggleReaction` from `canAddReaction` so users can still remove existing reactions and long-press to see who reacted when reaction limits (3 per user / 12 per message) are hit
- Fix applied to both Chat (`MessageView`) and Discussion (`DiscussionMessageView`)