### PR TITLE
IOS-5997 Add embed and divider block rendering in discussions

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/EmbedContentView/EmbedContentView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/EmbedContentView/EmbedContentView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct EmbedContentData {
+struct EmbedContentData: Equatable, Hashable {
     let icon: ImageAsset
     let processorName: String
     let hasContent: Bool

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/ChatMessage+Discussion.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/ChatMessage+Discussion.swift
@@ -8,6 +8,7 @@ extension ChatMessage {
         spaceId: String,
         position: MessageHorizontalPosition,
         textBuilder: any DiscussionTextBuilderProtocol,
+        embedContentDataBuilder: any EmbedContentDataBuilderProtocol,
         attachmentDetails: [String: ObjectDetails] = [:]
     ) -> [DiscussionBlockItem] {
         guard !blocks.isEmpty else {
@@ -28,6 +29,11 @@ extension ChatMessage {
         for (index, block) in blocks.enumerated() {
             switch block.content {
             case .text(let textBlock):
+                if textBlock.text == "---", textBlock.marks.isEmpty {
+                    result.append(.divider(id: index))
+                    continue
+                }
+
                 let content = textBuilder.makeAttributedString(
                     text: textBlock.text,
                     marks: textBlock.marks,
@@ -84,8 +90,12 @@ extension ChatMessage {
                 case .UNRECOGNIZED:
                     result.append(.unsupported(id: index, blockName: "link:unrecognized"))
                 }
-            case .embed:
-                result.append(.unsupported(id: index, blockName: "embed"))
+            case .embed(let embedBlock):
+                var block = BlockLatex()
+                block.text = embedBlock.text
+                block.processor = embedBlock.processor
+                let data = embedContentDataBuilder.build(from: block)
+                result.append(.embed(id: index, data: data))
             case nil:
                 result.append(.unsupported(id: index, blockName: "unknown"))
             }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessageBuilder.swift
@@ -13,6 +13,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
 
     private let accountParticipantsStorage: any ParticipantsStorageProtocol = Container.shared.participantsStorage()
     private let discussionTextBuilder: any DiscussionTextBuilderProtocol = Container.shared.discussionTextBuilder()
+    private let embedContentDataBuilder: any EmbedContentDataBuilderProtocol = Container.shared.embedContentDataBuilder()
     private let openDocumentProvider: any OpenedDocumentsProviderProtocol = Container.shared.openedDocumentProvider()
 
     private let spaceId: String
@@ -61,6 +62,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
                     spaceId: spaceId,
                     position: position,
                     textBuilder: discussionTextBuilder,
+                    embedContentDataBuilder: embedContentDataBuilder,
                     attachmentDetails: Dictionary(fullMessage.attachments.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
                 ),
                 replyModel: mapReply(
@@ -146,7 +148,7 @@ actor DiscussionMessageBuilder: DiscussionMessageBuilderProtocol, Sendable {
             let filesCout = fullMessage.replyAttachments.count(where: \.resolvedLayoutValue.isFile)
 
             let description: String
-            let replyBlocks = replyChat.resolvedDiscussionBlocks(spaceId: spaceId, position: .left, textBuilder: discussionTextBuilder)
+            let replyBlocks = replyChat.resolvedDiscussionBlocks(spaceId: spaceId, position: .left, textBuilder: discussionTextBuilder, embedContentDataBuilder: embedContentDataBuilder)
             let replyPlainText = replyBlocks.plainText
             if replyPlainText.isNotEmpty {
                 description = replyPlainText

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionBlockItem.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionBlockItem.swift
@@ -14,6 +14,8 @@ enum DiscussionBlockItem: Equatable, Hashable, Identifiable {
     case file(id: Int, details: MessageAttachmentDetails)
     case linkObject(id: Int, details: MessageAttachmentDetails)
     case bookmark(id: Int, details: ObjectDetails)
+    case embed(id: Int, data: EmbedContentData)
+    case divider(id: Int)
     case unsupported(id: Int, blockName: String)
 
     var id: Int {
@@ -30,6 +32,8 @@ enum DiscussionBlockItem: Equatable, Hashable, Identifiable {
              .file(let id, _),
              .linkObject(let id, _),
              .bookmark(let id, _),
+             .embed(let id, _),
+             .divider(let id),
              .unsupported(let id, _):
             return id
         }
@@ -46,7 +50,7 @@ enum DiscussionBlockItem: Equatable, Hashable, Identifiable {
              .toggle(_, let content):
             let text = NSAttributedString(content).string
             return text.isEmpty ? nil : text
-        case .image, .video, .file, .linkObject, .bookmark, .unsupported:
+        case .image, .video, .file, .linkObject, .bookmark, .embed, .divider, .unsupported:
             return nil
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionBlockItemView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionBlockItemView.swift
@@ -77,6 +77,13 @@ struct DiscussionBlockItemView: View {
             }
             .buttonStyle(.plain)
             .padding(.vertical, 2)
+        case .embed(_, let data):
+            DiscussionEmbedBlockView(data: data)
+                .padding(.vertical, 2)
+        case .divider:
+            Color.Shape.primary
+                .frame(height: 1)
+                .padding(.vertical, 10)
         case .unsupported(_, let blockName):
             DiscussionUnsupportedBlockView(blockName: blockName)
                 .padding(.vertical, 2)

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionEmbedBlockView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionEmbedBlockView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct DiscussionEmbedBlockView: View {
+
+    @State private var model: EmbedContentViewModel
+
+    var body: some View {
+        EmbedContentView(model: model)
+    }
+
+    init(data: EmbedContentData) {
+        self._model = State(initialValue: EmbedContentViewModel(data: data))
+    }
+}


### PR DESCRIPTION
## Summary
- Replace generic "Unsupported block" placeholder for embed blocks with the editor's `EmbedContentView` showing processor icon, name, and "Open" button
- Detect divider blocks (text "---" with no marks, matching desktop encoding) and render as a 1pt horizontal line
- Add `EmbedContentData: Equatable, Hashable` conformance and inject `EmbedContentDataBuilder` via DI