### PR TITLE
IOS-5993 Add uploadTime and totalTime to ScreenChatImage

### DIFF
--- a/Anytype/Sources/Analytics/AnalyticsConstants.swift
+++ b/Anytype/Sources/Analytics/AnalyticsConstants.swift
@@ -56,6 +56,8 @@ enum AnalyticsEventsPropertiesKey {
     static let size = "size"
     static let time = "time"
     static let status = "status"
+    static let uploadTime = "uploadTime"
+    static let totalTime = "totalTime"
 }
 
 enum AnalyticsEventsTypeValues {

--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -1817,7 +1817,7 @@ extension AnytypeAnalytics {
         ].compactMapValues { $0 })
     }
     
-    func logScreenChatImage(time: Int, status: ScreenChatImageStatus, size: Int?) {
+    func logScreenChatImage(time: Int, status: ScreenChatImageStatus, size: Int?, uploadTime: Int? = nil, totalTime: Int? = nil) {
         logEvent("ScreenChatImage", withEventProperties: .builder {
             [
                 AnalyticsEventsPropertiesKey.time: time,
@@ -1825,6 +1825,12 @@ extension AnytypeAnalytics {
             ]
             if let size {
                 [AnalyticsEventsPropertiesKey.size: size]
+            }
+            if let uploadTime {
+                [AnalyticsEventsPropertiesKey.uploadTime: uploadTime]
+            }
+            if let totalTime {
+                [AnalyticsEventsPropertiesKey.totalTime: totalTime]
             }
         })
     }

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/LinkObject/Common/MessageImageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/LinkObject/Common/MessageImageView.swift
@@ -7,7 +7,8 @@ struct MessageImageView: View {
     let syncStatus: SyncStatus?
     let syncError: SyncError?
     let sizeInBytes: Int?
-    
+    let uploadTimeMs: Int?
+
     var body: some View {
         GeometryReader { reader in
             CachedAsyncImage(url: ImageMetadata(id: imageId, side: .width(min(reader.size.width, reader.size.height))).contentUrl) { content in
@@ -27,7 +28,17 @@ struct MessageImageView: View {
                     MessageAttachmentLoadingIndicator()
                 }
             } loadTimeTracker: { time, success in
-                AnytypeAnalytics.instance().logScreenChatImage(time: time, status: success ? .success : .failure, size: sizeInBytes)
+                var totalTime: Int? = nil
+                if let uploadTimeMs {
+                    totalTime = uploadTimeMs + time
+                }
+                AnytypeAnalytics.instance().logScreenChatImage(
+                    time: time,
+                    status: success ? .success : .failure,
+                    size: sizeInBytes,
+                    uploadTime: uploadTimeMs,
+                    totalTime: totalTime
+                )
             }
         }
     }
@@ -35,6 +46,12 @@ struct MessageImageView: View {
 
 extension MessageImageView {
     init(details: MessageAttachmentDetails) {
-        self.init(imageId: details.id, syncStatus: details.syncStatus, syncError: details.syncError, sizeInBytes: details.sizeInBytes)
+        self.init(
+            imageId: details.id,
+            syncStatus: details.syncStatus,
+            syncError: details.syncError,
+            sizeInBytes: details.sizeInBytes,
+            uploadTimeMs: details.uploadTimeMs
+        )
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageAttachmentDetails.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageAttachmentDetails.swift
@@ -12,11 +12,18 @@ struct MessageAttachmentDetails: Equatable, Identifiable, Hashable {
     let syncStatus: SyncStatus?
     let syncError: SyncError?
     let downloadingState: Bool
+    let uploadTimeMs: Int?
 }
 
 extension MessageAttachmentDetails {
     init(details: ObjectDetails) {
         let source = details.source?.url.host() ?? details.source?.absoluteString
+
+        var uploadTimeMs: Int? = nil
+        if let addedDate = details.addedDate, let syncDate = details.syncDate, syncDate > addedDate {
+            uploadTimeMs = Int(syncDate.timeIntervalSince(addedDate) * 1000)
+        }
+
         self = MessageAttachmentDetails(
             id: details.id,
             title: details.title,
@@ -27,7 +34,8 @@ extension MessageAttachmentDetails {
             source: source,
             syncStatus: details.syncStatusValue,
             syncError: details.syncErrorValue,
-            downloadingState: false
+            downloadingState: false,
+            uploadTimeMs: uploadTimeMs
         )
     }
     
@@ -42,7 +50,8 @@ extension MessageAttachmentDetails {
             source: nil,
             syncStatus: nil,
             syncError: nil,
-            downloadingState: true
+            downloadingState: true,
+            uploadTimeMs: nil
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add `uploadTime` (sender upload latency) and `totalTime` (end-to-end delivery) to the `ScreenChatImage` analytics event
- Compute `uploadTimeMs` from `ObjectDetails.addedDate`/`syncDate` in `MessageAttachmentDetails`
- Both properties are omitted when source data is unavailable (not sent as 0 or null)