### PR TITLE
IOS-5949 Hide new messages separator in discussions

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -210,7 +210,7 @@ struct DiscussionView: View {
         case .message(let data):
             DiscussionMessageView(data: data, output: model)
         case .unread:
-            ChatMessageUnreadView()
+            EmptyView()
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -749,7 +749,6 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
         let newMessageBlocks = await discussionMessageBuilder.makeMessage(
             messages: messages,
             participants: participants,
-            firstUnreadMessageOrderId: firstUnreadMessageOrderId,
             limits: discussionMessageLimits
         )
         guard newMessageBlocks != mesageBlocks else { return }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
@@ -5,7 +5,6 @@ protocol DiscussionMessageBuilderProtocol: AnyObject, Sendable {
     func makeMessage(
         messages: [FullChatMessage],
         participants: [Participant],
-        firstUnreadMessageOrderId: String?,
         limits: any ChatMessageLimitsProtocol
     ) async -> [MessageSectionData]
 }
@@ -29,7 +28,6 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
     func makeMessage(
         messages: [FullChatMessage],
         participants: [Participant],
-        firstUnreadMessageOrderId: String?,
         limits: any ChatMessageLimitsProtocol
     ) async -> [MessageSectionData] {
 
@@ -50,7 +48,6 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
             let isYourMessage = message.creator == yourProfileIdentity
             let authorParticipant = participants.first { $0.identity == message.creator }
             let position: MessageHorizontalPosition = .left
-            let isUnread = message.orderID == firstUnreadMessageOrderId
 
             let messageModel = MessageViewData(
                 spaceId: spaceId,
@@ -96,11 +93,6 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                 reply: fullMessage.reply
             )
 
-            let unreadItem: MessageSectionItem? = isUnread ? .unread(id: "\(message.id)-unread", messageId: message.id, messageOrderId: message.orderID) : nil
-
-            if let unreadItem {
-                items.append(unreadItem)
-            }
             items.append(.message(messageModel))
         }
 


### PR DESCRIPTION
## Summary

- Remove the "New Messages" unread separator from discussions — discussions don't show the in-list separator, only the scroll-to-bottom counter badge
- Unread tracking, scroll-to-first-unread on open, and mark-as-read on view all remain functional