### PR TITLE
IOS-6041 Fix CI: tolerate libheif post-install warning

### DIFF
--- a/.github/actions/prepare-deps/action.yml
+++ b/.github/actions/prepare-deps/action.yml
@@ -11,3 +11,4 @@ runs:
     - uses: tecolicom/actions-use-homebrew-tools@v1
       with:
         tools: imagemagick libgit2
+      continue-on-error: true

--- a/.github/actions/prepare-deps/action.yml
+++ b/.github/actions/prepare-deps/action.yml
@@ -12,3 +12,6 @@ runs:
       with:
         tools: imagemagick libgit2
       continue-on-error: true
+    - name: Verify tools installed
+      shell: bash
+      run: command -v magick && brew list libgit2 || (echo "Required tools missing" && exit 1)


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the `tecolicom/actions-use-homebrew-tools` step in `prepare-deps` action
- Fixes nightly dev build failure caused by `libheif` post-install (`update-mime-database`) failing on the `macos-26` runner when the Homebrew cache expires
- The post-install warning is harmless — imagemagick installs correctly and badge stamping works fine without MIME type registration