### PR TITLE
IOS-6070 Disable homepage change in 1-on-1 channels

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -225,8 +225,12 @@ final class HomeWidgetsViewModel {
             supportsMultiChats = !spaceView.isOneToOne
 
             // Home widget renders whichever object is set as homepage (Chat / Page / Collection).
-            // Treat `.empty` as `.widgets` via `displayValue` — empty homepage must never render the widget.
-            guard case let .object(objectId) = spaceView.homepage.displayValue else {
+            // 1-on-1 channels always home on Chat; `SpaceView.homepage` is unreliable there
+            // (middleware may not populate it), so fall back to `info.spaceChatId`.
+            let effectiveHomepage: SpaceHomepage = spaceView.isOneToOne && !info.spaceChatId.isEmpty
+                ? .object(objectId: info.spaceChatId)
+                : spaceView.homepage
+            guard case let .object(objectId) = effectiveHomepage else {
                 if lastObserved != nil {
                     homepageTask?.cancel()
                     homepageTask = nil

--- a/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/Model/SpacePermissions.swift
+++ b/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/Model/SpacePermissions.swift
@@ -53,6 +53,6 @@ extension SpacePermissions {
         canEditPermissions = isOwner && !isLocalMode
         canApproveRequests = isOwner
         canChangeUxType = isOwner
-        canSetHomepage = isOwner || spaceView.isOneToOne
+        canSetHomepage = isOwner && !spaceView.isOneToOne
     }
 }


### PR DESCRIPTION
## Summary
- In 1-on-1 channels homepage is always Chat and can't be changed. Flip `canSetHomepage` to `isOwner && !isOneToOne` (was `isOwner || isOneToOne`, which actually granted edit access to every 1-on-1 member).
- Single-file change; all downstream UI already reads `canSetHomepage`, so the flip hides the Space Settings Home row, removes the "Change Home" action from the Home widget context menu, and keeps the post-creation picker from opening.
- Home widget itself still renders (its visibility is gated on the homepage object, not on `canSetHomepage`), so users can still tap it to return to Chat from deep navigation.

Linear: [IOS-6070](https://linear.app/anytype/issue/IOS-6070)