### PR TITLE
IOS-6020 Hide homepage picker and settings for Viewers

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
@@ -39,9 +39,12 @@ final class HomeWidgetsCoordinatorViewModel: HomeWidgetsModuleOutput, SetObjectC
 
     func onAppear() {
         guard FeatureFlags.createChannelFlow else { return }
-        let spaceView = spaceViewsStorage.spaceView(spaceId: spaceInfo.accountSpaceId)
+        let spaceId = spaceInfo.accountSpaceId
+        let canEdit = participantSpacesStorage.participantSpaceView(spaceId: spaceId)?.canEdit ?? false
+        guard canEdit else { return }
+        let spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)
         let homepageNotSet = spaceView?.homepage == .empty
-        let pickerAlreadyDismissed = onboardingStorage.isHomepagePickerDismissed(spaceId: spaceInfo.accountSpaceId)
+        let pickerAlreadyDismissed = onboardingStorage.isHomepagePickerDismissed(spaceId: spaceId)
         if homepageNotSet, !pickerAlreadyDismissed, !showHomepagePicker {
             showHomepagePicker = true
         }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Stub/StubWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Stub/StubWidgetsViewModel.swift
@@ -44,8 +44,7 @@ final class StubWidgetsViewModel {
         async let createHome: () = subscribeToCreateHomeChanges()
         async let inviteMembers: () = subscribeToInviteMembersChanges()
         async let onboarding: () = subscribeToOnboardingChanges()
-        async let permissions: () = subscribeToPermissionChanges()
-        _ = await (createHome, inviteMembers, onboarding, permissions)
+        _ = await (createHome, inviteMembers, onboarding)
     }
 
     // MARK: - Actions
@@ -79,19 +78,15 @@ final class StubWidgetsViewModel {
             onboardingStorage.resetCreateHomeDismissed(spaceId: spaceId)
         }
 
-        for await _ in workspaceStorage.spaceViewPublisher(spaceId: spaceId).removeDuplicates().values {
+        // participantSpaceViewPublisher covers both space view changes (homepage, name, etc.)
+        // and current user's permission changes (viewer/editor promotion/demotion)
+        for await _ in participantSpacesStorage.participantSpaceViewPublisher(spaceId: spaceId).values {
             recalculateShowCreateHome()
         }
     }
 
     private func subscribeToOnboardingChanges() async {
         for await _ in onboardingStorage.didChangePublisher.values {
-            recalculateShowCreateHome()
-        }
-    }
-
-    private func subscribeToPermissionChanges() async {
-        for await _ in participantSpacesStorage.participantSpaceViewPublisher(spaceId: spaceId).values {
             recalculateShowCreateHome()
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Stub/StubWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Stub/StubWidgetsViewModel.swift
@@ -44,7 +44,8 @@ final class StubWidgetsViewModel {
         async let createHome: () = subscribeToCreateHomeChanges()
         async let inviteMembers: () = subscribeToInviteMembersChanges()
         async let onboarding: () = subscribeToOnboardingChanges()
-        _ = await (createHome, inviteMembers, onboarding)
+        async let permissions: () = subscribeToPermissionChanges()
+        _ = await (createHome, inviteMembers, onboarding, permissions)
     }
 
     // MARK: - Actions
@@ -85,6 +86,12 @@ final class StubWidgetsViewModel {
 
     private func subscribeToOnboardingChanges() async {
         for await _ in onboardingStorage.didChangePublisher.values {
+            recalculateShowCreateHome()
+        }
+    }
+
+    private func subscribeToPermissionChanges() async {
+        for await _ in participantSpacesStorage.participantSpaceViewPublisher(spaceId: spaceId).values {
             recalculateShowCreateHome()
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Stub/StubWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Stub/StubWidgetsViewModel.swift
@@ -41,7 +41,7 @@ final class StubWidgetsViewModel {
     // MARK: - Subscriptions
 
     func startSubscriptions() async {
-        async let createHome: () = subscribeToCreateHomeChanges()
+        async let createHome: () = subscribeToSpaceAndPermissionChanges()
         async let inviteMembers: () = subscribeToInviteMembersChanges()
         async let onboarding: () = subscribeToOnboardingChanges()
         _ = await (createHome, inviteMembers, onboarding)
@@ -69,7 +69,7 @@ final class StubWidgetsViewModel {
 
     // MARK: - Private
 
-    private func subscribeToCreateHomeChanges() async {
+    private func subscribeToSpaceAndPermissionChanges() async {
         // If homepage is set, reset the "Create Home" dismissal once on entry.
         // This way, if homepage is later cleared (e.g. object deleted by middleware),
         // the widget will reappear on the next space visit.

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Stub/StubWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Stub/StubWidgetsViewModel.swift
@@ -19,6 +19,8 @@ final class StubWidgetsViewModel {
     private var onboardingStorage: any ChannelOnboardingStorageProtocol
     @Injected(\.pendingShareStorage) @ObservationIgnored
     private var pendingShareStorage: any PendingShareStorageProtocol
+    @Injected(\.participantSpacesStorage) @ObservationIgnored
+    private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
     @ObservationIgnored
     private let participantsSubscription: any ParticipantsSubscriptionProtocol
 
@@ -88,12 +90,14 @@ final class StubWidgetsViewModel {
     }
 
     private func recalculateShowCreateHome() {
+        let canEdit = participantSpacesStorage.participantSpaceView(spaceId: spaceId)?.canEdit ?? false
         let spaceView = workspaceStorage.spaceView(spaceId: spaceId)
         let homepageEmpty = spaceView?.homepage == .empty
         let pickerDismissed = onboardingStorage.isHomepagePickerDismissed(spaceId: spaceId)
         let createHomeDismissed = onboardingStorage.isCreateHomeDismissed(spaceId: spaceId)
 
         showCreateHome = FeatureFlags.createChannelFlow
+            && canEdit
             && homepageEmpty
             && pickerDismissed
             && !createHomeDismissed

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsView.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsView.swift
@@ -317,7 +317,7 @@ struct SpaceSettingsView: View {
     private var preferences: some View {
         SectionHeaderView(title: Loc.preferences)
         SettingsSection {
-            if FeatureFlags.homePage {
+            if FeatureFlags.homePage, model.canEdit {
                 RoundedButton(
                     Loc.SpaceSettings.HomePage.title,
                     decoration: model.homePageState.buttonDecoration

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
@@ -82,6 +82,7 @@ final class SpaceSettingsViewModel {
     var allowDelete = false
     var allowLeave = false
     var allowRemoteStorage = false
+    var canEdit = false
     var uxTypeSettingsData: SpaceUxTypeSettingsData?
     var shareSection: SpaceSettingsShareSection = .personal
     var membershipUpgradeReason: MembershipUpgradeReason?
@@ -343,6 +344,7 @@ final class SpaceSettingsViewModel {
         let spaceView = participantSpaceView.spaceView
 
         spaceIcon = spaceView.objectIconImage
+        canEdit = participantSpaceView.canEdit
         allowDelete = participantSpaceView.canBeDeleted
         allowLeave = participantSpaceView.canLeave
         allowRemoteStorage = participantSpaceView.isOwner


### PR DESCRIPTION
## Summary
- Add `canEdit` permission check before auto-showing the homepage picker on space entry, preventing Viewers from seeing the picker after joining via QR code
- Hide the "Create Home" stub widget for Viewers with a reactive permission subscription
- Hide the "Home" button in Space Settings preferences for Viewers