### PR TITLE
IOS-5950 Discussion final polish & feature toggle

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatInternalMessageStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatInternalMessageStorage.swift
@@ -38,7 +38,7 @@ struct ChatInternalMessageStorage: Sendable {
         allMessages.values.first(where: { $0.orderID == orderId })
     }
     
-    mutating func cleaLast(maxCache: Int) {
+    mutating func cleanLast(maxCache: Int) {
         if allMessages.count > maxCache {
             allMessages.removeLast(allMessages.count - maxCache)
         }

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
@@ -140,7 +140,7 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
         let newMessages = try await chatService.getMessages(chatObjectId: chatObjectId, beforeOrderId: first.orderID, limit: Constants.pageSize)
         guard newMessages.isNotEmpty else { return }
         await addNewMessages(messages: newMessages)
-        messages.cleaLast(maxCache: Constants.maxCacheSize)
+        messages.cleanLast(maxCache: Constants.maxCacheSize)
         updateFullMessages()
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
@@ -131,7 +131,7 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
         let newMessages = try await chatService.getMessages(chatObjectId: chatObjectId, beforeOrderId: first.orderID, limit: Constants.pageSize)
         guard newMessages.isNotEmpty else { return }
         await addNewMessages(messages: newMessages)
-        messages.cleaLast(maxCache: Constants.maxCacheSize)
+        messages.cleanLast(maxCache: Constants.maxCacheSize)
         updateFullMessages()
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -92,18 +92,14 @@ private struct HomeBottomNavigationPanelViewInternal: View {
     }
 
     private var discussIsland: some View {
-        HStack(spacing: 20) {
-            Button {
-                model.onTapDiscuss()
-            } label: {
-                Image(systemName: "message")
-                    .foregroundStyle(Color.Control.primary)
-            }
-            .frame(width: 32, height: 32)
+        Button {
+            model.onTapDiscuss()
+        } label: {
+            Image(systemName: "message")
+                .foregroundStyle(Color.Control.primary)
         }
-        .padding(.horizontal, 12)
-        .frame(height: 48)
-        .glassEffectInteractiveIOS26(in: Capsule())
+        .frame(width: 48, height: 48)
+        .glassEffectInteractiveIOS26(in: Circle())
     }
 
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
@@ -219,6 +219,11 @@ final class HomeBottomNavigationPanelViewModel {
     
     private func updateState() {
         guard let participantSpaceView else { return }
+
+        // Skip state update when navigating to discussion — panel will be hidden anyway,
+        // and updating would flicker the discuss button to search during push animation
+        if currentData is DiscussionCoordinatorData { return }
+
         canCreateObject = participantSpaceView.permissions.canEdit
         let isObjectScreen = (currentData as? EditorScreenData)?.objectId != nil
         let hasDiscussion = currentDiscussionId != nil

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -19,8 +19,7 @@ public extension FeatureDescription {
     static let discussionButton = FeatureDescription(
         title: "Discussion button in bottom navigation - IOS-5913",
         category: .productFeature(author: "vova@anytype.io", targetRelease: "18"),
-        defaultValue: false,
-        debugValue: true
+        defaultValue: true
     )
 
     static let qrCodeCircularText = FeatureDescription(


### PR DESCRIPTION
## Summary
- Fix discussion button flickering to search icon during push animation to discussion screen
- Fix discussion button shape from oval (Capsule) to circle matching the search button
- Fix `cleaLast` typo to `cleanLast` in method definition and all callers
- Enable `discussionButton` feature flag by default in all builds