### PR TITLE
IOS-5946 Context menu enhancement for discussions

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -45,12 +45,9 @@ struct DiscussionMessageView: View {
             .coordinateSpace(name: Constants.coordinateSpace)
             .messageFlashBackground(id: data.id)
             .background(Color.Background.primary)
-            .contentShape(.contextMenuPreview, Rectangle())
+            .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 16, style: .continuous))
             .contextMenu {
                 contextMenu
-            } preview: {
-                messageBody
-                    .background(Color.Background.primary)
             }
             .readFrame(space: .named(Constants.coordinateSpace)) {
                 contentCenterOffsetY = $0.midY
@@ -256,14 +253,6 @@ struct DiscussionMessageView: View {
             output?.didSelectCopyLink(message: data)
         } label: {
             Label(Loc.copyLink, systemImage: "link")
-        }
-
-        if data.canEdit {
-            AsyncButton {
-                await output?.didSelectEditMessage(message: data)
-            } label: {
-                Label(Loc.edit, systemImage: "pencil")
-            }
         }
 
         if data.canDelete {


### PR DESCRIPTION
## Summary
- Remove Edit action from discussion context menu (no edit on mobile v1, only delete)
- Remove custom preview closure to fix CALayer NaN crash on long messages
- Add rounded corners (16pt) to context menu preview shape