### PR TITLE
IOS-5998 Fix app freeze when tapping user avatar in chat

### DIFF
--- a/Anytype/Sources/ApplicationLayer/GlobalEnv/PresentedDismiss.swift
+++ b/Anytype/Sources/ApplicationLayer/GlobalEnv/PresentedDismiss.swift
@@ -1,18 +1,20 @@
 import Foundation
 import SwiftUI
+import AnytypeCore
 
 struct DismissAllPresented: Equatable {
-    
+
     private weak var window: UIWindow?
-    
+
     init(window: UIWindow?) {
         self.window = window
     }
-    
+
     func callAsFunction(animated: Bool = true) async {
         await withCheckedContinuation { continuation in
             Task { @MainActor [weak window] in
-                if let root = window?.rootViewController {
+                if let root = window?.rootViewController,
+                   !FeatureFlags.fixAvatarTapFreeze || root.presentedViewController != nil {
                     root.dismiss(animated: animated, completion: {
                         continuation.resume()
                     })

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -413,6 +413,7 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     
     // Checks is object supported for opening
     private func checkIsDataSupportedForOpening(_ data: ScreenData) async throws -> Bool {
+        if FeatureFlags.fixAvatarTapFreeze, case .alert(.spaceMember) = data { return true }
         guard let objectId = data.objectId else { return true }
         
         let document = documentsProvider.document(objectId: objectId, spaceId: data.spaceId, mode: .preview)

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatCollectionViewContainer.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatCollectionViewContainer.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import AnytypeCore
 
 final class ChatCollectionViewContainer<BottomPanel: View, EmptyView: View, ActionView: View>: UIViewController {
     
@@ -154,6 +155,9 @@ final class ChatCollectionViewContainer<BottomPanel: View, EmptyView: View, Acti
     }
     
     private func updateKeyboardHeight(event: KeyboardEvent) {
+        if FeatureFlags.fixAvatarTapFreeze {
+            guard view.window != nil else { return }
+        }
         let canHandleKeyboard = presentedViewController.map { $0.isBeingDismissed } ?? true
         guard canHandleKeyboard else { return }
         event.animate { [weak self] in

--- a/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
@@ -30,6 +30,10 @@ public extension FeatureFlags {
         value(for: .channelTypeSwitcher)
     }
 
+    static var fixAvatarTapFreeze: Bool {
+        value(for: .fixAvatarTapFreeze)
+    }
+
     static var muteAndHide: Bool {
         value(for: .muteAndHide)
     }
@@ -122,6 +126,7 @@ public extension FeatureFlags {
         .qrCodeCircularText,
         .createChannelFlow,
         .channelTypeSwitcher,
+        .fixAvatarTapFreeze,
         .muteAndHide,
         .setKanbanView,
         .fullInlineSetImpl,

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -44,6 +44,12 @@ public extension FeatureDescription {
         defaultValue: false
     )
 
+    static let fixAvatarTapFreeze = FeatureDescription(
+        title: "Fix avatar tap freeze in chat - IOS-5998",
+        category: .productFeature(author: "k@anytype.io", targetRelease: "18"),
+        defaultValue: true
+    )
+
     static let muteAndHide = FeatureDescription(
         title: "Mute and hide notification setting - IOS-5809",
         category: .productFeature(author: "k@anytype.io", targetRelease: "18"),


### PR DESCRIPTION
## Summary
- Fix app freeze on weak devices (iOS 17) when tapping a user avatar in chat
- Add `fixAvatarTapFreeze` feature flag (default: on) with three targeted fixes:
  - **DismissAllPresented**: skip `root.dismiss()` when nothing is presented to avoid `withCheckedContinuation` hang
  - **checkIsDataSupportedForOpening**: skip unnecessary `document.open()` for `.spaceMember` (participant layout is always supported)
  - **ChatCollectionViewContainer**: guard keyboard events when view is not in window to prevent layout thrashing