### PR TITLE
IOS-6069 Fix discussion button tappable area

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -99,8 +99,9 @@ private struct HomeBottomNavigationPanelViewInternal: View {
         } label: {
             Image(systemName: "message")
                 .foregroundStyle(Color.Control.primary)
+                .frame(width: 48, height: 48)
+                .contentShape(Circle())
         }
-        .frame(width: 48, height: 48)
         .glassEffectInteractiveIOS26(in: Circle())
     }
 


### PR DESCRIPTION
## Summary
- Fix small tappable area of the discussion button in the home bottom navigation panel — previously only the ~17pt SF Symbol bounds were hit-testable, making the button unresponsive to most taps.
- Root cause: `.frame(48×48)` and `.glassEffectInteractiveIOS26(in: Circle())` were applied outside the `Button`, and Apple's `.glassEffect(.interactive())` is documented for custom views (not Buttons) — it interfered with hit testing.
- Fix: move `.frame(48, 48)` and add `.contentShape(Circle())` inside the Button's label so the Button's own hit region is guaranteed to be 48×48 regardless of the glass effect layer above.