### PR TITLE
IOS-6027 Remove auto-copy of recovery phrase on reveal

### DIFF
--- a/Anytype/Sources/PresentationLayer/Auth/Join/Shared/KeyPhraseView/KeyPhraseViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Auth/Join/Shared/KeyPhraseView/KeyPhraseViewModel.swift
@@ -39,18 +39,20 @@ final class KeyPhraseViewModel {
         } else {
             AnytypeAnalytics.instance().logClickOnboarding(step: .phrase, button: .showAndCopy)
             keyShown = true
-            copy()
         }
     }
-    
+
     func onSecondaryButtonTap() {
         AnytypeAnalytics.instance().logClickOnboarding(step: .phrase, button: .checkLater)
         output?.onNext()
     }
-    
+
     func onPhraseTap() {
-        keyShown = true
-        copy()
+        if keyShown {
+            copy()
+        } else {
+            keyShown = true
+        }
     }
     
     func keyPhraseMoreInfo() -> AnyView? {

--- a/Anytype/Sources/PresentationLayer/Settings/KeychainPhraseView/KeychainPhraseView.swift
+++ b/Anytype/Sources/PresentationLayer/Settings/KeychainPhraseView/KeychainPhraseView.swift
@@ -19,7 +19,10 @@ struct KeychainPhraseView: View {
             Spacer.fixedHeight(24)
             SeedPhraseView(model: model)
             Spacer()
-            StandardButton(Loc.Keychain.showAndCopyKey, style: .secondaryLarge) {
+            StandardButton(
+                model.recoveryPhrase != nil ? Loc.Keychain.copyKey : Loc.Keychain.showKey,
+                style: .secondaryLarge
+            ) {
                 model.onSeedViewTap()
             }
             Spacer.fixedHeight(20)

--- a/Anytype/Sources/PresentationLayer/Settings/KeychainPhraseView/KeychainPhraseViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Settings/KeychainPhraseView/KeychainPhraseViewModel.swift
@@ -32,6 +32,8 @@ final class KeychainPhraseViewModel {
         Task {
             if recoveryPhrase.isNil {
                 try await obtainRecoveryPhrase()
+            } else {
+                copyPhrase()
             }
         }
     }
@@ -42,8 +44,6 @@ final class KeychainPhraseViewModel {
         try await localAuthWithContinuation { [weak self] in
             guard let self else { return }
             try obtainSeed()
-            onSuccessfullRecovery()
-            showToast()
         }
     }
     
@@ -63,12 +63,10 @@ final class KeychainPhraseViewModel {
         recoveryPhrase = try seedService.obtainSeed()
     }
     
-    private func onSuccessfullRecovery() {
+    func copyPhrase() {
+        guard let recoveryPhrase else { return }
         UISelectionFeedbackGenerator().selectionChanged()
         UIPasteboard.general.string = recoveryPhrase
-    }
-    
-    private func showToast() {
         toastBarData = ToastBarData(Loc.Keychain.Key.Copy.Toast.title)
         AnytypeAnalytics.instance().logKeychainPhraseCopy(shownInContext)
     }

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -45,7 +45,7 @@ public enum Loc {
             public static let title = Loc.tr("Auth", "Auth.JoinFlow.Key.Button.Saved.Title", fallback: "Next")
           }
           public enum Show {
-            public static let title = Loc.tr("Auth", "Auth.JoinFlow.Key.Button.Show.Title", fallback: "Reveal and copy")
+            public static let title = Loc.tr("Auth", "Auth.JoinFlow.Key.Button.Show.Title", fallback: "Show key")
           }
         }
         public enum ReadMore {
@@ -129,10 +129,11 @@ public enum Loc {
     }
   }
   public enum Keychain {
+    public static let copyKey = Loc.tr("Auth", "Keychain.Copy key", fallback: "Copy key")
     public static let haveYouBackedUpYourKey = Loc.tr("Auth", "Keychain.Have you backed up your key?", fallback: "Have you backed up your key?")
     public static let key = Loc.tr("Auth", "Keychain.Key", fallback: "Key")
     public static let seedPhrasePlaceholder = Loc.tr("Auth", "Keychain.SeedPhrasePlaceholder", fallback: "witch collapse practice feed shame open despair creek road again ice least lake tree young address brain despair")
-    public static let showAndCopyKey = Loc.tr("Auth", "Keychain.Show and copy key", fallback: "Show and copy key")
+    public static let showKey = Loc.tr("Auth", "Keychain.Show key", fallback: "Show key")
     public enum Error {
       public static let dataToStringConversionError = Loc.tr("Auth", "Keychain.Error.Data to String conversion error", fallback: "Data to String conversion error")
       public static let stringToDataConversionError = Loc.tr("Auth", "Keychain.Error.String to Data conversion error", fallback: "String to Data conversion error")

--- a/Modules/Loc/Sources/Loc/Resources/Auth.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/Auth.xcstrings
@@ -1736,7 +1736,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reveal and copy"
+            "value" : "Show key"
           }
         },
         "es" : {
@@ -9770,7 +9770,7 @@
         }
       }
     },
-    "Keychain.Show and copy key" : {
+    "Keychain.Show key" : {
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -9800,7 +9800,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Show and copy key"
+            "value" : "Show key"
           }
         },
         "es" : {
@@ -9921,6 +9921,17 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "顯示並複製密鑰"
+          }
+        }
+      }
+    },
+    "Keychain.Copy key" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy key"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Recovery phrase is no longer automatically copied to clipboard when revealed — prevents potential clipboard leak
- Onboarding: tapping blurred phrase or "Show key" button only reveals; tapping the visible phrase copies it
- Settings: button changes from "Show key" to "Copy key" after reveal; tapping visible phrase also copies