### PR TITLE
IOS-6013 Replace discussion empty state with empty screen

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorView.swift
@@ -72,9 +72,6 @@ struct DiscussionCoordinatorView: View {
             .sheet(item: $model.spaceShareData) { data in
                 SpaceShareCoordinatorView(data: data)
             }
-            .anytypeSheet(item: $model.qrCodeInviteLink) {
-                QrCodeView(title: Loc.joinSpace, data: $0.absoluteString, analyticsType: .inviteSpace, route: .chat)
-            }
             .onChange(of: model.photosItems) {
                 model.photosPickerFinished()
             }

--- a/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorViewModel.swift
@@ -39,7 +39,6 @@ final class DiscussionCoordinatorViewModel: DiscussionModuleOutput, ObjectSettin
     var cameraData: SimpleCameraData?
     var newLinkedObject: EditorScreenData?
     var spaceShareData: SpaceShareData?
-    var qrCodeInviteLink: URL?
     var dismiss = false
 
     @ObservationIgnored
@@ -111,14 +110,6 @@ final class DiscussionCoordinatorViewModel: DiscussionModuleOutput, ObjectSettin
 
     func fileImporterFinished(result: Result<[URL], any Error>) {
         filesPickerData?.handler(result)
-    }
-
-    func onInviteLinkSelected() {
-        spaceShareData = SpaceShareData(spaceId: spaceId, route: .chat)
-    }
-
-    func onShowQrCodeSelected(url: URL) {
-        qrCodeInviteLink = url
     }
 
     func onPushNotificationsAlertSelected() {

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionModuleOutput.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionModuleOutput.swift
@@ -12,8 +12,6 @@ protocol DiscussionModuleOutput: AnyObject {
     func onFilePickerSelected(data: FilesPickerData)
     func onShowCameraSelected(data: SimpleCameraData)
     func onUrlSelected(url: URL)
-    func onInviteLinkSelected()
-    func onShowQrCodeSelected(url: URL)
     func onPushNotificationsAlertSelected()
     func didSelectCreateObject(type: ObjectType)
     func didCreateDiscussion(discussionId: String)

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -149,19 +149,7 @@ struct DiscussionView: View {
     }
 
     private var emptyView: some View {
-        ConversationEmptyStateView(
-            spaceUxType: model.spaceUxType,
-            participantPermissions: model.participantPermissions,
-            addMembersAction: {
-                model.onTapInviteLink()
-            },
-            qrCodeAction: model.qrCodeInviteUrl != nil ? {
-                model.onTapShowQrCode()
-            } : nil
-        )
-        .task {
-            await model.updateInviteState()
-        }
+        Spacer()
     }
 
     private var actionView: some View {

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -54,10 +54,6 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     private var pushNotificationsAlertHandler: any PushNotificationsAlertHandlerProtocol
     @Injected(\.notificationsCenterService) @ObservationIgnored
     private var notificationsCenterService: any NotificationsCenterServiceProtocol
-    @Injected(\.workspaceService) @ObservationIgnored
-    private var workspaceService: any WorkspaceServiceProtocol
-    @Injected(\.universalLinkParser) @ObservationIgnored
-    private var universalLinkParser: any UniversalLinkParserProtocol
     @Injected(\.shareSuggestionService) @ObservationIgnored
     private var shareSuggestionService: any ShareSuggestionServiceProtocol
     @Injected(\.deepLinkParser) @ObservationIgnored
@@ -76,7 +72,6 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
 
     var dataLoaded = false
     var canEdit = false
-    var qrCodeInviteUrl: URL?
     @ObservationIgnored
     var keyboardDismiss: KeyboardDismiss?
 
@@ -227,15 +222,6 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
             }
         })
         output?.onShowCameraSelected(data: data)
-    }
-
-    func onTapInviteLink() {
-        output?.onInviteLinkSelected()
-    }
-
-    func onTapShowQrCode() {
-        guard let url = qrCodeInviteUrl else { return }
-        output?.onShowQrCodeSelected(url: url)
     }
 
     func startSubscriptions() async {
@@ -732,15 +718,6 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     private func subscribeOnPhotosItemsTask() async {
         for await photosItemsTask in attachmentHandler.photosItemsTaskPublisher.values {
             self.photosItemsTask = photosItemsTask
-        }
-    }
-
-    func updateInviteState() async {
-        do {
-            let invite = try await workspaceService.getCurrentInvite(spaceId: spaceId)
-            qrCodeInviteUrl = universalLinkParser.createUrl(link: .invite(cid: invite.cid, key: invite.fileKey))
-        } catch {
-            qrCodeInviteUrl = nil
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `ConversationEmptyStateView` in discussions with an empty `Spacer()` to match the updated Figma design (empty screen, no title/features/buttons)
- Remove unused invite-related code: `onTapInviteLink`, `onTapShowQrCode`, `updateInviteState`, `qrCodeInviteUrl`, and their protocol/coordinator counterparts
- Remove unused `workspaceService` and `universalLinkParser` dependencies from `DiscussionViewModel`