### PR TITLE
IOS-6071 Allow sosumi in Claude permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,7 @@
       "Bash(bash Scripts/:*)",
 
       "Bash(linctl:*)",
+      "Bash(sosumi:*)",
 
       "Skill(codeReview)",
       "Skill(cpp)",


### PR DESCRIPTION
## Summary
- Add `Bash(sosumi:*)` to `.claude/settings.json` allowlist so Apple docs lookups (`sosumi search`, `sosumi fetch`) no longer trigger permission prompts.