### PR TITLE
IOS-6061 Typography and spacing fixes in discussions

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -78,7 +78,7 @@ struct DiscussionView: View {
                 }
                 ToolbarItem(placement: .title) {
                     VStack(alignment: .leading, spacing: 0) {
-                        AnytypeText(model.objectName.withPlaceholder, style: .caption1Regular)
+                        AnytypeText(model.objectName.withPlaceholder, style: .caption1Medium)
                             .foregroundStyle(Color.Text.secondary)
                             .lineLimit(1)
                         AnytypeText(Loc.Discussion.Header.comments(model.commentsCount), style: .uxTitle2Semibold)

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionBlockItem.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionBlockItem.swift
@@ -71,7 +71,9 @@ enum DiscussionBlockItem: Equatable, Hashable, Identifiable {
         case .subheading: return 12
         case .quote: return 12
         case .checkbox, .bulleted, .numbered: return 12
-        case .text, .callout, .toggle, .image, .video, .file, .linkObject, .bookmark, .embed, .divider, .unsupported:
+        case .image, .video, .file, .linkObject, .bookmark, .embed:
+            return 12
+        case .text, .callout, .toggle, .divider, .unsupported:
             return 8
         }
     }
@@ -79,8 +81,9 @@ enum DiscussionBlockItem: Equatable, Hashable, Identifiable {
     var bottomSpacing: CGFloat {
         switch self {
         case .quote: return 12
-        case .text, .title, .heading, .subheading, .callout, .checkbox, .bulleted, .numbered, .toggle,
-             .image, .video, .file, .linkObject, .bookmark, .embed, .divider, .unsupported:
+        case .image, .video, .file, .linkObject, .bookmark, .embed:
+            return 12
+        case .text, .title, .heading, .subheading, .callout, .checkbox, .bulleted, .numbered, .toggle, .divider, .unsupported:
             return 0
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionHeaderView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionHeaderView.swift
@@ -19,7 +19,7 @@ struct DiscussionHeaderView: View {
 
     private var titleView: some View {
         VStack(alignment: .leading, spacing: 0) {
-            AnytypeText(objectName.withPlaceholder, style: .caption1Regular)
+            AnytypeText(objectName.withPlaceholder, style: .caption1Medium)
                 .foregroundStyle(Color.Text.secondary)
                 .lineLimit(1)
             AnytypeText(commentsString, style: .uxTitle2Semibold)

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageDividerView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageDividerView.swift
@@ -2,11 +2,9 @@ import SwiftUI
 
 struct DiscussionMessageDividerView: View {
     var body: some View {
-        VStack(alignment: .center) {
-            Rectangle()
-                .fill(Color.Shape.secondary)
-                .frame(height: 1)
-        }
-        .frame(height: 20)
+        Rectangle()
+            .fill(Color.Shape.secondary)
+            .frame(height: 1)
+            .padding(.vertical, 9.5)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageDividerView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageDividerView.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 struct DiscussionMessageDividerView: View {
     var body: some View {
-        Rectangle()
-            .fill(Color.Shape.secondary)
-            .frame(height: 1)
-            .padding(.vertical, 12)
+        VStack(alignment: .center) {
+            Rectangle()
+                .fill(Color.Shape.secondary)
+                .frame(height: 1)
+        }
+        .frame(height: 20)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -71,7 +71,6 @@ struct DiscussionMessageView: View {
             Spacer.fixedHeight(8)
             messageContent
             reactions
-
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -70,8 +70,8 @@ struct DiscussionMessageView: View {
             header
             Spacer.fixedHeight(8)
             messageContent
-            Spacer.fixedHeight(8)
             reactions
+
         }
     }
 
@@ -84,7 +84,7 @@ struct DiscussionMessageView: View {
             } label: {
                 HStack(spacing: 0) {
                     IconView(icon: data.authorIcon)
-                        .frame(width: 28, height: 28)
+                        .frame(width: 20, height: 20)
 
                     Spacer().frame(width: 6)
 
@@ -108,12 +108,12 @@ struct DiscussionMessageView: View {
             timestampLabel
                 .fixedSize()
         }
-        .frame(height: 32)
+        .frame(height: 20)
     }
 
     private var timestampLabel: some View {
         Text(data.timestampLabel)
-            .anytypeStyle(.caption2Regular)
+            .anytypeStyle(.caption1Regular)
             .foregroundStyle(Color.Text.secondary)
             .lineLimit(1)
     }
@@ -189,7 +189,7 @@ struct DiscussionMessageView: View {
                     output?.didSelectAddReaction(messageId: data.message.id)
                 }
             )
-            .padding(.top, 4)
+            .padding(.top, 8)
         }
     }
 


### PR DESCRIPTION
## Summary
- Make object name in discussions nav bar Medium weight
- Increase timestamp font from Caption 2 (11pt) to Caption 1 (13pt)
- Decrease user avatars from 28px to 20px, reduce header height accordingly
- Remove extra 8px spacer after message content to tighten reply spacing
- Add 12px top/bottom margins for media blocks (images, videos, files, bookmarks, embeds)
- Simplify message divider view