### PR TITLE
IOS-6023 Enable homePage feature flag

### DIFF
--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -13,7 +13,7 @@ public extension FeatureDescription {
     static let homePage = FeatureDescription(
         title: "Home Page",
         category: .productFeature(author: "vova@anytype.io", targetRelease: "18"),
-        defaultValue: false
+        defaultValue: true
     )
 
     static let discussionButton = FeatureDescription(


### PR DESCRIPTION
## Summary

- Enable `homePage` feature flag (`defaultValue: true`) so the "Home" field appears in Space Settings → Preferences
- Previously the flag was disabled, hiding the homepage setting from all users including owners
- The field remains gated by `canSetHomepage` permission (owner or one-on-one participant)