### PR TITLE
IOS-6007 Use round icons only for 1-1 chats, unify chat/data behavior

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatView.swift
@@ -154,7 +154,8 @@ struct ChatView: View {
     
     private var emptyView: some View {
         ConversationEmptyStateView(
-            spaceUxType: model.spaceUxType,
+            isStream: model.spaceUxType.isStream,
+            isOneToOne: model.isOneToOneSpace,
             participantPermissions: model.participantPermissions,
             addMembersAction: {
                 model.onTapInviteLink()

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
@@ -134,6 +134,8 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
     @ObservationIgnored
     var showEmptyState: Bool { mesageBlocks.isEmpty && dataLoaded }
     @ObservationIgnored
+    var isOneToOneSpace: Bool { participantSpaceView?.spaceView.isOneToOne ?? false }
+    @ObservationIgnored
     var spaceUxType: SpaceUxType { participantSpaceView?.spaceView.uxType ?? .data }
     @ObservationIgnored
     var participantPermissions: ParticipantPermissions? { participantSpaceView?.participant?.permission }
@@ -366,7 +368,7 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
     }
     
     func updateMentionState() async throws {
-        guard spaceUxType.supportsMentions else {
+        guard !isOneToOneSpace else {
             mentionObjectsModels = []
             return
         }

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/ChatHeader/ChatHeaderViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/ChatHeader/ChatHeaderViewModel.swift
@@ -113,9 +113,9 @@ final class ChatHeaderViewModel {
     private func subscribeOnSpaceView() async {
         for await participantSpaceView in participantSpacesStorage.participantSpaceViewPublisher(spaceId: spaceId).values {
             let spaceView = participantSpaceView.spaceView
-            spaceSupportsMultiChats = spaceView.uxType.supportsMultiChats
+            spaceSupportsMultiChats = !spaceView.isOneToOne
             isMultiChatSpace = spaceSupportsMultiChats
-            isOneToOne = spaceView.uxType.isOneToOne
+            isOneToOne = spaceView.isOneToOne
             oneToOneIdentity = spaceView.oneToOneIdentity
             spaceTitle = spaceView.title
             spaceIcon = spaceView.objectIconImage

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/ConversationEmptyStateView/ConversationEmptyStateView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/ConversationEmptyStateView/ConversationEmptyStateView.swift
@@ -4,26 +4,27 @@ import Services
 
 struct ConversationEmptyStateView: View {
 
-    let spaceUxType: SpaceUxType
+    let isStream: Bool
+    let isOneToOne: Bool
     let participantPermissions: ParticipantPermissions?
     let addMembersAction: (() -> Void)?
     let qrCodeAction: (() -> Void)?
 
     var body: some View {
-        if spaceUxType.isStream {
+        if isStream {
             streamEmptyStateView
         } else {
             chatEmptyStateView
         }
     }
-    
+
     private var chatEmptyStateView: some View {
         switch participantPermissions {
         case .owner:
             emptyStateView(
                 title: Loc.Chat.Empty.title,
-                addMembersAction: spaceUxType.supportsMultiChats ? nil : addMembersAction,
-                qrCodeAction: spaceUxType.supportsMultiChats ? nil : qrCodeAction
+                addMembersAction: isOneToOne ? nil : addMembersAction,
+                qrCodeAction: isOneToOne ? nil : qrCodeAction
             )
         case .writer:
             emptyStateView(

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -150,7 +150,8 @@ struct DiscussionView: View {
 
     private var emptyView: some View {
         ConversationEmptyStateView(
-            spaceUxType: model.spaceUxType,
+            isStream: model.spaceUxType.isStream,
+            isOneToOne: model.isOneToOneSpace,
             participantPermissions: model.participantPermissions,
             addMembersAction: {
                 model.onTapInviteLink()

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -132,6 +132,8 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     @ObservationIgnored
     var showEmptyState: Bool { mesageBlocks.isEmpty && dataLoaded }
     @ObservationIgnored
+    var isOneToOneSpace: Bool { participantSpaceView?.spaceView.isOneToOne ?? false }
+    @ObservationIgnored
     var spaceUxType: SpaceUxType { participantSpaceView?.spaceView.uxType ?? .data }
     @ObservationIgnored
     var participantPermissions: ParticipantPermissions? { participantSpaceView?.participant?.permission }
@@ -378,7 +380,7 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     }
 
     func updateMentionState() async throws {
-        guard spaceUxType.supportsMentions else {
+        guard !isOneToOneSpace else {
             mentionObjectsModels = []
             return
         }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -209,14 +209,14 @@ final class HomeWidgetsViewModel {
     private func startSpaceViewTask() async {
         for await spaceView in workspaceStorage.spaceViewPublisher(spaceId: spaceId).removeDuplicates().values {
             chatWidgetData = spaceView.canShowChatWidget ? SpaceChatWidgetData(spaceId: spaceId, output: output) : nil
-            supportsMultiChats = spaceView.uxType.supportsMultiChats
+            supportsMultiChats = !spaceView.isOneToOne
         }
     }
 
     private func startUnreadChatsTask() async {
         let spaceId = spaceId
         let spaceView = workspaceStorage.spaceView(spaceId: spaceId)
-        guard spaceView?.uxType.supportsMultiChats ?? false else { return }
+        guard !(spaceView?.isOneToOne ?? true) else { return }
 
         let previewsSequence = await chatMessagesPreviewsStorage.previewsSequenceWithEmpty
         let chatsSequence = await chatDetailsStorage.allChatsSequence

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderView.swift
@@ -94,7 +94,7 @@ private struct WidgetsHeaderMenuContent: View {
 
     @ViewBuilder
     private var notificationsMenu: some View {
-        if model.isDataSpace {
+        if model.supportsNotificationModeMenu {
             NotificationModeMenu(
                 currentMode: model.currentNotificationMode,
                 onModeChange: { await model.onNotificationModeChanged($0) }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderViewModel.swift
@@ -50,11 +50,11 @@ final class WidgetsHeaderViewModel {
     }
 
     var isOneToOneSpace: Bool {
-        spaceView?.uxType.isOneToOne == true
+        spaceView?.isOneToOne == true
     }
 
     var isDataSpace: Bool {
-        spaceView?.uxType.isData == true
+        !(spaceView?.isOneToOne ?? true)
     }
 
     var hasInviteLink: Bool {
@@ -107,7 +107,7 @@ final class WidgetsHeaderViewModel {
             inviteLink = nil
             return
         }
-        guard let spaceView, !spaceView.uxType.isOneToOne else {
+        guard let spaceView, !spaceView.isOneToOne else {
             inviteLink = nil
             return
         }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderViewModel.swift
@@ -53,7 +53,7 @@ final class WidgetsHeaderViewModel {
         spaceView?.isOneToOne == true
     }
 
-    var isDataSpace: Bool {
+    var supportsNotificationModeMenu: Bool {
         !(spaceView?.isOneToOne ?? true)
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Subviews/SpaceInfoView/SpaceInfoViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Subviews/SpaceInfoView/SpaceInfoViewModel.swift
@@ -58,7 +58,7 @@ final class SpaceInfoViewModel {
             spaceName = space.title
             spaceIcon = space.objectIconImage
             sharedSpace = space.isShared
-            isOneToOne = space.uxType.isOneToOne
+            isOneToOne = space.isOneToOne
             oneToOneIdentity = space.oneToOneIdentity
             updateOneToOneParticipant()
         }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
@@ -51,26 +51,28 @@ enum SpacePreviewCountersBuilder {
         var hasHighlightedMention = false
         var hasHighlightedReaction = false
 
+        let supportsMentions = !spaceView.isOneToOne
+
         for preview in previews {
             let effectiveMode = spaceView.effectiveNotificationMode(for: preview.chatId)
 
-            if FeatureFlags.muteAndHide && spaceView.uxType.supportsMultiChats {
+            if FeatureFlags.muteAndHide && !spaceView.isOneToOne {
                 switch effectiveMode {
                 case .all, .mentions, .UNRECOGNIZED:
                     totalUnread += preview.unreadCounter
                     // TODO: IOS-5561 - Temporary client-side fix. Should be handled by middleware.
-                    if spaceView.uxType.supportsMentions {
+                    if supportsMentions {
                         totalMentions += preview.mentionCounter
                     }
                 case .nothing:
-                    if spaceView.uxType.supportsMentions {
+                    if supportsMentions {
                         totalMentions += preview.mentionCounter
                     }
                 }
             } else {
                 totalUnread += preview.unreadCounter
                 // TODO: IOS-5561 - Temporary client-side fix. Should be handled by middleware.
-                if spaceView.uxType.supportsMentions {
+                if supportsMentions {
                     totalMentions += preview.mentionCounter
                 }
             }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -92,7 +92,7 @@ final class SpaceHubViewModel {
         guard let spaceView = spaces?.first(where: { $0.spaceView.id == spaceViewId })?.spaceView else { return }
         spaceMuteData = SpaceMuteData(
             spaceId: spaceView.targetSpaceId,
-            mode: spaceView.pushNotificationMode.toggled(isOneToOne: spaceView.uxType.isOneToOne)
+            mode: spaceView.pushNotificationMode.toggled(isOneToOne: spaceView.isOneToOne)
         )
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/SpaceCardModelBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/SpaceCardModelBuilder.swift
@@ -64,7 +64,7 @@ final class SpaceCardModelBuilder: SpaceCardModelBuilderProtocol, Sendable {
         }
 
         let multichatCompactPreview: String?
-        if spaceView.uxType.supportsMultiChats {
+        if !spaceView.isOneToOne {
             multichatCompactPreview = await buildMultichatCompactPreview(unreadPreviews: spaceData.unreadPreviews)
         } else {
             multichatCompactPreview = nil
@@ -82,8 +82,8 @@ final class SpaceCardModelBuilder: SpaceCardModelBuilderProtocol, Sendable {
             canBeDeleted: spaceData.space.canBeDeleted,
             canLeave: spaceData.space.canLeave,
             uxTypeName: spaceView.uxType.name,
-            supportsMultiChats: spaceView.uxType.supportsMultiChats,
-            isOneToOne: spaceView.uxType.isOneToOne,
+            supportsMultiChats: !spaceView.isOneToOne,
+            isOneToOne: spaceView.isOneToOne,
             currentNotificationMode: spaceView.pushNotificationMode,
             showsMessageAuthor: spaceView.uxType.showsMessageAuthor,
             lastMessage: lastMessage,

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Models/SpaceUxTypeSettingsData.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/Models/SpaceUxTypeSettingsData.swift
@@ -9,9 +9,9 @@ struct SpaceUxTypeSettingsData {
 extension SpaceUxTypeSettingsData {
     init(uxType: SpaceUxType) {
         switch uxType {
-        case .chat, .oneToOne:
+        case .oneToOne:
             icon = .X24.chat
-        case .data, .stream, .none, .UNRECOGNIZED:
+        case .chat, .data, .stream, .none, .UNRECOGNIZED:
             icon = .X24.space
         }
         typaName = uxType.name

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
@@ -347,8 +347,8 @@ final class SpaceSettingsViewModel {
         allowLeave = participantSpaceView.canLeave
         allowRemoteStorage = participantSpaceView.isOwner
         canAddWriters = spaceView.canAddWriters(participants: participants)
-        isOneToOne = spaceView.uxType.isOneToOne
-        showNotificationsSection = spaceView.uxType.supportsMultiChats
+        isOneToOne = spaceView.isOneToOne
+        showNotificationsSection = !spaceView.isOneToOne
 
         uxTypeSettingsData = participantSpaceView.canChangeUxType && spaceView.hasChat && FeatureFlags.channelTypeSwitcher ? SpaceUxTypeSettingsData(uxType: spaceView.uxType) : nil
 
@@ -408,7 +408,7 @@ final class SpaceSettingsViewModel {
     private func updateInviteIfNeeded() async throws {
         guard let participantSpaceView else { return }
         guard shareSection.isSharingAvailable else { return }
-        guard !participantSpaceView.spaceView.uxType.isOneToOne else { return }
+        guard !participantSpaceView.spaceView.isOneToOne else { return }
         
         if participantSpaceView.spaceView.uxType.isStream {
             let invite = try? await workspaceService.getGuestInvite(spaceId: workspaceInfo.accountSpaceId)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/Models/ObjectMenuSectionType.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/Models/ObjectMenuSectionType.swift
@@ -22,7 +22,7 @@ extension ObjectMenuSectionType {
         }
     }
 
-    static func section(for action: ObjectAction, isChat: Bool) -> ObjectMenuSectionType {
+    static func section(for action: ObjectAction) -> ObjectMenuSectionType {
         switch action {
         case .editInfo:
             return .horizontal

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/Models/ObjectMenuSectionType.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/Models/ObjectMenuSectionType.swift
@@ -27,7 +27,7 @@ extension ObjectMenuSectionType {
         case .editInfo:
             return .horizontal
         case .pin:
-            return isChat ? .horizontal : .mainSettings
+            return .mainSettings
         case .undoRedo, .copyLink, .inviteMembers:
             return .mainSettings
         case .linkItself, .locked, .makeAsTemplate:

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/ObjectMenuBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/ObjectMenuBuilder.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 struct ObjectMenuBuilder {
-    static func buildMenu(settings: [ObjectSetting], actions: [ObjectAction], isChat: Bool) -> ObjectMenuConfiguration {
+    static func buildMenu(settings: [ObjectSetting], actions: [ObjectAction]) -> ObjectMenuConfiguration {
         let allItems = settings.map { (ObjectMenuSectionType.section(for: $0), ObjectMenuItem.setting($0)) } +
-                       actions.map { (ObjectMenuSectionType.section(for: $0, isChat: isChat), ObjectMenuItem.action($0)) }
+                       actions.map { (ObjectMenuSectionType.section(for: $0), ObjectMenuItem.action($0)) }
         let grouped = Dictionary(grouping: allItems, by: { $0.0 })
 
         var sections: [ObjectMenuSection] = []

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/ObjectSettingsMenuViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/ObjectSettingsMenuViewModel.swift
@@ -87,8 +87,7 @@ final class ObjectSettingsMenuViewModel {
     private func rebuildMenu() {
         menuConfig = ObjectMenuBuilder.buildMenu(
             settings: viewModel.settings,
-            actions: viewModel.objectActions,
-            isChat: viewModel.isChat
+            actions: viewModel.objectActions
         )
     }
 

--- a/Anytype/Sources/ServiceLayer/ShareSuggestionService/ShareSuggestionService.swift
+++ b/Anytype/Sources/ServiceLayer/ShareSuggestionService/ShareSuggestionService.swift
@@ -50,12 +50,11 @@ final class ShareSuggestionService: ShareSuggestionServiceProtocol, Sendable {
     }
     
     private func displayIcon(spaceView: SpaceView, chatDetails: ObjectDetails) async -> INImage? {
-        switch spaceView.uxType {
-        case .chat, .oneToOne:
+        if spaceView.isOneToOne {
             return spaceIconStorage.iconLocalUrl(forSpaceId: spaceView.targetSpaceId)
                 .flatMap { try? Data(contentsOf: $0) }
                 .flatMap { INImage(imageData: $0) }
-        case .data, .stream, .none, .UNRECOGNIZED:
+        } else {
             guard let url = chatDetails.objectIcon?.imageId
                 .flatMap({ ImageMetadata(id: $0, side: .width(50)).contentUrl }) else { return nil }
             return await AnytypeImageDownloader.retrieveImage(with: url)
@@ -63,21 +62,19 @@ final class ShareSuggestionService: ShareSuggestionServiceProtocol, Sendable {
                 .flatMap { INImage(imageData: $0) }
         }
     }
-    
+
     private func displayName(spaceView: SpaceView, chatDetails: ObjectDetails) -> String {
-        switch spaceView.uxType {
-        case .chat, .oneToOne:
+        if spaceView.isOneToOne {
             return spaceView.title
-        case .data, .stream, .none, .UNRECOGNIZED:
+        } else {
             return chatDetails.name
         }
     }
 
     private func conversationIdentifier(spaceView: SpaceView, chatDetails: ObjectDetails) -> String? {
-        switch spaceView.uxType {
-        case .chat, .oneToOne:
+        if spaceView.isOneToOne {
             ConversationIdentifier(spaceId: spaceView.targetSpaceId, chatId: nil).encoded()
-        case .data, .stream, .none, .UNRECOGNIZED:
+        } else {
             ConversationIdentifier(spaceId: spaceView.targetSpaceId, chatId: chatDetails.id).encoded()
         }
     }

--- a/AnytypeNotificationServiceExtension/NotificationService.swift
+++ b/AnytypeNotificationServiceExtension/NotificationService.swift
@@ -110,7 +110,7 @@ extension DecryptedPushContent {
     }
 
     var supportsMultiChats: Bool {
-        spaceUxType == SpaceUxTypeValue.data
+        !isOneToOne
     }
 }
 

--- a/Modules/Services/Sources/Models/Details/ObjectIconBuilder.swift
+++ b/Modules/Services/Sources/Models/Details/ObjectIconBuilder.swift
@@ -52,7 +52,7 @@ public final class ObjectIconBuilder: ObjectIconBuilderProtocol {
         case .bookmark:
             return bookmarkIcon(iconImage: relations.iconImage)
         case .space, .spaceView:
-            return spaceIcon(iconImage: relations.iconImage, iconOption: relations.iconOption, objectName: relations.objectName, circular: !relations.spaceUxTypeValue.supportsMultiChats)
+            return spaceIcon(iconImage: relations.iconImage, iconOption: relations.iconOption, objectName: relations.objectName, circular: relations.spaceTypeValue == .oneToOne)
         case .objectType:
             return objectTypeIcon(customIcon: relations.customIcon, customIconColor: relations.customIconColor, iconImage: relations.iconImage, iconEmoji: relations.iconEmoji)
         case .discussion:


### PR DESCRIPTION
## Summary
- Round space icons are now used only for 1-1 direct messages; all other channels use square icons
- Unified behavioral differences between former chat and data spaces: notification controls, message previews, multi-chat previews, share suggestions, pin action placement, and space settings icons now treat all regular spaces identically
- Migrated SpaceUxType-based branching to SpaceType-based checks (`isOneToOne`) across 18 UI/behavioral files