### PR TITLE
IOS-6060 Fix sender name showing in new 1-1 chat previews

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessageBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessageBuilder.swift
@@ -38,9 +38,9 @@ actor ChatMessageBuilder: ChatMessageBuilderProtocol, Sendable {
         limits: any ChatMessageLimitsProtocol
     ) async -> [MessageSectionData] {
 
-        let spaceUxType = workspaceStorage.spaceView(spaceId: spaceId)?.uxType
-        let showsMessageAuthor = spaceUxType?.showsMessageAuthor ?? true
-        let positionsYourMessageOnRight = spaceUxType?.positionsYourMessageOnRight ?? true
+        let spaceView = workspaceStorage.spaceView(spaceId: spaceId)
+        let showsMessageAuthor = spaceView?.showsMessageAuthor ?? true
+        let positionsYourMessageOnRight = spaceView?.uxType.positionsYourMessageOnRight ?? true
         let participant = accountParticipantsStorage.participants.first { $0.spaceId == spaceId }
         let chatObject = openDocumentProvider.document(objectId: chatId, spaceId: spaceId)
         let isChatDeletedOrArchived = (chatObject.details?.isDeleted ?? false) || (chatObject.details?.isArchived ?? false)

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/SpaceCardModelBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceCard/SpaceCardModelBuilder.swift
@@ -85,7 +85,7 @@ final class SpaceCardModelBuilder: SpaceCardModelBuilderProtocol, Sendable {
             supportsMultiChats: !spaceView.isOneToOne,
             isOneToOne: spaceView.isOneToOne,
             currentNotificationMode: spaceView.pushNotificationMode,
-            showsMessageAuthor: spaceView.uxType.showsMessageAuthor,
+            showsMessageAuthor: spaceView.showsMessageAuthor,
             lastMessage: lastMessage,
             unreadCounter: spaceData.totalUnreadCounter,
             mentionCounter: spaceData.totalMentionCounter,

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
@@ -119,6 +119,10 @@ extension SpaceView {
         spaceType == .oneToOne
     }
 
+    var showsMessageAuthor: Bool {
+        !isOneToOne && uxType.showsMessageAuthor
+    }
+
     @available(*, deprecated, message: "Use homepage to determine initial screen")
     var initialScreenIsChat: Bool {
         uxType.initialScreenIsChat


### PR DESCRIPTION
## Summary
- Newly created 1-1 chats showed the sender name in message previews (both in the space list and inside the chat) while older 1-1 chats did not.
- Root cause: the decision relied on `SpaceUxType`, which is deprecated (IOS-5900). Middleware no longer populates it for new 1-1 spaces, so it defaulted to `.data` and returned `showsMessageAuthor = true`.
- Added `SpaceView.showsMessageAuthor` that reads the new `spaceType` (`.oneToOne`) first and falls back to `uxType` (preserves stream behavior); migrated the two call sites in `SpaceCardModelBuilder` and `ChatMessageBuilder`.