### PR TITLE
IOS-6014 Fix discussion screen empty after first comment

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -796,6 +796,14 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
         }
 
         let newChatId = try await chatService.addDiscussion(objectId: objectId)
+        // Update parent object's local details so the bottom panel can find the discussionId
+        // on re-open within the same session (middleware doesn't send this update via events)
+        let parentDoc = openDocumentProvider.document(objectId: objectId, spaceId: spaceId)
+        let updatedDetails = ObjectDetails(
+            id: objectId,
+            values: [BundledPropertyKey.discussionId.rawValue: newChatId.protobufValue]
+        )
+        parentDoc.detailsStorage.amend(details: updatedDetails)
 
         // Initialize deferred dependencies
         self.chatId = newChatId

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
@@ -76,8 +76,12 @@ final class HomeBottomNavigationPanelViewModel {
         }
         let document = documentsProvider.document(objectId: objectId, spaceId: editorData.spaceId)
         let objectName = document.details?.name ?? ""
+        let discussionId = currentDiscussionId ?? {
+            let id = document.details?.discussionId
+            return id?.isEmpty == false ? id : nil
+        }()
         let screenData = ScreenData.discussion(DiscussionCoordinatorData(
-            discussionId: currentDiscussionId,
+            discussionId: discussionId,
             objectId: objectId,
             objectName: objectName,
             spaceId: editorData.spaceId

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
@@ -37,10 +37,6 @@ final class HomeBottomNavigationPanelViewModel {
     private var currentData: AnyHashable?
     @ObservationIgnored
     private var participantSpaceView: ParticipantSpaceViewData?
-    @ObservationIgnored
-    private var currentDiscussionId: String?
-    @ObservationIgnored
-    private var detailsSubscriptionTask: Task<Void, Never>?
 
     // MARK: - Public properties
 
@@ -76,12 +72,9 @@ final class HomeBottomNavigationPanelViewModel {
         }
         let document = documentsProvider.document(objectId: objectId, spaceId: editorData.spaceId)
         let objectName = document.details?.name ?? ""
-        let discussionId = currentDiscussionId ?? {
-            let id = document.details?.discussionId
-            return id?.isEmpty == false ? id : nil
-        }()
+        let discussionId = document.details?.discussionId
         let screenData = ScreenData.discussion(DiscussionCoordinatorData(
-            discussionId: discussionId,
+            discussionId: discussionId?.isEmpty == false ? discussionId : nil,
             objectId: objectId,
             objectName: objectName,
             spaceId: editorData.spaceId
@@ -99,11 +92,7 @@ final class HomeBottomNavigationPanelViewModel {
     
     func updateVisibleScreen(data: AnyHashable) {
         currentData = data
-        detailsSubscriptionTask?.cancel()
-        detailsSubscriptionTask = nil
-        currentDiscussionId = nil
         updateState()
-        subscribeToDiscussionId(from: data)
     }
 
     func onTapCreateObject(type: ObjectType) {
@@ -164,20 +153,6 @@ final class HomeBottomNavigationPanelViewModel {
     
     // MARK: - Private
 
-    private func subscribeToDiscussionId(from data: AnyHashable) {
-        guard let editorData = data as? EditorScreenData,
-              let objectId = editorData.objectId else { return }
-        let document = documentsProvider.document(objectId: objectId, spaceId: editorData.spaceId)
-        detailsSubscriptionTask = Task { [weak self] in
-            for await details in document.detailsPublisher.values {
-                guard !Task.isCancelled else { return }
-                let discussionId = details.discussionId
-                self?.currentDiscussionId = discussionId.isNotEmpty ? discussionId : nil
-                self?.updateState()
-            }
-        }
-    }
-
     private func participantSubscription() async {
         for await data in participantSpacesStorage.participantSpaceViewPublisher(spaceId: info.accountSpaceId).values {
             participantSpaceView = data
@@ -229,9 +204,14 @@ final class HomeBottomNavigationPanelViewModel {
         if currentData is DiscussionCoordinatorData { return }
 
         canCreateObject = participantSpaceView.permissions.canEdit
-        let isObjectScreen = (currentData as? EditorScreenData)?.objectId != nil
-        let hasDiscussion = currentDiscussionId != nil
-        showDiscussButton = FeatureFlags.discussionButton && isObjectScreen && (canCreateObject || hasDiscussion)
+        guard let editorData = currentData as? EditorScreenData,
+              let objectId = editorData.objectId else {
+            showDiscussButton = false
+            return
+        }
+        let document = documentsProvider.document(objectId: objectId, spaceId: editorData.spaceId)
+        let hasDiscussion = document.details?.discussionId.isNotEmpty == true
+        showDiscussButton = FeatureFlags.discussionButton && (canCreateObject || hasDiscussion)
     }
 
     private func handleCreateObject() {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
@@ -37,6 +37,8 @@ final class HomeBottomNavigationPanelViewModel {
     private var currentData: AnyHashable?
     @ObservationIgnored
     private var participantSpaceView: ParticipantSpaceViewData?
+    @ObservationIgnored
+    private var detailsSubscriptionTask: Task<Void, Never>?
 
     // MARK: - Public properties
 
@@ -93,6 +95,7 @@ final class HomeBottomNavigationPanelViewModel {
     func updateVisibleScreen(data: AnyHashable) {
         currentData = data
         updateState()
+        subscribeToDetailsChanges(from: data)
     }
 
     func onTapCreateObject(type: ObjectType) {
@@ -152,6 +155,20 @@ final class HomeBottomNavigationPanelViewModel {
     }
     
     // MARK: - Private
+
+    private func subscribeToDetailsChanges(from data: AnyHashable) {
+        detailsSubscriptionTask?.cancel()
+        detailsSubscriptionTask = nil
+        guard let editorData = data as? EditorScreenData,
+              let objectId = editorData.objectId else { return }
+        let document = documentsProvider.document(objectId: objectId, spaceId: editorData.spaceId)
+        detailsSubscriptionTask = Task { [weak self] in
+            for await _ in document.detailsPublisher.values {
+                guard !Task.isCancelled else { return }
+                self?.updateState()
+            }
+        }
+    }
 
     private func participantSubscription() async {
         for await data in participantSpacesStorage.participantSpaceViewPublisher(spaceId: info.accountSpaceId).values {


### PR DESCRIPTION
## Summary
- Fix discussion screen showing empty (0 comments) when reopening after posting the first comment on a new object
- Root cause: middleware's `objectAddDiscussion` doesn't update the parent object's `discussionId` field via events, so the bottom panel couldn't resolve the discussion ID on re-open
- Fix: after creating a discussion, amend the parent document's `detailsStorage` directly so the panel reads the correct `discussionId`
- Simplify `HomeBottomNavigationPanelViewModel` by removing `currentDiscussionId` property, subscription task, and `subscribeToDiscussionId` method — read `discussionId` from document details on demand instead