### PR TITLE
IOS-6044 Update 3-dots menu on discussion screen

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorView.swift
@@ -4,7 +4,6 @@ struct DiscussionCoordinatorView: View {
 
     @State private var model: DiscussionCoordinatorViewModel
     @Environment(\.pageNavigation) private var pageNavigation
-    @Environment(\.chatActionProvider) private var chatActionProvider
 
     init(data: DiscussionCoordinatorData) {
         self._model = State(wrappedValue: DiscussionCoordinatorViewModel(data: data))
@@ -31,9 +30,6 @@ struct DiscussionCoordinatorView: View {
             }
             .sheet(item: $model.showEmojiData) {
                 MessageReactionPickerView(data: $0)
-            }
-            .anytypeSheet(isPresented: $model.showSyncStatusInfo) {
-                SyncStatusInfoView(spaceId: model.spaceId)
             }
             .sheet(item: $model.linkToObjectData) {
                 LinkToObjectSearchView(data: $0, showEditorScreen: { _ in })

--- a/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorView.swift
@@ -5,7 +5,6 @@ struct DiscussionCoordinatorView: View {
     @State private var model: DiscussionCoordinatorViewModel
     @Environment(\.pageNavigation) private var pageNavigation
     @Environment(\.chatActionProvider) private var chatActionProvider
-    @Environment(\.dismiss) private var dismiss
 
     init(data: DiscussionCoordinatorData) {
         self._model = State(wrappedValue: DiscussionCoordinatorViewModel(data: data))
@@ -22,14 +21,10 @@ struct DiscussionCoordinatorView: View {
             objectName: model.objectName,
             discussionId: model.discussionId,
             messageId: model.messageId,
-            output: model,
-            settingsOutput: model
+            output: model
         )
             .onAppear {
                 model.pageNavigation = pageNavigation
-            }
-            .onChange(of: model.dismiss) {
-                dismiss()
             }
             .sheet(item: $model.objectToMessageSearchData) {
                 ObjectSearchWithMetaCoordinatorView(data: $0)
@@ -39,9 +34,6 @@ struct DiscussionCoordinatorView: View {
             }
             .anytypeSheet(isPresented: $model.showSyncStatusInfo) {
                 SyncStatusInfoView(spaceId: model.spaceId)
-            }
-            .sheet(item: $model.objectIconPickerData) {
-                ObjectIconPicker(data: $0)
             }
             .sheet(item: $model.linkToObjectData) {
                 LinkToObjectSearchView(data: $0, showEditorScreen: { _ in })
@@ -69,9 +61,6 @@ struct DiscussionCoordinatorView: View {
             }
             .anytypeSheet(isPresented: $model.showDisabledPushNotificationsAlert){
                 DisabledPushNotificationsAlertView()
-            }
-            .sheet(item: $model.spaceShareData) { data in
-                SpaceShareCoordinatorView(data: data)
             }
             .onChange(of: model.photosItems) {
                 model.photosPickerFinished()

--- a/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorViewModel.swift
@@ -37,7 +37,6 @@ final class DiscussionCoordinatorViewModel: DiscussionModuleOutput {
 
     var objectToMessageSearchData: ObjectSearchWithMetaModuleData?
     var showEmojiData: MessageReactionPickerData?
-    var showSyncStatusInfo = false
     var linkToObjectData: LinkToObjectSearchModuleData?
     var showFilesPicker = false
     var showPhotosPicker = false

--- a/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorViewModel.swift
@@ -22,7 +22,7 @@ struct DiscussionCoordinatorData: Hashable, Codable {
 
 @MainActor
 @Observable
-final class DiscussionCoordinatorViewModel: DiscussionModuleOutput, ObjectSettingsCoordinatorOutput {
+final class DiscussionCoordinatorViewModel: DiscussionModuleOutput {
 
     @ObservationIgnored
     var discussionId: String?
@@ -38,7 +38,6 @@ final class DiscussionCoordinatorViewModel: DiscussionModuleOutput, ObjectSettin
     var objectToMessageSearchData: ObjectSearchWithMetaModuleData?
     var showEmojiData: MessageReactionPickerData?
     var showSyncStatusInfo = false
-    var objectIconPickerData: ObjectIconPickerData?
     var linkToObjectData: LinkToObjectSearchModuleData?
     var showFilesPicker = false
     var showPhotosPicker = false
@@ -49,8 +48,6 @@ final class DiscussionCoordinatorViewModel: DiscussionModuleOutput, ObjectSettin
     var safariUrl: URL?
     var cameraData: SimpleCameraData?
     var newLinkedObject: EditorScreenData?
-    var spaceShareData: SpaceShareData?
-    var dismiss = false
 
     @ObservationIgnored
     private var filesPickerData: FilesPickerData?
@@ -146,37 +143,4 @@ final class DiscussionCoordinatorViewModel: DiscussionModuleOutput, ObjectSettin
         }
     }
 
-    // MARK: - ObjectSettingsCoordinatorOutput
-
-    func closeEditor() {
-        dismiss.toggle()
-    }
-
-    func showEditorScreen(data: ScreenData) {
-        pageNavigation?.open(data)
-    }
-
-    func didCreateLinkToItself(selfName: String, data: ScreenData) {
-        anytypeAssertionFailure("Unsupported method: didCreateLinkToItself")
-    }
-
-    func didCreateTemplate(templateId: String) {
-        anytypeAssertionFailure("Unsupported method: didCreateTemplate")
-    }
-
-    func didTapUseTemplateAsDefault(templateId: String) {
-        anytypeAssertionFailure("Unsupported method: didTapUseTemplateAsDefault")
-    }
-
-    func didUndoRedo() {
-        anytypeAssertionFailure("Unsupported method: didUndoRedo")
-    }
-
-    func versionRestored(_ text: String) {
-        anytypeAssertionFailure("Unsupported method: versionRestored")
-    }
-
-    func showInviteMembers(spaceId: String) {
-        spaceShareData = SpaceShareData(spaceId: spaceId, route: .chat)
-    }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -9,11 +9,8 @@ struct DiscussionView: View {
     @Environment(\.keyboardDismiss) private var keyboardDismiss
     @Environment(\.chatActionProvider) private var chatActionProvider
 
-    private let settingsOutput: (any ObjectSettingsCoordinatorOutput)?
-
-    init(spaceId: String, objectId: String, objectName: String, discussionId: String?, messageId: String? = nil, output: (any DiscussionModuleOutput)?, settingsOutput: (any ObjectSettingsCoordinatorOutput)?) {
+    init(spaceId: String, objectId: String, objectName: String, discussionId: String?, messageId: String? = nil, output: (any DiscussionModuleOutput)?) {
         self._model = State(wrappedValue: DiscussionViewModel(spaceId: spaceId, objectId: objectId, objectName: objectName, chatId: discussionId, messageId: messageId, output: output))
-        self.settingsOutput = settingsOutput
     }
 
     var body: some View {
@@ -29,8 +26,9 @@ struct DiscussionView: View {
                 objectName: model.objectName,
                 commentsCount: model.commentsCount,
                 chatId: model.chatId,
-                spaceId: model.spaceId,
-                settingsOutput: settingsOutput
+                onTapCopyLink: {
+                    Task { await model.copyObjectLink() }
+                }
             )
         }
         .onAppear {

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -58,6 +58,10 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     private var shareSuggestionService: any ShareSuggestionServiceProtocol
     @Injected(\.deepLinkParser) @ObservationIgnored
     private var deepLinkParser: any DeepLinkParserProtocol
+    @Injected(\.universalLinkParser) @ObservationIgnored
+    private var universalLinkParser: any UniversalLinkParserProtocol
+    @Injected(\.workspaceService) @ObservationIgnored
+    private var workspaceService: any WorkspaceServiceProtocol
 
     private let participantSubscription: any ParticipantsSubscriptionProtocol
     private var chatStorage: (any DiscussionMessagesStorageProtocol)?
@@ -648,6 +652,13 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
             deepLink: .chatMessage(chatObjectId: objectId, spaceId: spaceId, messageId: message.message.id),
             scheme: .main
         )
+        UIPasteboard.general.string = link?.absoluteString
+        toastBarData = ToastBarData(Loc.copied)
+    }
+
+    func copyObjectLink() async {
+        let invite = try? await workspaceService.getCurrentInvite(spaceId: spaceId)
+        let link = universalLinkParser.createUrl(link: .object(objectId: objectId, spaceId: spaceId, cid: invite?.cid, key: invite?.fileKey))
         UIPasteboard.general.string = link?.absoluteString
         toastBarData = ToastBarData(Loc.copied)
     }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionHeaderView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionHeaderView.swift
@@ -1,13 +1,11 @@
 import SwiftUI
-import Services
 
 struct DiscussionHeaderView: View {
 
     let objectName: String
     let commentsCount: Int
     let chatId: String?
-    let spaceId: String
-    let settingsOutput: (any ObjectSettingsCoordinatorOutput)?
+    let onTapCopyLink: () -> Void
 
     var body: some View {
         NavigationHeader(
@@ -38,12 +36,14 @@ struct DiscussionHeaderView: View {
 
     @ViewBuilder
     private var moreButton: some View {
-        if let chatId {
-            ObjectSettingsMenuContainer(
-                objectId: chatId,
-                spaceId: spaceId,
-                output: settingsOutput
-            ) {
+        if chatId != nil {
+            Menu {
+                Button {
+                    onTapCopyLink()
+                } label: {
+                    Label(Loc.copyLink, systemImage: "link")
+                }
+            } label: {
                 Image(asset: .X24.more)
                     .foregroundStyle(Color.Control.primary)
                     .frame(width: NavigationHeaderConstants.buttonSize, height: NavigationHeaderConstants.buttonSize)


### PR DESCRIPTION
## Summary
- Replace full object settings menu with a lightweight menu containing only "Copy Link" on the discussion screen
- Copy link now copies a shareable universal link to the parent object (not the chat object)
- Remove unused `ObjectSettingsCoordinatorOutput` conformance and related dead code from discussion coordinator