### PR TITLE
IOS-6005 Increase discussion text limit to 8000 characters

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageLimits.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageLimits.swift
@@ -3,6 +3,11 @@ import Factory
 import Services
 import AnytypeCore
 
+enum DiscussionMessageGlobalLimits {
+    static let textLimit = 8000
+    static let textLimitWarning = 7950
+}
+
 final class DiscussionMessageLimits: ChatMessageLimitsProtocol, Sendable {
 
     private struct MessageLimitStorage {
@@ -22,7 +27,7 @@ final class DiscussionMessageLimits: ChatMessageLimitsProtocol, Sendable {
     private let currentDateProvider: any ChatMessageLimitsDateProviderProtocol = Container.shared.chatDateProvider()
 
     var textLimit: Int {
-        ChatMessageGlobalLimits.textLimit
+        DiscussionMessageGlobalLimits.textLimit
     }
 
     var attachmentsLimit: Int {
@@ -30,11 +35,11 @@ final class DiscussionMessageLimits: ChatMessageLimitsProtocol, Sendable {
     }
 
     func textIsLimited(text: NSAttributedString) -> Bool {
-        text.string.count > ChatMessageGlobalLimits.textLimit
+        text.string.count > DiscussionMessageGlobalLimits.textLimit
     }
 
     func textIsWarinig(text: NSAttributedString) -> Bool {
-        text.string.count >= ChatMessageGlobalLimits.textLimitWarning
+        text.string.count >= DiscussionMessageGlobalLimits.textLimitWarning
     }
 
     func canAddReaction(message: ChatMessage, yourProfileIdentity: String) -> Bool {


### PR DESCRIPTION
## Summary
- Add `DiscussionMessageGlobalLimits` with `textLimit = 8000` and `textLimitWarning = 7950`
- Update `DiscussionMessageLimits` to use discussion-specific limits instead of chat limits (4000)