### PR TITLE
IOS-6023 Restrict homepage controls to owner + one-on-one handling

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
@@ -40,8 +40,8 @@ final class HomeWidgetsCoordinatorViewModel: HomeWidgetsModuleOutput, SetObjectC
     func onAppear() {
         guard FeatureFlags.createChannelFlow else { return }
         let spaceId = spaceInfo.accountSpaceId
-        let canEdit = participantSpacesStorage.participantSpaceView(spaceId: spaceId)?.canEdit ?? false
-        guard canEdit else { return }
+        let canSetHomepage = participantSpacesStorage.participantSpaceView(spaceId: spaceId)?.canSetHomepage ?? false
+        guard canSetHomepage else { return }
         let spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)
         let homepageNotSet = spaceView?.homepage == .empty
         let pickerAlreadyDismissed = onboardingStorage.isHomepagePickerDismissed(spaceId: spaceId)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Stub/StubWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Stub/StubWidgetsViewModel.swift
@@ -92,14 +92,14 @@ final class StubWidgetsViewModel {
     }
 
     private func recalculateShowCreateHome() {
-        let canEdit = participantSpacesStorage.participantSpaceView(spaceId: spaceId)?.canEdit ?? false
+        let canSetHomepage = participantSpacesStorage.participantSpaceView(spaceId: spaceId)?.canSetHomepage ?? false
         let spaceView = workspaceStorage.spaceView(spaceId: spaceId)
         let homepageEmpty = spaceView?.homepage == .empty
         let pickerDismissed = onboardingStorage.isHomepagePickerDismissed(spaceId: spaceId)
         let createHomeDismissed = onboardingStorage.isCreateHomeDismissed(spaceId: spaceId)
 
         showCreateHome = FeatureFlags.createChannelFlow
-            && canEdit
+            && canSetHomepage
             && homepageEmpty
             && pickerDismissed
             && !createHomeDismissed

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsView.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsView.swift
@@ -317,7 +317,7 @@ struct SpaceSettingsView: View {
     private var preferences: some View {
         SectionHeaderView(title: Loc.preferences)
         SettingsSection {
-            if FeatureFlags.homePage, model.canEdit {
+            if FeatureFlags.homePage, model.canSetHomepage {
                 RoundedButton(
                     Loc.SpaceSettings.HomePage.title,
                     decoration: model.homePageState.buttonDecoration

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
@@ -83,6 +83,7 @@ final class SpaceSettingsViewModel {
     var allowLeave = false
     var allowRemoteStorage = false
     var canEdit = false
+    var canSetHomepage = false
     var uxTypeSettingsData: SpaceUxTypeSettingsData?
     var shareSection: SpaceSettingsShareSection = .personal
     var membershipUpgradeReason: MembershipUpgradeReason?
@@ -345,6 +346,7 @@ final class SpaceSettingsViewModel {
 
         spaceIcon = spaceView.objectIconImage
         canEdit = participantSpaceView.canEdit
+        canSetHomepage = participantSpaceView.canSetHomepage
         allowDelete = participantSpaceView.canBeDeleted
         allowLeave = participantSpaceView.canLeave
         allowRemoteStorage = participantSpaceView.isOwner

--- a/Anytype/Sources/PreviewMocks/Mocks/Models/SpacePermissionsMock.swift
+++ b/Anytype/Sources/PreviewMocks/Mocks/Models/SpacePermissionsMock.swift
@@ -13,7 +13,8 @@ extension SpacePermissions {
             canDeleteLink: Bool.random(),
             canEditPermissions: Bool.random(),
             canApproveRequests: Bool.random(),
-            canChangeUxType: Bool.random()
+            canChangeUxType: Bool.random(),
+            canSetHomepage: Bool.random()
         )
     }
 }

--- a/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/Model/ParticipantSpaceViewData.swift
+++ b/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/Model/ParticipantSpaceViewData.swift
@@ -47,4 +47,8 @@ extension ParticipantSpaceViewData {
     var canChangeUxType: Bool {
         permissions.canChangeUxType
     }
+
+    var canSetHomepage: Bool {
+        permissions.canSetHomepage
+    }
 }

--- a/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/Model/SpacePermissions.swift
+++ b/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/Model/SpacePermissions.swift
@@ -13,6 +13,7 @@ struct SpacePermissions: Equatable, Hashable {
     let canEditPermissions: Bool
     let canApproveRequests: Bool
     let canChangeUxType: Bool
+    let canSetHomepage: Bool
 }
 
 extension SpacePermissions {
@@ -52,5 +53,6 @@ extension SpacePermissions {
         canEditPermissions = isOwner && !isLocalMode
         canApproveRequests = isOwner
         canChangeUxType = isOwner
+        canSetHomepage = isOwner || spaceView.isOneToOne
     }
 }


### PR DESCRIPTION
## Summary

- Add `canSetHomepage` permission (`isOwner || isOneToOne`) to `SpacePermissions`, restricting homepage picker, "Create Home" widget, and Space Settings "Home" field to space owners only in regular channels
- Both participants in one-on-one channels retain full access to homepage controls