### PR TITLE
IOS-6073 Register chat subId before first send to prevent chatAdd drop

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -835,7 +835,13 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
             chatActionProviderBinding.wrappedValue.register(chatId: newChatId, handler: self)
         }
 
-        // Start deferred subscriptions
+        // Best-effort: register the message subscription with middleware before createMessage
+        // fires, so the first chatAdd event carries our subId instead of being filtered out in
+        // DiscussionMessagesStorage.handle(events:). If this throws (e.g. transient network
+        // error), swallow it — addDiscussion already succeeded and the user's first comment
+        // must still be sendable; startDeferredSubscriptions will retry on its own.
+        try? await chatStorage?.startSubscriptionIfNeeded()
+
         startDeferredSubscriptions()
 
         return newChatId


### PR DESCRIPTION
## Summary
- Fixes a race on first-comment send where `createMessage` reached middleware before `subscribeLastMessages` registered the storage's `subId`, so the resulting `chatAdd` event was dropped by the subId filter in `DiscussionMessagesStorage.handle(events:)` and the UI showed "0 comments" until the user sent a second message and scrolled.
- `createDiscussionIfNeeded` now best-effort awaits `startSubscriptionIfNeeded` before returning, so the subId is registered before the first send. Uses `try?` so a transient network error can't block an otherwise-successful first comment — `startDeferredSubscriptions` retries on its own.