### PR TITLE
IOS-6015 Dismiss homepage picker on both Create and Later paths

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
@@ -63,11 +63,9 @@ final class HomeWidgetsCoordinatorViewModel: HomeWidgetsModuleOutput, SetObjectC
 
     func onHomepagePickerFinished(result: HomepagePickerResult) {
         showHomepagePicker = false
+        onboardingStorage.setHomepagePickerDismissed(spaceId: spaceInfo.accountSpaceId)
 
-        if case .later = result {
-            onboardingStorage.setHomepagePickerDismissed(spaceId: spaceInfo.accountSpaceId)
-            return
-        }
+        if case .later = result { return }
 
         guard case .homepageSet(let value) = result, case .object(let details) = value else { return }
         pageNavigation?.open(details.screenData())


### PR DESCRIPTION
## Summary
- Fixed homepage picker re-appearing after user selects a homepage option (Create) and navigates back
- Moved `setHomepagePickerDismissed` before the `.later` early return so it fires for both Create and Later paths
- Previously only the "Later" path persisted the dismissed state, causing the picker to re-show on navigation back