### PR TITLE
IOS-6075 Send replies to root comment, not to a reply

### DIFF
--- a/AnyTypeTests/Discussion/DiscussionMessageBuilderThreadingTests.swift
+++ b/AnyTypeTests/Discussion/DiscussionMessageBuilderThreadingTests.swift
@@ -269,6 +269,60 @@ struct DiscussionThreadGrouperTests {
         #expect(result.roots[0].message.id == "root1")
         #expect(result.threadReplies.isEmpty)
     }
+
+    // MARK: - findRootParent(of:in:)
+
+    @Test
+    func findRootParent_rootMessage_returnsOwnId() {
+        let root = makeMessage(id: "root1", orderID: "001")
+
+        let rootId = grouper.findRootParent(of: root.message, in: [root])
+
+        #expect(rootId == "root1")
+    }
+
+    @Test
+    func findRootParent_directReply_returnsParentId() {
+        let root = makeMessage(id: "root1", orderID: "001")
+        let reply = makeMessage(id: "r1", orderID: "002", replyToMessageID: "root1")
+
+        let rootId = grouper.findRootParent(of: reply.message, in: [root, reply])
+
+        #expect(rootId == "root1")
+    }
+
+    @Test
+    func findRootParent_nestedReplyChain_returnsRootId() {
+        // A (root) → B → C; findRootParent(C) should return A
+        let msgA = makeMessage(id: "A", orderID: "001")
+        let msgB = makeMessage(id: "B", orderID: "002", replyToMessageID: "A")
+        let msgC = makeMessage(id: "C", orderID: "003", replyToMessageID: "B")
+
+        let rootId = grouper.findRootParent(of: msgC.message, in: [msgA, msgB, msgC])
+
+        #expect(rootId == "A")
+    }
+
+    @Test
+    func findRootParent_orphanReply_returnsNil() {
+        // Reply references a parent not in the message list
+        let orphan = makeMessage(id: "orphan", orderID: "001", replyToMessageID: "missing")
+
+        let rootId = grouper.findRootParent(of: orphan.message, in: [orphan])
+
+        #expect(rootId == nil)
+    }
+
+    @Test
+    func findRootParent_cyclicChain_returnsNil() {
+        // A replies to B, B replies to A → cycle
+        let msgA = makeMessage(id: "A", orderID: "001", replyToMessageID: "B")
+        let msgB = makeMessage(id: "B", orderID: "002", replyToMessageID: "A")
+
+        let rootId = grouper.findRootParent(of: msgA.message, in: [msgA, msgB])
+
+        #expect(rootId == nil)
+    }
 }
 
 // MARK: - Integration Tests for MessageViewData Flags

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -67,6 +67,7 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
     private var chatStorage: (any DiscussionMessagesStorageProtocol)?
     private let openDocumentProvider: any OpenedDocumentsProviderProtocol = Container.shared.openedDocumentProvider()
     private var discussionMessageBuilder: (any DiscussionMessageBuilderProtocol)?
+    private let threadGrouper = DiscussionThreadGrouper()
     private var chatObject: (any BaseDocumentProtocol)?
     private let initialMessageId: String?
 
@@ -599,15 +600,20 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
 
     func didSelectReplyTo(message: MessageViewData) {
         AnytypeAnalytics.instance().logClickMessageMenuReply()
+        let rootParentId = resolveRootParentId(for: message.message)
         withAnimation {
             inputFocused = true
             replyToMessage = ChatInputReplyModel(
-                id: message.message.id,
+                id: rootParentId,
                 title: Loc.Chat.replyTo(message.authorName),
                 description: message.discussionBlocks.plainText,
                 icon: message.attachmentsDetails.first?.objectIconImage
             )
         }
+    }
+
+    private func resolveRootParentId(for message: ChatMessage) -> String {
+        threadGrouper.findRootParent(of: message, in: messages) ?? message.id
     }
 
     func didSelectReplyMessage(message: MessageViewData) {

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionThreadGrouper.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionThreadGrouper.swift
@@ -7,6 +7,16 @@ struct DiscussionThreadGroupResult {
 
 struct DiscussionThreadGrouper {
 
+    /// Find the root parent id of `message` within `messages`.
+    /// If `message` has no parent, returns its own id.
+    /// Returns nil if the reply chain is broken (orphan) or cyclic.
+    func findRootParent(of message: ChatMessage, in messages: [FullChatMessage]) -> String? {
+        guard !message.replyToMessageID.isEmpty else { return message.id }
+        let messageById = makeMessageById(messages)
+        var cache: [String: String] = [:]
+        return findRootParentId(messageId: message.replyToMessageID, messageById: messageById, rootCache: &cache)
+    }
+
     /// Walk the replyToMessageID chain to find the root parent message id.
     /// Returns nil if the chain is broken (orphan) or cyclic.
     /// Uses `rootCache` to memoize results — all intermediate nodes in a resolved
@@ -60,10 +70,7 @@ struct DiscussionThreadGrouper {
     func groupMessagesIntoThreads(
         messages: [FullChatMessage]
     ) -> DiscussionThreadGroupResult {
-        let messageById = Dictionary(
-            messages.map { ($0.message.id, $0) },
-            uniquingKeysWith: { _, last in last }
-        )
+        let messageById = makeMessageById(messages)
 
         var roots: [FullChatMessage] = []
         var threadReplies: [String: [FullChatMessage]] = [:]
@@ -89,5 +96,12 @@ struct DiscussionThreadGrouper {
         }
 
         return DiscussionThreadGroupResult(roots: roots, threadReplies: threadReplies)
+    }
+
+    private func makeMessageById(_ messages: [FullChatMessage]) -> [String: FullChatMessage] {
+        Dictionary(
+            messages.map { ($0.message.id, $0) },
+            uniquingKeysWith: { _, last in last }
+        )
     }
 }


### PR DESCRIPTION
## Summary

- Long-tap → Reply on a reply now targets the root comment instead of creating a reply-to-reply. Fixes cascading disappearance when an intermediate reply is deleted.
- Resolves the root parent via `DiscussionThreadGrouper.findRootParent(of:in:)` (new public API that reuses the existing chain-walk logic).
- Adds unit tests for the new API covering root, direct reply, nested chain, orphan, and cycle cases.