### PR TITLE
IOS-6031 Fix members stuck in pending when adding above tier limit

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
@@ -28,7 +28,7 @@ final class GroupChannelCreateCoordinatorViewModel {
         } else {
             selectMembersData = SelectMembersData(
                 contacts: contacts,
-                writersLimit: sharedSpaceView?.writersLimit,
+                writersLimit: sharedSpaceView?.availableWriterSlots,
                 readersLimit: sharedSpaceView?.readersLimit
             )
         }

--- a/Anytype/Sources/ServiceLayer/PendingShare/PendingShareRetryService.swift
+++ b/Anytype/Sources/ServiceLayer/PendingShare/PendingShareRetryService.swift
@@ -67,10 +67,12 @@ actor PendingShareService: PendingShareServiceProtocol {
         // On retry, writers who were added before a partial failure will be safely skipped.
         if state.identities.isNotEmpty {
             let identityIds = state.identities.map(\.identity)
-            let writersLimit = spaceViewsStorage.spaceView(spaceId: spaceId)?.writersLimit ?? identityIds.count
+            let availableWriterSlots = spaceViewsStorage.spaceView(spaceId: spaceId)?.availableWriterSlots
+                ?? spaceViewsStorage.allSpaceViews.first(where: { $0.isShared })?.availableWriterSlots
+                ?? 0
 
-            let writerIds = Array(identityIds.prefix(writersLimit))
-            let readerIds = Array(identityIds.dropFirst(writersLimit))
+            let writerIds = Array(identityIds.prefix(availableWriterSlots))
+            let readerIds = Array(identityIds.dropFirst(availableWriterSlots))
 
             if writerIds.isNotEmpty {
                 do {

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
@@ -138,6 +138,12 @@ extension SpaceView {
         chatId.isNotEmpty
     }
     
+    /// Available writer slots for new members, accounting for the owner occupying one seat.
+    /// Returns nil when the tier limit is unknown.
+    var availableWriterSlots: Int? {
+        writersLimit.map { max(0, $0 - 1) }
+    }
+
     func canAddWriters(participants: [Participant]) -> Bool {
         guard let writersLimit else { return true }
         return writersLimit > activeWriters(participants: participants)


### PR DESCRIPTION
## Summary

- Add `SpaceView.availableWriterSlots` that subtracts 1 from `writersLimit` to account for the owner occupying a writer seat
- Fix `PendingShareRetryService` to use `availableWriterSlots` with a fallback chain (new space → any shared space → 0) instead of `identityIds.count`, which sent all members as writers and caused middleware rejection when exceeding the tier limit
- Fix `GroupChannelCreateCoordinatorViewModel` to pass `availableWriterSlots` to the SelectMembers screen so the UI reflects actual available editor slots