### PR TITLE
IOS-6012 Remove Stop hook from settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -142,17 +142,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "Evaluate if Claude should stop. Context: $ARGUMENTS\n\nCheck if:\n1. All requested tasks are complete\n2. No test failures mentioned\n3. No TODO items left\n4. User wasn't asking for more\n\nRespond with {\"ok\": true} or {\"ok\": false, \"reason\": \"...\"}",
-            "timeout": 30
-          }
-        ]
-      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Remove the prompt-based Stop hook that ran an extra LLM evaluation on every turn
- The hook added latency/cost overhead and could cause false continuations (e.g., interpreting a question to the user as "unfinished work")
- Claude's built-in agentic loop handles multi-step task completion without needing an external stop gate