### PR TITLE
IOS-6074 Fix comment content clipping when adding first reaction

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Subviews/DiscussionMessageView.swift
@@ -36,10 +36,6 @@ struct DiscussionMessageView: View {
             .fixTappableArea()
             .messageFlashBackground(id: data.id)
             .background(Color.Background.primary)
-            .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 16, style: .continuous))
-            .contextMenu {
-                contextMenu
-            }
     }
 
     private var messageBody: some View {
@@ -52,26 +48,46 @@ struct DiscussionMessageView: View {
                         .padding(.leading, Constants.replyBarLeadingPadding)
                         .padding(.bottom, data.isLastReply ? Constants.replyBarBottomPadding : 0)
                     messageInnerContent
-                        .padding(.leading, Constants.replyContentLeadingPadding)
-                        .padding(.trailing, Constants.messageHorizontalPadding)
-                        .padding(.vertical, Constants.messageVerticalPadding)
-                    Spacer()
                 }
             } else {
                 messageInnerContent
-                    .padding(.horizontal, Constants.messageHorizontalPadding)
-                    .padding(.vertical, Constants.messageVerticalPadding)
             }
         }
     }
 
     private var messageInnerContent: some View {
         VStack(alignment: .leading, spacing: 0) {
+            bubble
+            reactions
+        }
+    }
+
+    // Context menu is attached to `bubble` (which excludes the reactions row)
+    // so the preview-source rect stays stable when the first reaction is added.
+    // Otherwise the dismiss-zoom animation interpolates into a taller rect and
+    // clips the comment content (IOS-6074). Padding lives inside the bubble so
+    // the full padded comment area is part of the long-press hit region and
+    // defines the preview card's shape. The bubble's bottom padding doubles as
+    // the visible gap between the last text line and the reactions row below.
+    private var bubble: some View {
+        VStack(alignment: .leading, spacing: 0) {
             header
             Spacer.fixedHeight(8)
             messageContent
-            reactions
         }
+        .padding(.leading, bubbleLeadingPadding)
+        .padding(.trailing, Constants.messageHorizontalPadding)
+        .padding(.vertical, Constants.messageVerticalPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.Background.primary)
+        .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .contextMenu {
+            contextMenu
+        }
+    }
+
+    private var bubbleLeadingPadding: CGFloat {
+        data.isReply ? Constants.replyContentLeadingPadding : Constants.messageHorizontalPadding
     }
 
     private var header: some View {
@@ -188,7 +204,9 @@ struct DiscussionMessageView: View {
                     output?.didSelectAddReaction(messageId: data.message.id)
                 }
             )
-            .padding(.top, 8)
+            .padding(.leading, bubbleLeadingPadding)
+            .padding(.trailing, Constants.messageHorizontalPadding)
+            .padding(.bottom, Constants.messageVerticalPadding)
         }
     }
 


### PR DESCRIPTION
## Summary
- Isolated the `.contextMenu` / `.contentShape(.contextMenuPreview, ...)` to the `bubble` subview so the preview rect stays stable whether or not the comment has reactions.
- The previous preview rect grew when the first reaction was added, and the dismiss-zoom animation interpolated into a taller rect — clipping the comment content for a few frames (IOS-6074).
- Bubble now owns its padding internally and renders a full-width rounded preview card; reactions row is a sibling below with its own padding.