### PR TITLE
IOS-6009 Add Grep and WebSearch to allow list

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,8 @@
   "permissions": {
     "allow": [
       "Read(*)",
+      "Grep(*)",
+      "WebSearch(*)",
 
       "Bash(git checkout:*)",
       "Bash(git worktree:*)",


### PR DESCRIPTION
## Summary
- Add `Grep(*)` and `WebSearch(*)` to Claude Code permissions allow list in `.claude/settings.json`