### PR TITLE
IOS-6018 Update contacts list in Group flow

### DIFF
--- a/AnyTypeTests/Services/ContactsSorterTests.swift
+++ b/AnyTypeTests/Services/ContactsSorterTests.swift
@@ -4,7 +4,7 @@ import Testing
 @Suite
 struct ContactsSorterTests {
 
-    // MARK: - Group 1: Members with shared spaces
+    // MARK: - Space count sorting
 
     @Test func sortBySpaceCountDescending() {
         let contacts = [
@@ -19,22 +19,35 @@ struct ContactsSorterTests {
         #expect(sorted.map(\.identity) == ["b", "c", "a"])
     }
 
-    @Test func sharedSpacesGroupSortsByNameNotGlobalName() {
-        // Within the shared-spaces group, globalName should NOT affect order
+    // MARK: - AnyName sorting
+
+    @Test func globalNameFirstWhenSpaceCountEqual() {
         let contacts = [
-            Contact(identity: "a", name: "Zoe", globalName: "zoe.any", icon: nil),
-            Contact(identity: "b", name: "Alice", globalName: "", icon: nil)
+            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),
+            Contact(identity: "b", name: "Bob", globalName: "bob.any", icon: nil)
         ]
         let spaceCounts = ["a": 2, "b": 2]
 
         let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
 
-        // Alice before Zoe by name, even though Zoe has globalName
         #expect(sorted[0].identity == "b")
-        #expect(sorted[1].identity == "a")
     }
 
-    @Test func sortByNameWhenSpaceCountEqual() {
+    @Test func bothHaveGlobalNameSortsByName() {
+        let contacts = [
+            Contact(identity: "a", name: "Zara", globalName: "zara.any", icon: nil),
+            Contact(identity: "b", name: "Anna", globalName: "anna.any", icon: nil)
+        ]
+        let spaceCounts = ["a": 1, "b": 1]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        #expect(sorted[0].identity == "b") // Anna before Zara
+    }
+
+    // MARK: - Name sorting
+
+    @Test func sortByNameWhenSpaceCountAndGlobalNameEqual() {
         let contacts = [
             Contact(identity: "a", name: "Zoe", globalName: "", icon: nil),
             Contact(identity: "b", name: "Alice", globalName: "", icon: nil),
@@ -47,69 +60,41 @@ struct ContactsSorterTests {
         #expect(sorted.map(\.name) == ["Alice", "Bob", "Zoe"])
     }
 
-    // MARK: - Group 2 & 3: Members with no shared spaces
-
-    @Test func zeroSpacesGlobalNameBeforeNoGlobalName() {
+    @Test func nameSortIsCaseInsensitive() {
         let contacts = [
-            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),
-            Contact(identity: "b", name: "Bob", globalName: "bob.any", icon: nil)
+            Contact(identity: "a", name: "bob", globalName: "", icon: nil),
+            Contact(identity: "b", name: "Alice", globalName: "", icon: nil)
         ]
-        let spaceCounts: [String: Int] = [:]
+        let spaceCounts = ["a": 1, "b": 1]
 
         let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
 
-        #expect(sorted[0].identity == "b") // Bob has globalName
-        #expect(sorted[1].identity == "a")
+        #expect(sorted[0].identity == "b") // "Alice" before "bob"
     }
 
-    @Test func zeroSpacesBothHaveGlobalNameSortsByName() {
+    // MARK: - All criteria combined
+
+    @Test func allCriteriaCombined() {
         let contacts = [
-            Contact(identity: "a", name: "Zara", globalName: "zara.any", icon: nil),
-            Contact(identity: "b", name: "Anna", globalName: "anna.any", icon: nil)
+            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),          // 1 space, no AnyName
+            Contact(identity: "b", name: "Bob", globalName: "bob.any", icon: nil),     // 3 spaces, AnyName
+            Contact(identity: "c", name: "Charlie", globalName: "", icon: nil),         // 3 spaces, no AnyName
+            Contact(identity: "d", name: "Diana", globalName: "diana.any", icon: nil), // 1 space, AnyName
+            Contact(identity: "e", name: "Eve", globalName: "eve.any", icon: nil)      // 1 space, AnyName
         ]
-        let spaceCounts: [String: Int] = [:]
+        let spaceCounts = ["a": 1, "b": 3, "c": 3, "d": 1, "e": 1]
 
         let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
 
-        #expect(sorted[0].identity == "b") // Anna before Zara
-    }
-
-    @Test func zeroSpacesNoGlobalNameSortsByName() {
-        let contacts = [
-            Contact(identity: "a", name: "Zara", globalName: "", icon: nil),
-            Contact(identity: "b", name: "Anna", globalName: "", icon: nil)
-        ]
-        let spaceCounts: [String: Int] = [:]
-
-        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
-
-        #expect(sorted[0].identity == "b") // Anna before Zara
-    }
-
-    // MARK: - All three groups combined
-
-    @Test func allThreeGroupsCombined() {
-        let contacts = [
-            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),          // 0 spaces, no global → group 3
-            Contact(identity: "b", name: "Bob", globalName: "bob.any", icon: nil),     // 2 spaces → group 1
-            Contact(identity: "c", name: "Charlie", globalName: "", icon: nil),         // 2 spaces → group 1
-            Contact(identity: "d", name: "Diana", globalName: "diana.any", icon: nil), // 0 spaces, global → group 2
-            Contact(identity: "e", name: "Eve", globalName: "eve.any", icon: nil),     // 1 space → group 1
-            Contact(identity: "f", name: "Frank", globalName: "", icon: nil)            // 0 spaces, no global → group 3
-        ]
-        let spaceCounts = ["b": 2, "c": 2, "e": 1]
-
-        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
-
-        // Group 1: shared spaces (sorted by count desc, then name)
-        #expect(sorted[0].identity == "b") // 2 spaces, Bob
-        #expect(sorted[1].identity == "c") // 2 spaces, Charlie
-        #expect(sorted[2].identity == "e") // 1 space, Eve
-        // Group 2: 0 spaces + has globalName (sorted by name)
-        #expect(sorted[3].identity == "d") // Diana
-        // Group 3: 0 spaces + no globalName (sorted by name)
-        #expect(sorted[4].identity == "a") // Alice
-        #expect(sorted[5].identity == "f") // Frank
+        // 3 spaces + AnyName: Bob
+        #expect(sorted[0].identity == "b")
+        // 3 spaces + no AnyName: Charlie
+        #expect(sorted[1].identity == "c")
+        // 1 space + AnyName: Diana, Eve (alphabetical)
+        #expect(sorted[2].identity == "d")
+        #expect(sorted[3].identity == "e")
+        // 1 space + no AnyName: Alice
+        #expect(sorted[4].identity == "a")
     }
 
     // MARK: - Edge cases
@@ -138,19 +123,7 @@ struct ContactsSorterTests {
 
         let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
 
-        #expect(sorted[0].identity == "a") // 1 space
-        #expect(sorted[1].identity == "b") // 0 spaces
-    }
-
-    @Test func nameSortIsCaseInsensitive() {
-        let contacts = [
-            Contact(identity: "a", name: "bob", globalName: "", icon: nil),
-            Contact(identity: "b", name: "Alice", globalName: "", icon: nil)
-        ]
-        let spaceCounts = ["a": 1, "b": 1]
-
-        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
-
-        #expect(sorted[0].identity == "b") // "Alice" before "bob"
+        #expect(sorted[0].identity == "a")
+        #expect(sorted[1].identity == "b")
     }
 }

--- a/AnyTypeTests/Services/ContactsSorterTests.swift
+++ b/AnyTypeTests/Services/ContactsSorterTests.swift
@@ -1,0 +1,120 @@
+import Testing
+@testable import Anytype
+
+@Suite
+struct ContactsSorterTests {
+
+    @Test func sortBySpaceCountDescending() {
+        let contacts = [
+            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),
+            Contact(identity: "b", name: "Bob", globalName: "", icon: nil),
+            Contact(identity: "c", name: "Charlie", globalName: "", icon: nil)
+        ]
+        let spaceCounts = ["a": 1, "b": 3, "c": 2]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        #expect(sorted.map(\.identity) == ["b", "c", "a"])
+    }
+
+    @Test func sortByGlobalNamePresenceWhenSpaceCountEqual() {
+        let contacts = [
+            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),
+            Contact(identity: "b", name: "Bob", globalName: "bob.any", icon: nil),
+            Contact(identity: "c", name: "Charlie", globalName: "", icon: nil)
+        ]
+        let spaceCounts = ["a": 2, "b": 2, "c": 2]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        #expect(sorted[0].identity == "b")
+    }
+
+    @Test func sortByNameWhenSpaceCountAndGlobalNameEqual() {
+        let contacts = [
+            Contact(identity: "a", name: "Zoe", globalName: "", icon: nil),
+            Contact(identity: "b", name: "Alice", globalName: "", icon: nil),
+            Contact(identity: "c", name: "Bob", globalName: "", icon: nil)
+        ]
+        let spaceCounts = ["a": 1, "b": 1, "c": 1]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        #expect(sorted.map(\.name) == ["Alice", "Bob", "Zoe"])
+    }
+
+    @Test func allThreeCriteriaCombined() {
+        let contacts = [
+            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),        // 1 space, no global
+            Contact(identity: "b", name: "Bob", globalName: "bob.any", icon: nil),   // 2 spaces, global
+            Contact(identity: "c", name: "Charlie", globalName: "", icon: nil),       // 2 spaces, no global
+            Contact(identity: "d", name: "Diana", globalName: "diana.any", icon: nil),// 2 spaces, global
+            Contact(identity: "e", name: "Eve", globalName: "eve.any", icon: nil)     // 1 space, global
+        ]
+        let spaceCounts = ["a": 1, "b": 2, "c": 2, "d": 2, "e": 1]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        // 2 spaces + global name: Bob, Diana (alphabetical)
+        #expect(sorted[0].identity == "b")
+        #expect(sorted[1].identity == "d")
+        // 2 spaces + no global name: Charlie
+        #expect(sorted[2].identity == "c")
+        // 1 space + global name: Eve
+        #expect(sorted[3].identity == "e")
+        // 1 space + no global name: Alice
+        #expect(sorted[4].identity == "a")
+    }
+
+    @Test func emptyContactsReturnsEmpty() {
+        let sorted = ContactsSorter.sorted([], spaceCounts: [:])
+
+        #expect(sorted.isEmpty)
+    }
+
+    @Test func singleContactReturnsSame() {
+        let contacts = [Contact(identity: "a", name: "Alice", globalName: "alice.any", icon: nil)]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: ["a": 1])
+
+        #expect(sorted.count == 1)
+        #expect(sorted[0].identity == "a")
+    }
+
+    @Test func missingSpaceCountTreatedAsZero() {
+        let contacts = [
+            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),
+            Contact(identity: "b", name: "Bob", globalName: "", icon: nil)
+        ]
+        let spaceCounts = ["a": 1] // "b" missing
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        #expect(sorted[0].identity == "a")
+        #expect(sorted[1].identity == "b")
+    }
+
+    @Test func nameSortIsCaseInsensitive() {
+        let contacts = [
+            Contact(identity: "a", name: "bob", globalName: "", icon: nil),
+            Contact(identity: "b", name: "Alice", globalName: "", icon: nil)
+        ]
+        let spaceCounts = ["a": 1, "b": 1]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        #expect(sorted[0].identity == "b") // "Alice" before "bob"
+    }
+
+    @Test func bothHaveGlobalNameSortsByName() {
+        let contacts = [
+            Contact(identity: "a", name: "Zara", globalName: "zara.any", icon: nil),
+            Contact(identity: "b", name: "Anna", globalName: "anna.any", icon: nil)
+        ]
+        let spaceCounts = ["a": 1, "b": 1]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        #expect(sorted[0].identity == "b") // Anna before Zara
+    }
+}

--- a/AnyTypeTests/Services/ContactsSorterTests.swift
+++ b/AnyTypeTests/Services/ContactsSorterTests.swift
@@ -4,6 +4,8 @@ import Testing
 @Suite
 struct ContactsSorterTests {
 
+    // MARK: - Group 1: Members with shared spaces
+
     @Test func sortBySpaceCountDescending() {
         let contacts = [
             Contact(identity: "a", name: "Alice", globalName: "", icon: nil),
@@ -17,20 +19,22 @@ struct ContactsSorterTests {
         #expect(sorted.map(\.identity) == ["b", "c", "a"])
     }
 
-    @Test func sortByGlobalNamePresenceWhenSpaceCountEqual() {
+    @Test func sharedSpacesGroupSortsByNameNotGlobalName() {
+        // Within the shared-spaces group, globalName should NOT affect order
         let contacts = [
-            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),
-            Contact(identity: "b", name: "Bob", globalName: "bob.any", icon: nil),
-            Contact(identity: "c", name: "Charlie", globalName: "", icon: nil)
+            Contact(identity: "a", name: "Zoe", globalName: "zoe.any", icon: nil),
+            Contact(identity: "b", name: "Alice", globalName: "", icon: nil)
         ]
-        let spaceCounts = ["a": 2, "b": 2, "c": 2]
+        let spaceCounts = ["a": 2, "b": 2]
 
         let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
 
+        // Alice before Zoe by name, even though Zoe has globalName
         #expect(sorted[0].identity == "b")
+        #expect(sorted[1].identity == "a")
     }
 
-    @Test func sortByNameWhenSpaceCountAndGlobalNameEqual() {
+    @Test func sortByNameWhenSpaceCountEqual() {
         let contacts = [
             Contact(identity: "a", name: "Zoe", globalName: "", icon: nil),
             Contact(identity: "b", name: "Alice", globalName: "", icon: nil),
@@ -43,28 +47,72 @@ struct ContactsSorterTests {
         #expect(sorted.map(\.name) == ["Alice", "Bob", "Zoe"])
     }
 
-    @Test func allThreeCriteriaCombined() {
+    // MARK: - Group 2 & 3: Members with no shared spaces
+
+    @Test func zeroSpacesGlobalNameBeforeNoGlobalName() {
         let contacts = [
-            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),        // 1 space, no global
-            Contact(identity: "b", name: "Bob", globalName: "bob.any", icon: nil),   // 2 spaces, global
-            Contact(identity: "c", name: "Charlie", globalName: "", icon: nil),       // 2 spaces, no global
-            Contact(identity: "d", name: "Diana", globalName: "diana.any", icon: nil),// 2 spaces, global
-            Contact(identity: "e", name: "Eve", globalName: "eve.any", icon: nil)     // 1 space, global
+            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),
+            Contact(identity: "b", name: "Bob", globalName: "bob.any", icon: nil)
         ]
-        let spaceCounts = ["a": 1, "b": 2, "c": 2, "d": 2, "e": 1]
+        let spaceCounts: [String: Int] = [:]
 
         let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
 
-        // 2 spaces + global name: Bob, Diana (alphabetical)
-        #expect(sorted[0].identity == "b")
-        #expect(sorted[1].identity == "d")
-        // 2 spaces + no global name: Charlie
-        #expect(sorted[2].identity == "c")
-        // 1 space + global name: Eve
-        #expect(sorted[3].identity == "e")
-        // 1 space + no global name: Alice
-        #expect(sorted[4].identity == "a")
+        #expect(sorted[0].identity == "b") // Bob has globalName
+        #expect(sorted[1].identity == "a")
     }
+
+    @Test func zeroSpacesBothHaveGlobalNameSortsByName() {
+        let contacts = [
+            Contact(identity: "a", name: "Zara", globalName: "zara.any", icon: nil),
+            Contact(identity: "b", name: "Anna", globalName: "anna.any", icon: nil)
+        ]
+        let spaceCounts: [String: Int] = [:]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        #expect(sorted[0].identity == "b") // Anna before Zara
+    }
+
+    @Test func zeroSpacesNoGlobalNameSortsByName() {
+        let contacts = [
+            Contact(identity: "a", name: "Zara", globalName: "", icon: nil),
+            Contact(identity: "b", name: "Anna", globalName: "", icon: nil)
+        ]
+        let spaceCounts: [String: Int] = [:]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        #expect(sorted[0].identity == "b") // Anna before Zara
+    }
+
+    // MARK: - All three groups combined
+
+    @Test func allThreeGroupsCombined() {
+        let contacts = [
+            Contact(identity: "a", name: "Alice", globalName: "", icon: nil),          // 0 spaces, no global → group 3
+            Contact(identity: "b", name: "Bob", globalName: "bob.any", icon: nil),     // 2 spaces → group 1
+            Contact(identity: "c", name: "Charlie", globalName: "", icon: nil),         // 2 spaces → group 1
+            Contact(identity: "d", name: "Diana", globalName: "diana.any", icon: nil), // 0 spaces, global → group 2
+            Contact(identity: "e", name: "Eve", globalName: "eve.any", icon: nil),     // 1 space → group 1
+            Contact(identity: "f", name: "Frank", globalName: "", icon: nil)            // 0 spaces, no global → group 3
+        ]
+        let spaceCounts = ["b": 2, "c": 2, "e": 1]
+
+        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
+
+        // Group 1: shared spaces (sorted by count desc, then name)
+        #expect(sorted[0].identity == "b") // 2 spaces, Bob
+        #expect(sorted[1].identity == "c") // 2 spaces, Charlie
+        #expect(sorted[2].identity == "e") // 1 space, Eve
+        // Group 2: 0 spaces + has globalName (sorted by name)
+        #expect(sorted[3].identity == "d") // Diana
+        // Group 3: 0 spaces + no globalName (sorted by name)
+        #expect(sorted[4].identity == "a") // Alice
+        #expect(sorted[5].identity == "f") // Frank
+    }
+
+    // MARK: - Edge cases
 
     @Test func emptyContactsReturnsEmpty() {
         let sorted = ContactsSorter.sorted([], spaceCounts: [:])
@@ -86,12 +134,12 @@ struct ContactsSorterTests {
             Contact(identity: "a", name: "Alice", globalName: "", icon: nil),
             Contact(identity: "b", name: "Bob", globalName: "", icon: nil)
         ]
-        let spaceCounts = ["a": 1] // "b" missing
+        let spaceCounts = ["a": 1] // "b" missing → treated as 0
 
         let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
 
-        #expect(sorted[0].identity == "a")
-        #expect(sorted[1].identity == "b")
+        #expect(sorted[0].identity == "a") // 1 space
+        #expect(sorted[1].identity == "b") // 0 spaces
     }
 
     @Test func nameSortIsCaseInsensitive() {
@@ -104,17 +152,5 @@ struct ContactsSorterTests {
         let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
 
         #expect(sorted[0].identity == "b") // "Alice" before "bob"
-    }
-
-    @Test func bothHaveGlobalNameSortsByName() {
-        let contacts = [
-            Contact(identity: "a", name: "Zara", globalName: "zara.any", icon: nil),
-            Contact(identity: "b", name: "Anna", globalName: "anna.any", icon: nil)
-        ]
-        let spaceCounts = ["a": 1, "b": 1]
-
-        let sorted = ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
-
-        #expect(sorted[0].identity == "b") // Anna before Zara
     }
 }

--- a/Anytype/Sources/ServiceLayer/ContactsService/ContactsService.swift
+++ b/Anytype/Sources/ServiceLayer/ContactsService/ContactsService.swift
@@ -8,7 +8,7 @@ protocol ContactsServiceProtocol: Sendable {
 
 actor ContactsService: ContactsServiceProtocol {
 
-    private let spaceViewsStorage: any SpaceViewsStorageProtocol = Container.shared.spaceViewsStorage()
+    private let accountManager: any AccountManagerProtocol = Container.shared.accountManager()
     private let subscriptionStorageProvider: any SubscriptionStorageProviderProtocol = Container.shared.subscriptionStorageProvider()
 
     private var prefetchTask: Task<[Contact], Never>?
@@ -28,27 +28,13 @@ actor ContactsService: ContactsServiceProtocol {
     // MARK: - Private
 
     private func fetchContacts() async -> [Contact] {
-        let oneToOneSpaces = spaceViewsStorage.allSpaceViews.filter {
-            $0.isOneToOne && $0.isActive
-        }
-        guard oneToOneSpaces.isNotEmpty else {
-            prefetchTask = nil
-            return []
-        }
-
-        let identities = oneToOneSpaces.compactMap(\.oneToOneIdentity).filter(\.isNotEmpty)
-        guard identities.isNotEmpty else {
-            prefetchTask = nil
-            return []
-        }
-
         let subId = "ContactsService-\(UUID().uuidString)"
         let subscriptionStorage = subscriptionStorageProvider.createSubscriptionStorage(subId: subId)
 
         let filters: [DataviewFilter] = .builder {
             SearchHelper.layoutFilter([.participant])
             SearchHelper.participantStatusFilter(.active)
-            SearchHelper.identities(identities)
+            SearchHelper.notIdentity(accountManager.account.id)
         }
 
         let searchData: SubscriptionData = .crossSpaceSearch(
@@ -68,14 +54,21 @@ actor ContactsService: ContactsServiceProtocol {
         do {
             try await subscriptionStorage.startOrUpdateSubscription(data: searchData)
 
-            let identitySet = Set(identities)
             var contacts: [Contact] = []
+            var spaceCounts: [String: Int] = [:]
             var seen = Set<String>()
 
             for await state in subscriptionStorage.statePublisher.values {
                 let participants = state.items.compactMap { try? Participant(details: $0) }
+
+                // Count spaces per identity
+                for participant in participants where participant.identity.isNotEmpty {
+                    spaceCounts[participant.identity, default: 0] += 1
+                }
+
+                // Deduplicate by identity
                 for participant in participants {
-                    guard identitySet.contains(participant.identity), !seen.contains(participant.identity) else { continue }
+                    guard participant.identity.isNotEmpty, !seen.contains(participant.identity) else { continue }
                     seen.insert(participant.identity)
                     contacts.append(Contact(
                         identity: participant.identity,
@@ -87,7 +80,7 @@ actor ContactsService: ContactsServiceProtocol {
                 break
             }
 
-            return contacts.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            return ContactsSorter.sorted(contacts, spaceCounts: spaceCounts)
         } catch {
             return []
         }

--- a/Anytype/Sources/ServiceLayer/ContactsService/ContactsSorter.swift
+++ b/Anytype/Sources/ServiceLayer/ContactsService/ContactsSorter.swift
@@ -2,19 +2,23 @@ import Foundation
 import AnytypeCore
 
 enum ContactsSorter {
-    /// Sorts contacts by:
-    /// 1. Number of shared spaces (descending)
-    /// 2. Has global name (contacts with global name first)
-    /// 3. Name (ascending, case-insensitive)
+    /// Sorts contacts into three priority groups:
+    /// 1. Members with shared spaces — sorted by space count (desc), then name (asc)
+    /// 2. Members with no shared spaces but with AnyName — sorted by name (asc)
+    /// 3. Members with no shared spaces and no AnyName — sorted by name (asc)
     static func sorted(_ contacts: [Contact], spaceCounts: [String: Int]) -> [Contact] {
         contacts.sorted { a, b in
             let countA = spaceCounts[a.identity] ?? 0
             let countB = spaceCounts[b.identity] ?? 0
+
             if countA != countB { return countA > countB }
 
-            let aHasGlobalName = a.globalName.isNotEmpty
-            let bHasGlobalName = b.globalName.isNotEmpty
-            if aHasGlobalName != bHasGlobalName { return aHasGlobalName }
+            // AnyName priority only applies within the 0-spaces group
+            if countA == 0 {
+                let aHasGlobalName = a.globalName.isNotEmpty
+                let bHasGlobalName = b.globalName.isNotEmpty
+                if aHasGlobalName != bHasGlobalName { return aHasGlobalName }
+            }
 
             return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
         }

--- a/Anytype/Sources/ServiceLayer/ContactsService/ContactsSorter.swift
+++ b/Anytype/Sources/ServiceLayer/ContactsService/ContactsSorter.swift
@@ -2,23 +2,19 @@ import Foundation
 import AnytypeCore
 
 enum ContactsSorter {
-    /// Sorts contacts into three priority groups:
-    /// 1. Members with shared spaces — sorted by space count (desc), then name (asc)
-    /// 2. Members with no shared spaces but with AnyName — sorted by name (asc)
-    /// 3. Members with no shared spaces and no AnyName — sorted by name (asc)
+    /// Sorts contacts by:
+    /// 1. Number of shared spaces (descending)
+    /// 2. Has AnyName (contacts with AnyName first)
+    /// 3. Name (ascending, case-insensitive)
     static func sorted(_ contacts: [Contact], spaceCounts: [String: Int]) -> [Contact] {
         contacts.sorted { a, b in
             let countA = spaceCounts[a.identity] ?? 0
             let countB = spaceCounts[b.identity] ?? 0
-
             if countA != countB { return countA > countB }
 
-            // AnyName priority only applies within the 0-spaces group
-            if countA == 0 {
-                let aHasGlobalName = a.globalName.isNotEmpty
-                let bHasGlobalName = b.globalName.isNotEmpty
-                if aHasGlobalName != bHasGlobalName { return aHasGlobalName }
-            }
+            let aHasGlobalName = a.globalName.isNotEmpty
+            let bHasGlobalName = b.globalName.isNotEmpty
+            if aHasGlobalName != bHasGlobalName { return aHasGlobalName }
 
             return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
         }

--- a/Anytype/Sources/ServiceLayer/ContactsService/ContactsSorter.swift
+++ b/Anytype/Sources/ServiceLayer/ContactsService/ContactsSorter.swift
@@ -1,0 +1,22 @@
+import Foundation
+import AnytypeCore
+
+enum ContactsSorter {
+    /// Sorts contacts by:
+    /// 1. Number of shared spaces (descending)
+    /// 2. Has global name (contacts with global name first)
+    /// 3. Name (ascending, case-insensitive)
+    static func sorted(_ contacts: [Contact], spaceCounts: [String: Int]) -> [Contact] {
+        contacts.sorted { a, b in
+            let countA = spaceCounts[a.identity] ?? 0
+            let countB = spaceCounts[b.identity] ?? 0
+            if countA != countB { return countA > countB }
+
+            let aHasGlobalName = a.globalName.isNotEmpty
+            let bHasGlobalName = b.globalName.isNotEmpty
+            if aHasGlobalName != bHasGlobalName { return aHasGlobalName }
+
+            return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
+        }
+    }
+}

--- a/Modules/Services/Sources/Services/SearchService/SearchHelper.swift
+++ b/Modules/Services/Sources/Services/SearchService/SearchHelper.swift
@@ -116,6 +116,14 @@ public class SearchHelper {
         return filter
     }
 
+    public static func notIdentity(_ identityId: String) -> DataviewFilter {
+        var filter = DataviewFilter()
+        filter.condition = .notEqual
+        filter.value = identityId.protobufValue
+        filter.relationKey = BundledPropertyKey.identity.rawValue
+        return filter
+    }
+
     // MARK: - Type Filters
 
     public static func typeFilter(_ typeIds: [String]) -> DataviewFilter {


### PR DESCRIPTION
## Summary
- Updated contacts list in the Group channel creation flow to show all participants from all spaces instead of only one-to-one contacts
- Contacts are now sorted by: number of shared spaces (desc), global name presence, then name (asc) — matching desktop implementation
- Extracted sorting logic into `ContactsSorter` with unit tests