### PR TITLE
IOS-5963 Remove scroll-to-mention and scroll-to-reaction from discussions

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -165,13 +165,10 @@ struct DiscussionView: View {
     }
 
     private var actionView: some View {
+        // Discussions only use scroll-to-bottom; mention/reaction buttons are Chat-only
         ChatActionPanelView(model: model.actionModel) {
             model.onTapScrollToBottom()
-        } onTapMention: {
-            model.onTapMention()
-        } onTapReaction: {
-            anytypeAssertionFailure("Reactions are not supported in discussions")
-        }
+        } onTapMention: { } onTapReaction: { }
     }
 
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -168,7 +168,11 @@ struct DiscussionView: View {
         // Discussions only use scroll-to-bottom; mention/reaction buttons are Chat-only
         ChatActionPanelView(model: model.actionModel) {
             model.onTapScrollToBottom()
-        } onTapMention: { } onTapReaction: { }
+        } onTapMention: {
+            anytypeAssertionFailure("Mentions scroll is not supported in discussions")
+        } onTapReaction: {
+            anytypeAssertionFailure("Reactions scroll is not supported in discussions")
+        }
     }
 
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -546,16 +546,6 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
         }
     }
 
-    func onTapMention() {
-        guard let chatState, let chatStorage else { return }
-        AnytypeAnalytics.instance().logClickScrollToMention(chatId: chatId ?? "")
-        Task {
-            let message = try await chatStorage.loadPagesTo(orderId: chatState.mentions.oldestOrderID)
-            collectionViewScrollProxy.scrollTo(itemId: message.id, position: .center, animated: true)
-            messageHiglightId = message.id
-        }
-    }
-
     func onTapDismissKeyboard() {
         inputFocused = false
     }
@@ -829,8 +819,8 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
             actionModel = ChatActionPanelModel(
                 showScrollToBottom: chatState.messages.counter > 0 || bigDistanceToBottom,
                 srollToBottomCounter: Int(chatState.messages.counter),
-                showMentions: chatState.mentions.counter > 0,
-                mentionsCounter: Int(chatState.mentions.counter),
+                showMentions: false,
+                mentionsCounter: 0,
                 showReactions: false
             )
         } else {


### PR DESCRIPTION
## Summary
- Remove scroll-to-mention button and `onTapMention()` logic from Discussion module (was copied from Chat but not needed)
- Remove scroll-to-reaction dead code (assertion failure handler)
- Keep only scroll-to-bottom button in discussions