### PR TITLE
IOS-6030 Fix incorrect backward navigation when creating group with no contacts

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorView.swift
@@ -23,6 +23,11 @@ struct GroupChannelCreateCoordinatorView: View {
             SelectMembersView(contacts: data.contacts, writersLimit: data.writersLimit, readersLimit: data.readersLimit) { selectedMembers in
                 model.onSelectMembersNext(selectedMembers)
             }
+        } else if model.contactsEmpty {
+            SpaceCreateCoordinatorView(
+                data: model.spaceCreateDataWithEmptyContacts,
+                embedInNavigationStack: false
+            )
         } else {
             ProgressView()
         }

--- a/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
@@ -15,17 +15,21 @@ final class GroupChannelCreateCoordinatorViewModel {
 
     var selectMembersData: SelectMembersData?
     var spaceCreateData: SpaceCreateData?
+    var spaceCreateDataWithEmptyContacts: SpaceCreateData {
+        makeSpaceCreateData(contacts: [])
+    }
+    var contactsEmpty = false
 
     // MARK: - Lifecycle
 
     func loadContacts() async {
         let contacts = await contactsService.loadContacts()
-        let sharedSpaceView = spaceViewsStorage.allSpaceViews
-            .first { $0.isActive && $0.isShared }
 
         if contacts.isEmpty {
-            spaceCreateData = SpaceCreateData(spaceUxType: .data, channelType: .group)
+            contactsEmpty = true
         } else {
+            let sharedSpaceView = spaceViewsStorage.allSpaceViews
+                .first { $0.isActive && $0.isShared }
             selectMembersData = SelectMembersData(
                 contacts: contacts,
                 writersLimit: sharedSpaceView?.availableWriterSlots,
@@ -41,6 +45,10 @@ final class GroupChannelCreateCoordinatorViewModel {
         let contacts = selectMembersData?.contacts
             .filter { selectedIdentities.contains($0.identity) }
             .sorted { $0.name.caseInsensitiveCompare($1.name) == .orderedAscending } ?? []
-        spaceCreateData = SpaceCreateData(spaceUxType: .data, selectedContacts: contacts, channelType: .group)
+        spaceCreateData = makeSpaceCreateData(contacts: contacts)
+    }
+    
+    private func makeSpaceCreateData(contacts: [Contact]) -> SpaceCreateData {
+        return SpaceCreateData(spaceUxType: .data, selectedContacts: contacts, channelType: .group)
     }
 }


### PR DESCRIPTION
## Summary
- When creating a group channel with no contacts, the Name & Icon screen was pushed onto the NavigationStack, showing a back button that led to an infinite loading state
- Fixed by rendering the screen as root content instead of a pushed destination when contacts are empty