### PR TITLE
IOS-5889 Fix chat opening twice from deep link navigation

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/ChatCoordinator/ChatCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChatCoordinator/ChatCoordinatorView.swift
@@ -54,7 +54,7 @@ struct ChatCoordinatorView: View {
                 SimpleCameraView(data: $0)
             }
             .sheet(item: $model.newLinkedObject) {
-                ChatCreateObjectCoordinatorView(data: $0)
+                ChatCreateObjectCoordinatorView(data: $0, chatId: model.chatId)
             }
             .anytypeSheet(item: $model.pushNotificationsAlertData) {
                 PushNotificationsAlertView(data: $0)

--- a/Anytype/Sources/PresentationLayer/Flows/ChatCreateObject/ChatCreateObjectCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChatCreateObject/ChatCreateObjectCoordinatorView.swift
@@ -10,8 +10,8 @@ struct ChatCreateObjectCoordinatorView: View {
 
     @State private var topInset: CGFloat = 0
 
-    init(data: EditorScreenData, onDismiss: @escaping (ChatCreateObjectDismissResult) -> Void = { _ in }) {
-        _model = State(initialValue: ChatCreateObjectCoordinatorViewModel(data: data, onDismiss: onDismiss))
+    init(data: EditorScreenData, chatId: String? = nil, onDismiss: @escaping (ChatCreateObjectDismissResult) -> Void = { _ in }) {
+        _model = State(initialValue: ChatCreateObjectCoordinatorViewModel(data: data, chatId: chatId, onDismiss: onDismiss))
     }
     
     var body: some View {

--- a/Anytype/Sources/PresentationLayer/Flows/ChatCreateObject/ChatCreateObjectCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChatCreateObject/ChatCreateObjectCoordinatorViewModel.swift
@@ -39,8 +39,12 @@ final class ChatCreateObjectCoordinatorViewModel {
     @ObservationIgnored
     var dismiss: DismissAction?
     
-    init(data: EditorScreenData, onDismiss: @escaping (ChatCreateObjectDismissResult) -> Void) {
+    @ObservationIgnored
+    let chatId: String?
+
+    init(data: EditorScreenData, chatId: String? = nil, onDismiss: @escaping (ChatCreateObjectDismissResult) -> Void) {
         self.data = data
+        self.chatId = chatId
         if let objectId = data.objectId {
             self.document = openDocumentProvider.document(objectId: objectId, spaceId: data.spaceId)
         } else {
@@ -78,8 +82,8 @@ final class ChatCreateObjectCoordinatorViewModel {
     }
     
     func onTapAttach() {
-        guard let link = data.chatLink else { return }
-        chatActionProvider?.addAttachment(link, clearInput: false)
+        guard let link = data.chatLink, let chatId else { return }
+        chatActionProvider?.addAttachment(chatId: chatId, link, clearInput: false)
         dismiss(with: .attachedToChat)
     }
     

--- a/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorView.swift
@@ -61,7 +61,7 @@ struct DiscussionCoordinatorView: View {
                 SimpleCameraView(data: $0)
             }
             .sheet(item: $model.newLinkedObject) {
-                ChatCreateObjectCoordinatorView(data: $0)
+                ChatCreateObjectCoordinatorView(data: $0, chatId: model.discussionId)
             }
             .anytypeSheet(item: $model.pushNotificationsAlertData) {
                 PushNotificationsAlertView(data: $0)

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -334,8 +334,10 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
         }
     }
 
-    private func showSpace(spaceId: String, spaceUxType: SpaceUxType? = nil) async {
-        guard currentSpaceId != spaceId else { return }
+    /// Builds the home path for a space without committing to navigationPath.
+    /// Returns nil if already in the target space.
+    private func prepareSpacePath(spaceId: String, spaceUxType: SpaceUxType? = nil) async -> HomePath? {
+        guard currentSpaceId != spaceId else { return nil }
 
         setActiveSpace(spaceId: spaceId)
         let homeObject = await homeObjectScreenData(spaceId: spaceId, spaceUxType: spaceUxType)
@@ -345,20 +347,31 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
             homeObject
         }
 
-        let currentPath = HomePath(initialPath: path)
-        if navigationPath != currentPath {
+        return HomePath(initialPath: path)
+    }
+
+    private func showSpace(spaceId: String, spaceUxType: SpaceUxType? = nil) async {
+        guard let newPath = await prepareSpacePath(spaceId: spaceId, spaceUxType: spaceUxType) else { return }
+        if navigationPath != newPath {
             await dismissAllPresented?()
-            navigationPath = currentPath
+            navigationPath = newPath
         }
     }
-    
+
     // main show screen logic
     private func showScreen(data: ScreenData) async throws {
         guard try await checkIsDataSupportedForOpening(data) else { return }
 
-        await showSpace(spaceId: data.spaceId)
-
-        var currentPath = navigationPath
+        // Build space path without committing — showScreen will commit once with final state
+        var currentPath: HomePath
+        let isSwitchingSpace: Bool
+        if let spacePath = await prepareSpacePath(spaceId: data.spaceId) {
+            currentPath = spacePath
+            isSwitchingSpace = true
+        } else {
+            currentPath = navigationPath
+            isSwitchingSpace = false
+        }
 
         await dismissAllPresented?()
 
@@ -384,8 +397,7 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
                 spaceProfileData = spaceInfo
             }
         case .chat(let data):
-            // Chat-type spaces already have SpaceChatCoordinatorData as home screen.
-            // Match by spaceId to avoid pushing a duplicate chat screen.
+            // 1-1 spaces: home screen is SpaceChatCoordinatorData (chatId resolved at view time).
             if let existingData = currentPath.path.lazy.compactMap({ $0.base as? SpaceChatCoordinatorData }).first(where: { $0.spaceId == data.spaceId }) {
                 currentPath.popTo(existingData)
                 if data.messageId != nil {
@@ -395,11 +407,32 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
                     navigationPath = currentPath
                     return
                 }
+            // Channel/stream spaces: home screen is ChatCoordinatorData (chatId known at build time).
+            // Match by chatId because multiple chats can exist in one space.
+            // Channel/stream spaces: home screen is ChatCoordinatorData (chatId known at build time).
+            // Match by chatId because multiple chats can exist in one space.
+            } else if let existingChat = currentPath.path.lazy.compactMap({ $0.base as? ChatCoordinatorData }).first(where: { $0.chatId == data.chatId }) {
+                currentPath.popTo(existingChat)
+                if let messageId = data.messageId {
+                    if isSwitchingSpace {
+                        // Chat is being created fresh — include messageId in path data
+                        currentPath.replaceLast(data)
+                    } else {
+                        // Chat already on screen — scroll via provider without recreating
+                        chatProvider.scrollToMessage(chatId: data.chatId, messageId: messageId)
+                    }
+                }
             } else {
                 currentPath.openOnce(data)
             }
         case .spaceChat(let data):
-            currentPath.openOnce(data)
+            // Homepage refactor may place ChatCoordinatorData (not SpaceChatCoordinatorData)
+            // as home screen. Check for existing ChatCoordinatorData for the same space.
+            if let existingChat = currentPath.path.lazy.compactMap({ $0.base as? ChatCoordinatorData }).first(where: { $0.spaceId == data.spaceId }) {
+                currentPath.popTo(existingChat)
+            } else {
+                currentPath.openOnce(data)
+            }
         case .widget(let data):
             currentPath.openOnce(data)
         case .discussion(let data):

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -409,8 +409,6 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
                 }
             // Channel/stream spaces: home screen is ChatCoordinatorData (chatId known at build time).
             // Match by chatId because multiple chats can exist in one space.
-            // Channel/stream spaces: home screen is ChatCoordinatorData (chatId known at build time).
-            // Match by chatId because multiple chats can exist in one space.
             } else if let existingChat = currentPath.path.lazy.compactMap({ $0.base as? ChatCoordinatorData }).first(where: { $0.chatId == data.chatId }) {
                 currentPath.popTo(existingChat)
                 if let messageId = data.messageId {

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -400,12 +400,14 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
             // 1-1 spaces: home screen is SpaceChatCoordinatorData (chatId resolved at view time).
             if let existingData = currentPath.path.lazy.compactMap({ $0.base as? SpaceChatCoordinatorData }).first(where: { $0.spaceId == data.spaceId }) {
                 currentPath.popTo(existingData)
-                if data.messageId != nil {
-                    currentPath.replaceLast(SpaceChatCoordinatorData(spaceId: data.spaceId, messageId: data.messageId))
-                    // SpaceChatCoordinatorData.== compares only spaceId (required for
-                    // openOnce dedup), so the guard below won't detect messageId change.
-                    navigationPath = currentPath
-                    return
+                if let messageId = data.messageId {
+                    if isSwitchingSpace {
+                        // Space is being opened fresh — include messageId in path data
+                        currentPath.replaceLast(SpaceChatCoordinatorData(spaceId: data.spaceId, messageId: messageId))
+                    } else {
+                        // Chat already on screen — scroll via provider without recreating
+                        chatProvider.scrollToMessage(chatId: data.chatId, messageId: messageId)
+                    }
                 }
             // Channel/stream spaces: home screen is ChatCoordinatorData (chatId known at build time).
             // Match by chatId because multiple chats can exist in one space.

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
@@ -615,11 +615,7 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
     func didSelectReplyMessage(message: MessageViewData) {
         guard let reply = message.reply else { return }
         AnytypeAnalytics.instance().logClickScrollToReply(chatId: message.chatId)
-        Task {
-            try await chatStorage.loadPagesTo(messageId: reply.id)
-            collectionViewScrollProxy.scrollTo(itemId: reply.id)
-            messageHiglightId = reply.id
-        }
+        scrollToMessage(messageId: reply.id)
     }
     
     func didSelectDeleteMessage(message: MessageViewData) {
@@ -665,7 +661,7 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
 
     func scrollToMessage(messageId: String) {
         Task {
-            try await chatStorage.loadPagesTo(messageId: messageId)
+            try? await chatStorage.loadPagesTo(messageId: messageId)
             collectionViewScrollProxy.scrollTo(itemId: messageId)
             messageHiglightId = messageId
         }

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
@@ -502,7 +502,7 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
     }
     
     func configureProvider(_ provider: Binding<ChatActionProvider>) {
-        provider.wrappedValue.handler = self
+        provider.wrappedValue.register(chatId: chatId, handler: self)
     }
     
     private func handleAttachmentError(_ error: any Error) {
@@ -662,7 +662,15 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
     }
 
     // MARK: - ChatActionProviderHandler
-    
+
+    func scrollToMessage(messageId: String) {
+        Task {
+            try await chatStorage.loadPagesTo(messageId: messageId)
+            collectionViewScrollProxy.scrollTo(itemId: messageId)
+            messageHiglightId = messageId
+        }
+    }
+
     func addAttachment(_ attachment: ChatLinkObject, clearInput needsClearInput: Bool) {
         Task {
             let results = try await searchService.searchObjects(spaceId: attachment.spaceId, objectIds: [attachment.objectId])

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatExternalActionProvider.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatExternalActionProvider.swift
@@ -11,7 +11,7 @@ struct ChatActionProvider {
 
     private var handlers = NSMapTable<NSString, AnyObject>.strongToWeakObjects()
 
-    mutating func register(chatId: String, handler: any ChatActionProviderHandler) {
+    func register(chatId: String, handler: any ChatActionProviderHandler) {
         handlers.setObject(handler as AnyObject, forKey: chatId as NSString)
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatExternalActionProvider.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatExternalActionProvider.swift
@@ -4,15 +4,29 @@ import SwiftUI
 @MainActor
 protocol ChatActionProviderHandler: AnyObject {
     func addAttachment(_ attachment: ChatLinkObject, clearInput: Bool)
+    func scrollToMessage(messageId: String)
 }
 
 struct ChatActionProvider {
-    
-    weak var handler: (any ChatActionProviderHandler)?
-        
+
+    private var handlers = NSMapTable<NSString, AnyObject>.strongToWeakObjects()
+
+    mutating func register(chatId: String, handler: any ChatActionProviderHandler) {
+        handlers.setObject(handler as AnyObject, forKey: chatId as NSString)
+    }
+
+    private func handler(for chatId: String) -> (any ChatActionProviderHandler)? {
+        handlers.object(forKey: chatId as NSString) as? any ChatActionProviderHandler
+    }
+
     @MainActor
-    func addAttachment(_ attachment: ChatLinkObject, clearInput: Bool) {
-        handler?.addAttachment(attachment, clearInput: clearInput)
+    func addAttachment(chatId: String, _ attachment: ChatLinkObject, clearInput: Bool) {
+        handler(for: chatId)?.addAttachment(attachment, clearInput: clearInput)
+    }
+
+    @MainActor
+    func scrollToMessage(chatId: String, messageId: String) {
+        handler(for: chatId)?.scrollToMessage(messageId: messageId)
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -597,13 +597,9 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     }
 
     func didSelectReplyMessage(message: MessageViewData) {
-        guard let reply = message.reply, let chatStorage else { return }
+        guard let reply = message.reply else { return }
         AnytypeAnalytics.instance().logClickScrollToReply(chatId: message.chatId)
-        Task {
-            try await chatStorage.loadPagesTo(messageId: reply.id)
-            collectionViewScrollProxy.scrollTo(itemId: reply.id)
-            messageHiglightId = reply.id
-        }
+        scrollToMessage(messageId: reply.id)
     }
 
     func didSelectDeleteMessage(message: MessageViewData) {
@@ -652,9 +648,9 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     // MARK: - ChatActionProviderHandler
 
     func scrollToMessage(messageId: String) {
-        guard chatStorage != nil else { return }
+        guard let chatStorage else { return }
         Task {
-            try await chatStorage?.loadPagesTo(messageId: messageId)
+            try? await chatStorage.loadPagesTo(messageId: messageId)
             collectionViewScrollProxy.scrollTo(itemId: messageId)
             messageHiglightId = messageId
         }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -507,7 +507,8 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     }
 
     func configureProvider(_ provider: Binding<ChatActionProvider>) {
-        provider.wrappedValue.handler = self
+        guard let chatId else { return }
+        provider.wrappedValue.register(chatId: chatId, handler: self)
     }
 
     private func handleAttachmentError(_ error: any Error) {
@@ -649,6 +650,15 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     }
 
     // MARK: - ChatActionProviderHandler
+
+    func scrollToMessage(messageId: String) {
+        guard chatStorage != nil else { return }
+        Task {
+            try await chatStorage?.loadPagesTo(messageId: messageId)
+            collectionViewScrollProxy.scrollTo(itemId: messageId)
+            messageHiglightId = messageId
+        }
+    }
 
     func addAttachment(_ attachment: ChatLinkObject, clearInput needsClearInput: Bool) {
         Task {


### PR DESCRIPTION
## Summary
- Fix duplicate chat push when navigating via deep link to a chat message in channel/stream spaces. After the homepage refactor (IOS-5955/5856), channels use `ChatCoordinatorData` as home screen instead of `SpaceChatCoordinatorData`, causing the dedup logic to miss existing chats in the navigation path.
- Extract `prepareSpacePath` to build navigation path without committing, preventing double `navigationPath` updates that caused `AnytypeNavigationView` to animate a duplicate push.
- Refactor `ChatActionProvider` to use `NSMapTable` with chatId-keyed handlers, enabling targeted `scrollToMessage` calls to existing chat views without screen recreation.