### PR TITLE
IOS-6043 Fix discussion screen navigation bar blur/background

### DIFF
--- a/Anytype/Sources/FrameworkExtensions/SwiftUI/TappableArea+Button.swift
+++ b/Anytype/Sources/FrameworkExtensions/SwiftUI/TappableArea+Button.swift
@@ -1,13 +1,17 @@
 import SwiftUI
 
+enum ExpandedTapAreaButtonConstants {
+    static let defaultInsets = EdgeInsets(side: 15)
+}
+
 struct ExpandedTapAreaButton<Label: View>: View {
-    
+
     let action: @MainActor () -> Void
     let insets: EdgeInsets
     @ViewBuilder
     let label: Label
-    
-    init(action: @escaping @MainActor () -> Void, insets: EdgeInsets = EdgeInsets(side: 15), @ViewBuilder label: () -> Label) {
+
+    init(insets: EdgeInsets = ExpandedTapAreaButtonConstants.defaultInsets, action: @escaping @MainActor () -> Void, @ViewBuilder label: () -> Label) {
         self.action = action
         self.insets = insets
         self.label = label()

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Navigation/PageNavigationBackButton.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Navigation/PageNavigationBackButton.swift
@@ -1,12 +1,18 @@
 import SwiftUI
 
 struct PageNavigationBackButton: View {
-    
+
+    private let useExpandedTapArea: Bool
+
     @Environment(\.pageNavigation) private var pageNavigation
     @Environment(\.pageNavigationHiddenBackButton) private var pageNavigationHiddenBackButton
-    
+
+    init(useExpandedTapArea: Bool = true) {
+        self.useExpandedTapArea = useExpandedTapArea
+    }
+
     var body: some View {
-        ExpandedTapAreaButton {
+        ExpandedTapAreaButton(insets: useExpandedTapArea ? ExpandedTapAreaButtonConstants.defaultInsets : EdgeInsets()) {
             pageNavigation.pop()
         } label: {
             Image(asset: .X24.back)

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatView.swift
@@ -187,7 +187,8 @@ struct ChatView: View {
             bottomPanel: bottomPanel,
             emptyView: emptyView,
             showEmptyState: model.showEmptyState,
-            showSectionHeaders: true
+            showSectionHeaders: true,
+            topContentInset: NavigationHeaderConstants.height
         ) {
             cell(data: $0)
         } headerBuilder: {

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatCollectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatCollectionView.swift
@@ -18,6 +18,7 @@ struct ChatCollectionView<
     let emptyView: EmptyView
     let showEmptyState: Bool
     let showSectionHeaders: Bool
+    let topContentInset: CGFloat
     let itemBuilder: (Item) -> ItemView
     let headerBuilder: (Section.Header) -> HeaderView
     @ViewBuilder
@@ -80,7 +81,7 @@ struct ChatCollectionView<
         actionView.safeAreaRegions = SafeAreaRegions()
 
         let container = ChatCollectionViewContainer(collectionView: collectionView, bottomPanel: bottomPanel, emptyView: emptyView, actionView: actionView)
-        container.contentInset = UIEdgeInsets(top: NavigationHeaderConstants.height, left: 0, bottom: 10, right: 0)
+        container.contentInset = UIEdgeInsets(top: topContentInset, left: 0, bottom: 10, right: 0)
         return container
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -14,23 +14,9 @@ struct DiscussionView: View {
     }
 
     var body: some View {
-        ZStack {
-            Color.Background.primary
-            mainView
-                .ignoresSafeArea()
-        }
-        .messageReactionSelectedColor(Color.Control.accent100)
-        .messageReactionUnselectedColor(Color.Shape.transparentSecondary)
-        .overlay(alignment: .top) {
-            DiscussionHeaderView(
-                objectName: model.objectName,
-                commentsCount: model.commentsCount,
-                chatId: model.chatId,
-                onTapCopyLink: {
-                    Task { await model.copyObjectLink() }
-                }
-            )
-        }
+        contentView
+            .messageReactionSelectedColor(Color.Control.accent100)
+            .messageReactionUnselectedColor(Color.Shape.transparentSecondary)
         .onAppear {
             model.keyboardDismiss = keyboardDismiss
             model.configureProvider(chatActionProvider)
@@ -61,6 +47,81 @@ struct DiscussionView: View {
         }
         .snackbar(toastBarData: $model.toastBarData)
         .homeBottomPanelHidden(true)
+    }
+
+    // MARK: - iOS version-specific content
+
+    @ViewBuilder
+    private var contentView: some View {
+        if #available(iOS 26.0, *) {
+            ios26Content
+        } else {
+            legacyContent
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private var ios26Content: some View {
+        NavigationStack {
+            ZStack {
+                Color.Background.primary
+                mainView(topContentInset: 0)
+                    .ignoresSafeArea()
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden(true)
+            .toolbarRole(.editor)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    PageNavigationBackButton(useExpandedTapArea: false)
+                        .buttonBorderShape(.circle)
+                }
+                ToolbarItem(placement: .title) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        AnytypeText(model.objectName.withPlaceholder, style: .caption1Regular)
+                            .foregroundStyle(Color.Text.secondary)
+                            .lineLimit(1)
+                        AnytypeText(Loc.Discussion.Header.comments(model.commentsCount), style: .uxTitle2Semibold)
+                            .foregroundStyle(Color.Text.primary)
+                            .lineLimit(1)
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    if model.chatId != nil {
+                        Menu {
+                            Button {
+                                Task { await model.copyObjectLink() }
+                            } label: {
+                                Label(Loc.copyLink, systemImage: "link")
+                            }
+                        } label: {
+                            Image(asset: .X24.more)
+                                .foregroundStyle(Color.Control.primary)
+                        }
+                        .buttonBorderShape(.circle)
+                    }
+                }
+            }
+            .scrollEdgeEffectStyle(.soft, for: .top)
+        }
+    }
+
+    private var legacyContent: some View {
+        ZStack {
+            Color.Background.primary
+            mainView(topContentInset: NavigationHeaderConstants.height)
+                .ignoresSafeArea()
+        }
+        .overlay(alignment: .top) {
+            DiscussionHeaderView(
+                objectName: model.objectName,
+                commentsCount: model.commentsCount,
+                chatId: model.chatId,
+                onTapCopyLink: {
+                    Task { await model.copyObjectLink() }
+                }
+            )
+        }
     }
 
     @ViewBuilder
@@ -164,14 +225,15 @@ struct DiscussionView: View {
     }
 
     @ViewBuilder
-    private var mainView: some View {
+    private func mainView(topContentInset: CGFloat) -> some View {
         ChatCollectionView(
             items: model.mesageBlocks,
             scrollProxy: model.collectionViewScrollProxy,
             bottomPanel: bottomPanel,
             emptyView: emptyView,
             showEmptyState: model.showEmptyState,
-            showSectionHeaders: false
+            showSectionHeaders: false,
+            topContentInset: topContentInset
         ) {
             cell(data: $0)
         } headerBuilder: {


### PR DESCRIPTION
## Summary

- On iOS 26, replace custom NavigationHeader overlay with system NavigationStack + toolbar for native `.scrollEdgeEffectStyle(.soft)` blur effect
- On iOS 18, keep existing custom DiscussionHeaderView with HomeBlurEffectView (unchanged behavior)
- Make ChatCollectionView top content inset configurable (0 for system nav bar, 44pt for custom header)
- Add `useExpandedTapArea` parameter to PageNavigationBackButton for system toolbar compatibility