### PR TITLE
IOS-5991 Fix settings button hit area on welcome screen

### DIFF
--- a/.claude/hooks/skill-rules.json
+++ b/.claude/hooks/skill-rules.json
@@ -447,7 +447,7 @@
           "glassEffectInteractiveIOS26",
           "glassEffectIDIOS26",
           "glassEffectIOS26",
-          "buttonStyleGlassIOS26",
+          "buttonStyleCircleGlassIOS26",
           "\\.glassEffect\\(",
           "GlassEffectContainer"
         ]

--- a/.claude/skills/liquid-glass-developer/SKILL.md
+++ b/.claude/skills/liquid-glass-developer/SKILL.md
@@ -42,8 +42,8 @@ GlassEffectContainerIOS26(spacing: 20) {
 // Morphing transition ID
 .glassEffectIDIOS26("buttonId", in: glassNamespace)
 
-// Glass button style (legacy, prefer glassEffectInteractiveIOS26)
-.buttonStyleGlassIOS26()
+// Circle glass button style (for Button views — handles full-frame hit testing)
+.buttonStyleCircleGlassIOS26()
 ```
 
 ### Complete Pattern Example

--- a/Anytype/Sources/FrameworkExtensions/SwiftUI/View+iOS26.swift
+++ b/Anytype/Sources/FrameworkExtensions/SwiftUI/View+iOS26.swift
@@ -22,13 +22,15 @@ extension View {
     }
     
     @ViewBuilder
-    public func buttonStyleGlassIOS26() -> some View {
+    public func buttonStyleCircleGlassIOS26() -> some View {
         if #available(iOS 26.0, *) {
             self.buttonStyle(.glass)
+                .buttonBorderShape(.circle)
         } else {
             self
                 .background(Color.Background.navigationPanel)
                 .background(.ultraThinMaterial)
+                .clipShape(Circle())
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/Auth/PrimaryAuthView/PrimaryAuthView.swift
+++ b/Anytype/Sources/PresentationLayer/Auth/PrimaryAuthView/PrimaryAuthView.swift
@@ -81,7 +81,7 @@ struct PrimaryAuthView: View {
                     .foregroundStyle(Color.Control.secondary)
             }
             .frame(width: NavigationHeaderConstants.buttonSize, height: NavigationHeaderConstants.buttonSize)
-            .glassEffectInteractiveIOS26(in: Circle())
+            .buttonStyleCircleGlassIOS26()
             .disabled(model.inProgress)
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -88,7 +88,7 @@ private struct HomeBottomNavigationPanelViewInternal: View {
                 .foregroundStyle(Color.Control.primary)
         }
         .frame(width: 48, height: 48)
-        .buttonStyleCircleGlassIOS26()
+        .glassEffectInteractiveIOS26(in: Circle())
     }
 
     private var discussIsland: some View {
@@ -96,11 +96,10 @@ private struct HomeBottomNavigationPanelViewInternal: View {
             model.onTapDiscuss()
         } label: {
             Image(systemName: "message")
-                .frame(width: 32, height: 32)
                 .foregroundStyle(Color.Control.primary)
         }
         .frame(width: 48, height: 48)
-        .buttonStyleCircleGlassIOS26()
+        .glassEffectInteractiveIOS26(in: Circle())
     }
 
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -88,7 +88,7 @@ private struct HomeBottomNavigationPanelViewInternal: View {
                 .foregroundStyle(Color.Control.primary)
         }
         .frame(width: 48, height: 48)
-        .glassEffectInteractiveIOS26(in: Circle())
+        .buttonStyleCircleGlassIOS26()
     }
 
     private var discussIsland: some View {
@@ -96,10 +96,11 @@ private struct HomeBottomNavigationPanelViewInternal: View {
             model.onTapDiscuss()
         } label: {
             Image(systemName: "message")
+                .frame(width: 32, height: 32)
                 .foregroundStyle(Color.Control.primary)
         }
         .frame(width: 48, height: 48)
-        .glassEffectInteractiveIOS26(in: Circle())
+        .buttonStyleCircleGlassIOS26()
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Replace `glassEffectInteractiveIOS26` with `buttonStyleCircleGlassIOS26` for the welcome-screen settings button — the interactive glass modifier paints a surface that intercepts taps without forwarding them to the Button, breaking hit testing outside the opaque label area (reproduced on iPad mini per App Review report).
- Rename `buttonStyleGlassIOS26` → `buttonStyleCircleGlassIOS26` and bake in the circle shape (`.buttonBorderShape(.circle)` on iOS 26, `.clipShape(Circle())` on legacy) so the Button system owns full-frame hit testing.
- Update skill docs (`liquid-glass-developer`, `skill-rules.json`) to the new name.