### PR TITLE
IOS-6042 Fix all members added as viewers when creating group channel

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChannelCreate/GroupChannelCreateCoordinatorViewModel.swift
@@ -10,8 +10,8 @@ final class GroupChannelCreateCoordinatorViewModel {
     @Injected(\.contactsService)
     private var contactsService: any ContactsServiceProtocol
     @ObservationIgnored
-    @Injected(\.spaceViewsStorage)
-    private var spaceViewsStorage: any SpaceViewsStorageProtocol
+    @Injected(\.participantSpacesStorage)
+    private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
 
     var selectMembersData: SelectMembersData?
     var spaceCreateData: SpaceCreateData?
@@ -28,8 +28,9 @@ final class GroupChannelCreateCoordinatorViewModel {
         if contacts.isEmpty {
             contactsEmpty = true
         } else {
-            let sharedSpaceView = spaceViewsStorage.allSpaceViews
-                .first { $0.isActive && $0.isShared }
+            let sharedSpaceView = participantSpacesStorage.allParticipantSpaces
+                .first { $0.spaceView.isActive && $0.spaceView.isShared && $0.isOwner }?
+                .spaceView
             selectMembersData = SelectMembersData(
                 contacts: contacts,
                 writersLimit: sharedSpaceView?.availableWriterSlots,

--- a/Anytype/Sources/ServiceLayer/PendingShare/PendingShareRetryService.swift
+++ b/Anytype/Sources/ServiceLayer/PendingShare/PendingShareRetryService.swift
@@ -13,8 +13,8 @@ actor PendingShareService: PendingShareServiceProtocol {
     private var storage: any PendingShareStorageProtocol
     @Injected(\.workspaceService)
     private var workspaceService: any WorkspaceServiceProtocol
-    @Injected(\.spaceViewsStorage)
-    private var spaceViewsStorage: any SpaceViewsStorageProtocol
+    @Injected(\.participantSpacesStorage)
+    private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
 
     private var runningSpaceIds = Set<String>()
 
@@ -67,8 +67,10 @@ actor PendingShareService: PendingShareServiceProtocol {
         // On retry, writers who were added before a partial failure will be safely skipped.
         if state.identities.isNotEmpty {
             let identityIds = state.identities.map(\.identity)
-            let availableWriterSlots = spaceViewsStorage.spaceView(spaceId: spaceId)?.availableWriterSlots
-                ?? spaceViewsStorage.allSpaceViews.first(where: { $0.isShared })?.availableWriterSlots
+            let availableWriterSlots = participantSpacesStorage.participantSpaceView(spaceId: spaceId)?.spaceView.availableWriterSlots
+                ?? participantSpacesStorage.allParticipantSpaces
+                    .first { $0.spaceView.isActive && $0.spaceView.isShared && $0.isOwner }?
+                    .spaceView.availableWriterSlots
                 ?? 0
 
             let writerIds = Array(identityIds.prefix(availableWriterSlots))


### PR DESCRIPTION
## Summary

- Use `participantSpacesStorage` with explicit `isOwner` check when looking up writer/reader limits from existing shared spaces
- Previously the lookup could pick a space where the user is an editor (not owner), returning nil limits which caused all members to fall through to the `?? 0` fallback and be added as readers
- Fixes regression introduced in IOS-6031