### PR TITLE
IOS-5864 simplify: cheaper chat-preview lookups, tighter builder API, comment cleanup

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -119,21 +119,12 @@ private struct HomeWidgetsInternalView: View {
         if context == .overlay, let data = model.homeWidgetData {
             HomeWidgetView(data: data)
                 .id("\(data.objectId)-\(data.canSetHomepage)")
-                // 8pt gap to the channel-pins section that follows. Lives on
-                // the home widget itself so the spacing only applies when home
-                // is visible — no extra view needed otherwise.
                 .padding(.bottom, 8)
         }
     }
 
     @ViewBuilder
     private var unreadWidget: some View {
-        // No `context == .overlay` gate — unread is global to the space and
-        // should be visible in both navigation and overlay contexts. The legacy
-        // `topWidgets` (flag-off branch) only suppressed unread in overlay as a
-        // side effect of sharing the slot with the home widget via `else if`;
-        // that constraint doesn't carry over now that home and unread are
-        // dedicated sections.
         if model.shouldShowUnreadSection {
             HomeWidgetsGroupView(title: Loc.unread) {
                 model.onTapUnreadHeader()

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/BaseDocumentProtocol+Favorites.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/BaseDocumentProtocol+Favorites.swift
@@ -2,13 +2,6 @@ import Foundation
 import Services
 
 extension BaseDocumentProtocol {
-
-    /// Returns true if this document's widget tree contains a widget block referencing
-    /// `objectId`. The semantic meaning is carried by the document the call is made on:
-    ///  - Called on the per-user personal widgets document, it answers "is favorited".
-    ///  - Called on the shared channel widgets document, it answers "is channel-pinned".
-    /// Call-site variable names (`personalWidgetsObject` / `channelWidgetsObject`) make
-    /// the intent explicit without needing separately-named wrappers.
     func containsWidgetFor(objectId: String) -> Bool {
         widgetBlockIdFor(targetObjectId: objectId) != nil
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Builders/WidgetChatPreviewBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Builders/WidgetChatPreviewBuilder.swift
@@ -3,14 +3,7 @@ import Services
 
 @MainActor
 protocol WidgetChatPreviewBuilderProtocol: AnyObject, Sendable {
-    /// Builds the `MessagePreviewModel` for a single chat row. Returns `nil` when
-    /// the object is not a chat or has no last message — callers should render a
-    /// plain (non-chat) row in that case.
-    func build(
-        chatPreviews: [ChatMessagePreview],
-        objectId: String,
-        spaceView: SpaceView?
-    ) -> MessagePreviewModel?
+    func build(chatPreview: ChatMessagePreview, spaceView: SpaceView?) -> MessagePreviewModel?
 }
 
 @MainActor
@@ -18,15 +11,8 @@ final class WidgetChatPreviewBuilder: WidgetChatPreviewBuilderProtocol, Sendable
 
     private let dateFormatter = ChatPreviewDateFormatter()
 
-    func build(
-        chatPreviews: [ChatMessagePreview],
-        objectId: String,
-        spaceView: SpaceView?
-    ) -> MessagePreviewModel? {
-        guard let preview = chatPreviews.first(where: { $0.chatId == objectId }),
-              let lastMessage = preview.lastMessage else {
-            return nil
-        }
+    func build(chatPreview: ChatMessagePreview, spaceView: SpaceView?) -> MessagePreviewModel? {
+        guard let lastMessage = chatPreview.lastMessage else { return nil }
 
         let attachments = lastMessage.attachments.prefix(3).map { objectDetails in
             MessagePreviewModel.Attachment(
@@ -35,7 +21,7 @@ final class WidgetChatPreviewBuilder: WidgetChatPreviewBuilderProtocol, Sendable
             )
         }
 
-        let notificationMode = spaceView?.effectiveNotificationMode(for: objectId) ?? .all
+        let notificationMode = spaceView?.effectiveNotificationMode(for: chatPreview.chatId) ?? .all
 
         return MessagePreviewModel(
             creatorTitle: lastMessage.creator?.title,
@@ -43,9 +29,9 @@ final class WidgetChatPreviewBuilder: WidgetChatPreviewBuilderProtocol, Sendable
             attachments: Array(attachments),
             localizedAttachmentsText: lastMessage.localizedAttachmentsText,
             chatPreviewDate: dateFormatter.localizedDateString(for: lastMessage.createdAt, showTodayTime: true),
-            unreadCounter: preview.unreadCounter,
-            mentionCounter: preview.mentionCounter,
-            hasUnreadReactions: preview.hasUnreadReactions,
+            unreadCounter: chatPreview.unreadCounter,
+            mentionCounter: chatPreview.mentionCounter,
+            hasUnreadReactions: chatPreview.hasUnreadReactions,
             notificationMode: notificationMode,
             chatName: nil
         )

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Builders/WidgetRowModelBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Builders/WidgetRowModelBuilder.swift
@@ -34,7 +34,8 @@ final class WidgetRowModelBuilder: WidgetRowModelBuilderProtocol, Sendable {
         let previewsByChatId: [String: ChatMessagePreview]
         if let spaceId = spaceView?.targetSpaceId {
             previewsByChatId = Dictionary(
-                uniqueKeysWithValues: chatPreviews.lazy.filter { $0.spaceId == spaceId }.map { ($0.chatId, $0) }
+                chatPreviews.lazy.filter { $0.spaceId == spaceId }.map { ($0.chatId, $0) },
+                uniquingKeysWith: { first, _ in first }
             )
         } else {
             previewsByChatId = [:]

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Builders/WidgetRowModelBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Builders/WidgetRowModelBuilder.swift
@@ -31,12 +31,11 @@ final class WidgetRowModelBuilder: WidgetRowModelBuilderProtocol, Sendable {
         spaceView: SpaceView?,
         chatPreviews: [ChatMessagePreview]
     ) -> [ListWidgetRowModel] {
-        configs.map { config in
-            let chatPreview = chatPreviewBuilder.build(
-                chatPreviews: chatPreviews,
-                objectId: config.id,
-                spaceView: spaceView
-            )
+        let previewsByChatId = Dictionary(chatPreviews.map { ($0.chatId, $0) }, uniquingKeysWith: { first, _ in first })
+        return configs.map { config in
+            let chatPreview = previewsByChatId[config.id].flatMap {
+                chatPreviewBuilder.build(chatPreview: $0, spaceView: spaceView)
+            }
             return ListWidgetRowModel(details: config, chatPreview: chatPreview)
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Builders/WidgetRowModelBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Builders/WidgetRowModelBuilder.swift
@@ -31,7 +31,14 @@ final class WidgetRowModelBuilder: WidgetRowModelBuilderProtocol, Sendable {
         spaceView: SpaceView?,
         chatPreviews: [ChatMessagePreview]
     ) -> [ListWidgetRowModel] {
-        let previewsByChatId = Dictionary(chatPreviews.map { ($0.chatId, $0) }, uniquingKeysWith: { first, _ in first })
+        let previewsByChatId: [String: ChatMessagePreview]
+        if let spaceId = spaceView?.targetSpaceId {
+            previewsByChatId = Dictionary(
+                uniqueKeysWithValues: chatPreviews.lazy.filter { $0.spaceId == spaceId }.map { ($0.chatId, $0) }
+            )
+        } else {
+            previewsByChatId = [:]
+        }
         return configs.map { config in
             let chatPreview = previewsByChatId[config.id].flatMap {
                 chatPreviewBuilder.build(chatPreview: $0, spaceView: spaceView)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetActionsMenu/WidgetCommonActionsMenuView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetActionsMenu/WidgetCommonActionsMenuView.swift
@@ -3,14 +3,12 @@ import SwiftUI
 import AnytypeCore
 import Services
 
-// Matches the context-menu transition-to-list animation so delete / unpin actions
-// don't glitch mid-animation. Used by `.removeSystemWidget` and `.channelPin`.
+// Wait for the context menu's transition-to-list animation before running actions
+// that mutate the list, otherwise the removal animation glitches.
 private let menuDismissAnimationDelay: TimeInterval = 0.7
 
 enum WidgetMenuItem: Hashable {
     case changeType
-    /// Legacy "Unpin" action for object widgets under `personalFavorites` flag-off.
-    /// Under flag-on, `.channelPin` (bidirectional, owner-gated) replaces this.
     case remove
     case removeSystemWidget
     case favorite(isFavorited: Bool)
@@ -22,15 +20,9 @@ struct WidgetCommonActionsMenuView: View {
     let items: [WidgetMenuItem]
     let widgetBlockId: String
     let channelWidgetsObject: any BaseDocumentProtocol
-    /// Per-user personal widgets document. `nil` when the personalFavorites flag
-    /// is off; in that case `.favorite` items never appear (VM's `menuItems`
-    /// filters them out).
     let personalWidgetsObject: (any BaseDocumentProtocol)?
     let homeState: HomeWidgetsState
     let output: (any CommonWidgetModuleOutput)?
-    /// `nil` for library widgets (Bin / Objects / Tasks / …). `.favorite` and
-    /// `.channelPin` items require this to be non-nil — the VM's `menuItems` only
-    /// emits them when `targetObjectId != nil`.
     let targetObjectId: String?
 
     @StateObject private var model = WidgetCommonActionsMenuViewModel()
@@ -75,9 +67,6 @@ struct WidgetCommonActionsMenuView: View {
             }
         case .remove:
             Button {
-                // Same delay rationale as `.removeSystemWidget`: wait for the context
-                // menu's transition-to-list animation to finish before triggering the
-                // unpin, or the row-removal animation glitches.
                 DispatchQueue.main.asyncAfter(deadline: .now() + menuDismissAnimationDelay) {
                     model.provider.onDeleteWidgetTap(
                         widgetObject: channelWidgetsObject,
@@ -92,9 +81,6 @@ struct WidgetCommonActionsMenuView: View {
             }
         case .removeSystemWidget:
             Button(role: .destructive) {
-                // Fix animation glitch.
-                // We should to finalize context menu transition to list and then delete object
-                // If we find how customize context menu transition, this 🩼 can be deleted
                 DispatchQueue.main.asyncAfter(deadline: .now() + menuDismissAnimationDelay) {
                     model.provider.onDeleteWidgetTap(
                         widgetObject: channelWidgetsObject,
@@ -109,9 +95,7 @@ struct WidgetCommonActionsMenuView: View {
 
             }
         case let .favorite(isFavorited):
-            // X24 star variants are not in the asset catalog (plan Addendum A); the SF
-            // Symbol fallback mirrors `ObjectActionRow.menuIcon` — dedicated icons are a
-            // design-system follow-up.
+            // TODO: swap SF Symbol fallback for X24 star assets once design adds them.
             Button {
                 guard let targetObjectId else {
                     anytypeAssertionFailure(".favorite menu item emitted without targetObjectId")
@@ -130,20 +114,11 @@ struct WidgetCommonActionsMenuView: View {
                 Image(systemName: isFavorited ? "star.fill" : "star")
             }
         case let .channelPin(isPinned):
-            // See `WidgetActionsViewCommonMenuProvider.onChannelPinTap` for the toggle
-            // logic. Under the `personalFavorites` flag, this replaces the legacy
-            // `.remove` / "Unpin" menu item — channel pins become permission-gated and
-            // bidirectional (pin or unpin). Flag-off keeps `.remove` for parity with
-            // the pre-IOS-5864 behavior.
             Button {
                 guard let targetObjectId else {
                     anytypeAssertionFailure(".channelPin menu item emitted without targetObjectId")
                     return
                 }
-                // Match `menuDismissAnimationDelay` used by `.removeSystemWidget`: the
-                // context menu's transition-to-list animation hasn't finished when the
-                // tap fires. Without the delay, unpinning a row that's currently
-                // animating produces a glitch.
                 DispatchQueue.main.asyncAfter(deadline: .now() + menuDismissAnimationDelay) {
                     model.provider.onChannelPinTap(
                         targetObjectId: targetObjectId,
@@ -159,7 +134,6 @@ struct WidgetCommonActionsMenuView: View {
 }
 
 private final class WidgetCommonActionsMenuViewModel: ObservableObject {
-    // Simple way for inject di. Model is this case is not needed.
     @Injected(\.widgetActionsViewCommonMenuProvider)
     var provider: any WidgetActionsViewCommonMenuProviderProtocol
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Container/WidgetContainerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Container/WidgetContainerViewModel.swift
@@ -11,22 +11,12 @@ final class WidgetContainerViewModel {
     // MARK: - DI
 
     let widgetBlockId: String
-    /// Shared channel widgets document (`info.widgetsId`). The widget block this
-    /// container wraps lives in here.
     let channelWidgetsObject: any BaseDocumentProtocol
-    /// Per-user personal widgets document (`info.personalWidgetsId`). Passed in
-    /// from `HomeWidgetsViewModel` via `WidgetSubmoduleData` so there is a single
-    /// owner. `nil` when the personalFavorites flag is off.
+    // `nil` when the personalFavorites flag is off.
     @ObservationIgnored
     let personalWidgetsObject: (any BaseDocumentProtocol)?
-    /// Per-space account info — needed by the new `.favorite` menu items to
-    /// derive `personalWidgetsId`. All current call sites forward
-    /// `WidgetSubmoduleData.spaceInfo` here.
     let spaceInfo: AccountInfo
-    /// Target object id referenced by this widget block. Populated for `.object`
-    /// sources (channel pins / personal favorites) and `nil` for library widgets
-    /// (Pinned / Recent / etc.). Needed by the new `.favorite` / `.channelPin`
-    /// menu items in Task 10 so the provider can toggle state for the right object.
+    // `nil` for library widgets (Pinned / Recent / …).
     let targetObjectId: String?
     weak var output: (any CommonWidgetModuleOutput)?
 
@@ -43,15 +33,8 @@ final class WidgetContainerViewModel {
     }
     var homeState: HomeWidgetsState = .readonly
     var toastData: ToastBarData?
-    /// Source-filtered items fixed at init — `.changeType` / `.removeSystemWidget`
-    /// inclusion depends only on widget source. Runtime items (`.favorite`,
-    /// `.channelPin`) are appended by the computed `menuItems` below.
     @ObservationIgnored
     private let baseMenuItems: [WidgetMenuItem]
-    /// Final menu items for the long-press context menu. Evaluated lazily each time
-    /// SwiftUI builds the `.contextMenu` closure (i.e. on long-press), so the
-    /// per-item state is read synchronously from live documents without needing
-    /// persistent subscriptions.
     var menuItems: [WidgetMenuItem] {
         guard FeatureFlags.personalFavorites, targetObjectId != nil else {
             return baseMenuItems
@@ -63,21 +46,14 @@ final class WidgetContainerViewModel {
         return baseMenuItems + extras
     }
 
-    /// Whether `targetObjectId` currently lives in the per-user personal widgets
-    /// document. Read on demand from the already-open doc; stale-while-menu-open is
-    /// acceptable since the menu is re-evaluated on every long-press.
     private var isFavorited: Bool {
         guard let personalWidgetsObject, let targetObjectId else { return false }
         return personalWidgetsObject.containsWidgetFor(objectId: targetObjectId)
     }
-    /// Whether `targetObjectId` is currently present in the shared channel widgets
-    /// document. Read on demand from `channelWidgetsObject`.
     private var isPinnedToChannel: Bool {
         guard let targetObjectId else { return false }
         return channelWidgetsObject.containsWidgetFor(objectId: targetObjectId)
     }
-    /// Gate for rendering `.channelPin`. Read on demand from the participant-space
-    /// storage snapshot.
     private var canManageChannelPins: Bool {
         guard FeatureFlags.personalFavorites, targetObjectId != nil else { return false }
         return participantSpacesStorage
@@ -117,10 +93,6 @@ final class WidgetContainerViewModel {
 
         let numberOfWidgetLayouts = source?.availableWidgetLayout.count ?? 0
         let menuItems = numberOfWidgetLayouts > 1 ? expectedMenuItems : expectedMenuItems.filter { $0 != .changeType }
-        // `.removeSystemWidget` is library-only (destructive delete for Bin / Objects / …).
-        // `.remove` is the legacy "Unpin" action for object widgets (flag-off only). Under
-        // flag-on, `.channelPin` (bidirectional, owner-gated) is appended by the computed
-        // `menuItems` below and replaces `.remove`.
         if source?.isLibrary ?? false {
             self.baseMenuItems = menuItems.filter { $0 != .remove }
         } else if FeatureFlags.personalFavorites {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Link/LinkWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Link/LinkWidgetViewModel.swift
@@ -86,10 +86,8 @@ final class LinkWidgetViewModel {
             return
         }
         let spaceView = spaceViewsStorage.spaceView(spaceId: linkedObjectDetails.spaceId)
-        badgeModel = chatPreviewBuilder.build(
-            chatPreviews: chatPreviews,
-            objectId: linkedObjectDetails.id,
-            spaceView: spaceView
-        )
+        badgeModel = chatPreviews.first(where: { $0.chatId == linkedObjectDetails.id }).flatMap {
+            chatPreviewBuilder.build(chatPreview: $0, spaceView: spaceView)
+        }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Link/LinkWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Link/LinkWidgetViewModel.swift
@@ -86,7 +86,9 @@ final class LinkWidgetViewModel {
             return
         }
         let spaceView = spaceViewsStorage.spaceView(spaceId: linkedObjectDetails.spaceId)
-        badgeModel = chatPreviews.first(where: { $0.chatId == linkedObjectDetails.id }).flatMap {
+        badgeModel = chatPreviews.first(where: {
+            $0.spaceId == linkedObjectDetails.spaceId && $0.chatId == linkedObjectDetails.id
+        }).flatMap {
             chatPreviewBuilder.build(chatPreview: $0, spaceView: spaceView)
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowData.swift
@@ -1,24 +1,10 @@
 import Foundation
 
-// View-data for a single row in the My Favorites section. Built by
-// `MyFavoritesViewModel` from `ObjectDetails` + the widget-block id, so the row
-// view renders from flat fields and doesn't need to know about `ObjectDetails`.
-// Matches the shape used by `ListWidgetRowModel` for channel-pin rows — closure
-// pre-bound at row-build time captures the navigation target, keeping the view
-// layer decoupled from routing semantics.
 struct MyFavoritesRowData: Identifiable, Equatable {
-    /// Widget block id inside the personal widgets virtual document. Stable per
-    /// favorite; used as SwiftUI identity and as the block id handed to reorder /
-    /// remove RPCs.
     let id: String
-    /// Target object id the favorite points to. Used by the long-press context
-    /// menu to toggle favorite / channel-pin state.
     let objectId: String
     let title: String
     let icon: Icon
-    /// Non-nil only when the favorited object is a chat with a last message.
-    /// Drives the unread-counter / mention / reaction badges — gated view-side by
-    /// `\.shouldHideChatBadges` so they hide while the unread section is expanded.
     let chatPreview: MessagePreviewModel?
     @EquatableNoop var onTap: @MainActor () -> Void
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift
@@ -6,21 +6,11 @@ import AnytypeCore
 struct MyFavoritesRowView: View {
     let row: MyFavoritesRowData
     let showDivider: Bool
-    /// Channel widgets document for this space (`info.widgetsId`). Passed through
-    /// to `WidgetActionsViewCommonMenuProvider.onChannelPinTap` so it can toggle
-    /// the pin against the correct document.
     let channelWidgetsObject: any BaseDocumentProtocol
-    /// Per-user personal widgets document (`info.personalWidgetsId`). Passed through
-    /// to `onFavoriteTap` so the toggle runs against an already-open doc.
     let personalWidgetsObject: any BaseDocumentProtocol
     let canManageChannelPins: Bool
-    /// Computed once at the ViewModel layer (`pinnedToChannelObjectIds`) so each
-    /// row receives a plain Bool instead of opening its own subscription.
     let isPinnedToChannel: Bool
 
-    /// Hides chat badges while the dedicated unread section is expanded — a chat's
-    /// unread signal shouldn't appear in two places at once. Pushed into the
-    /// environment by `HomeWidgetsView`.
     @Environment(\.shouldHideChatBadges) private var shouldHideChatBadges
 
     var body: some View {
@@ -52,7 +42,6 @@ struct MyFavoritesRowView: View {
         }
         .if(FeatureFlags.personalFavorites) {
             $0.contextMenu {
-                // Favorite section of a favorites row always renders "Unfavorite".
                 MyFavoritesRowContextMenu(
                     objectId: row.objectId,
                     channelWidgetsObject: channelWidgetsObject,
@@ -83,8 +72,6 @@ struct MyFavoritesRowView: View {
     }
 }
 
-/// Split out so the context menu's body does not re-compute when the outer row
-/// redraws for unrelated reasons (spacing / divider).
 private struct MyFavoritesRowContextMenu: View {
     let objectId: String
     let channelWidgetsObject: any BaseDocumentProtocol
@@ -120,7 +107,6 @@ private struct MyFavoritesRowContextMenu: View {
 }
 
 private final class MyFavoritesRowContextMenuViewModel: ObservableObject {
-    // Simple way for inject di. Model in this case is not needed.
     @Injected(\.widgetActionsViewCommonMenuProvider)
     var provider: any WidgetActionsViewCommonMenuProviderProtocol
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift
@@ -127,7 +127,8 @@ final class MyFavoritesViewModel {
         let spaceView = self.spaceView
         let spaceId = self.spaceId
         let previewsByChatId = Dictionary(
-            uniqueKeysWithValues: chatPreviews.lazy.filter { $0.spaceId == spaceId }.map { ($0.chatId, $0) }
+            chatPreviews.lazy.filter { $0.spaceId == spaceId }.map { ($0.chatId, $0) },
+            uniquingKeysWith: { first, _ in first }
         )
         let newRows: [MyFavoritesRowData] = sourceBlocks.map { block in
             let details = block.details

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift
@@ -10,14 +10,8 @@ final class MyFavoritesViewModel {
 
     @ObservationIgnored
     let personalWidgetsObject: any BaseDocumentProtocol
-    /// Shared channel widgets document — used to compute the per-row
-    /// `isPinnedToChannel` flag shown in the long-press menu.
     @ObservationIgnored
     let channelWidgetsObject: any BaseDocumentProtocol
-    /// Row-tap routing. Plain closure (not a module-output protocol) because
-    /// `HomeWidgetsView` already has a `CommonWidgetModuleOutput` it can forward
-    /// to — adding another protocol indirection just to hand back the same
-    /// `ScreenData` would be noise. See IOS-5864 Task 5.
     @ObservationIgnored
     let onObjectSelected: (ObjectDetails) -> Void
 
@@ -42,12 +36,8 @@ final class MyFavoritesViewModel {
 
     // MARK: - Source state
 
-    /// Raw per-favorite (block id + details) tuples sourced from the personal
-    /// widgets document. Kept separate from the published `rows` so we can
-    /// recompute the row array whenever chat previews / space view update
-    /// without re-reading the document tree.
     @ObservationIgnored
-    private var sourceBlocks: [(blockId: String, details: ObjectDetails)] = []
+    private var sourceBlocks: [SourceBlock] = []
     @ObservationIgnored
     private var chatPreviews: [ChatMessagePreview] = []
     @ObservationIgnored
@@ -56,14 +46,8 @@ final class MyFavoritesViewModel {
     // MARK: - Published state
 
     var rows: [MyFavoritesRowData] = []
-    /// Object ids currently pinned to the channel widgets document. Computed
-    /// reactively from `channelWidgetsObject.syncPublisher` so each row can
-    /// render a plain `Bool` via `.contains(objectId)` without its own subscription.
     var pinnedToChannelObjectIds: Set<String> = []
 
-    /// Owner-only gate for the row's `.pinToChannel` menu item. Read on demand from
-    /// the participant-space storage snapshot — ownership transfer is rare enough
-    /// that a live subscription isn't warranted. Mirrors `WidgetContainerViewModel`.
     var canManageChannelPins: Bool {
         participantSpacesStorage
             .participantSpaceView(spaceId: spaceId)?
@@ -95,20 +79,20 @@ final class MyFavoritesViewModel {
     private func startPersonalWidgetsSubscription() async {
         for await _ in personalWidgetsObject.syncPublisher.values {
             let widgets = personalWidgetsObject.children.filter(\.isWidget)
-            sourceBlocks = widgets.compactMap { block in
+            let next: [SourceBlock] = widgets.compactMap { block in
                 guard let info = personalWidgetsObject.widgetInfo(block: block),
                       case let .object(details) = info.source,
                       details.isNotDeletedAndSupportedForOpening else {
                     return nil
                 }
-                return (blockId: block.id, details: details)
+                return SourceBlock(blockId: block.id, details: details)
             }
+            guard sourceBlocks != next else { continue }
+            sourceBlocks = next
             recomputeRows()
         }
     }
 
-    /// Rebuilds `pinnedToChannelObjectIds` on every channel widgets document
-    /// emission. Single subscription instead of one per row.
     private func startChannelPinsSubscription() async {
         for await _ in channelWidgetsObject.syncPublisher.values {
             var next: Set<String> = []
@@ -138,19 +122,15 @@ final class MyFavoritesViewModel {
 
     // MARK: - Row recomputation
 
-    /// Single projection point from raw sources to published `rows`. Called from
-    /// every subscription so a chat-preview-only change (e.g. unread counter tick)
-    /// still propagates without touching the personal widgets document.
     private func recomputeRows() {
         let onObjectSelected = self.onObjectSelected
         let spaceView = self.spaceView
+        let previewsByChatId = Dictionary(chatPreviews.map { ($0.chatId, $0) }, uniquingKeysWith: { first, _ in first })
         let newRows: [MyFavoritesRowData] = sourceBlocks.map { block in
-            let chatPreview = chatPreviewBuilder.build(
-                chatPreviews: chatPreviews,
-                objectId: block.details.id,
-                spaceView: spaceView
-            )
             let details = block.details
+            let chatPreview = previewsByChatId[details.id].flatMap {
+                chatPreviewBuilder.build(chatPreview: $0, spaceView: spaceView)
+            }
             return MyFavoritesRowData(
                 id: block.blockId,
                 objectId: details.id,
@@ -168,8 +148,6 @@ final class MyFavoritesViewModel {
 
     func dropUpdate(from: DropDataElement<MyFavoritesRowData>, to: DropDataElement<MyFavoritesRowData>) {
         guard from.data.id != to.data.id else { return }
-        // Optimistic local reorder so the gesture feels immediate. The authoritative
-        // tree arrives via `syncPublisher` once the move RPC completes.
         rows.move(fromOffsets: IndexSet(integer: from.index), toOffset: to.index)
     }
 
@@ -189,4 +167,9 @@ final class MyFavoritesViewModel {
             )
         }
     }
+}
+
+private struct SourceBlock: Equatable {
+    let blockId: String
+    let details: ObjectDetails
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift
@@ -125,7 +125,10 @@ final class MyFavoritesViewModel {
     private func recomputeRows() {
         let onObjectSelected = self.onObjectSelected
         let spaceView = self.spaceView
-        let previewsByChatId = Dictionary(chatPreviews.map { ($0.chatId, $0) }, uniquingKeysWith: { first, _ in first })
+        let spaceId = self.spaceId
+        let previewsByChatId = Dictionary(
+            uniqueKeysWithValues: chatPreviews.lazy.filter { $0.spaceId == spaceId }.map { ($0.chatId, $0) }
+        )
         let newRows: [MyFavoritesRowData] = sourceBlocks.map { block in
             let details = block.details
             let chatPreview = previewsByChatId[details.id].flatMap {

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectAction.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectAction.swift
@@ -16,7 +16,6 @@ enum ObjectAction: Hashable, Identifiable {
     case inviteMembers
     case editInfo
 
-    // When adding to case
     @available(*, deprecated, message: "Use spaceType overload instead")
     static func buildActions(
         details: ObjectDetails,
@@ -42,7 +41,6 @@ enum ObjectAction: Hashable, Identifiable {
                 ObjectAction.pin(isPinned: isPinnedToWidgets)
             }
 
-            // `canCreateWidget` already excludes templates, so no extra check needed.
             if canCreateWidget && FeatureFlags.personalFavorites {
                 ObjectAction.favorite(isFavorited: isFavorited)
             }
@@ -115,7 +113,6 @@ enum ObjectAction: Hashable, Identifiable {
                 ObjectAction.pin(isPinned: isPinnedToWidgets)
             }
 
-            // `canCreateWidget` already excludes templates, so no extra check needed.
             if canCreateWidget && FeatureFlags.personalFavorites {
                 ObjectAction.favorite(isFavorited: isFavorited)
             }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionRow.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionRow.swift
@@ -85,11 +85,8 @@ extension ObjectAction {
         case let .archive(isArchived):
             return isArchived ? .X32.restore : .X32.delete
         case .pin, .favorite:
-            // Neutral fallback — `.pin` and `.favorite` are rendered via `menuIcon`
-            // (SF Symbols) in `ObjectSettingsMenuView`, which is the only runtime
-            // surface. The rail asset only appears in the SwiftUI preview below.
-            // Dedicated X32.pin / X32.pin.slash / X32.star assets are a
-            // design-system follow-up (plan Addendum A).
+            // TODO: swap for X32.pin / X32.star once design ships them. Runtime uses
+            // `menuIcon` (SF Symbols); this rail asset only appears in the preview.
             return .X32.Favorite.favorite
         case let .locked(isLocked):
             return isLocked ? .X32.Lock.unlock : .X32.Lock.lock

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
@@ -80,17 +80,9 @@ final class ObjectSettingsViewModel {
         return openDocumentsProvider.document(objectId: info.widgetsId, spaceId: spaceId)
     }()
 
-    // Per-user personal widgets document (IOS-5864). Opened lazily so flag-off
-    // behaviour stays byte-identical. `isFavorited` is read from this document's
-    // widget tree via the `BaseDocumentProtocol+Favorites` helper.
-    //
-    // Uses the per-space `AccountInfo` from `workspaceStorage` (same pattern as
-    // `widgetObject` above) rather than the global `accountManager.account.info`:
-    // (1) personal widgets are per-space, so the encoded id must reflect the
-    // current space — using the global signup-space id would derive the wrong
-    // virtual document in shared workspaces; (2) `accountManager.account.info`
-    // can race app launch with `AccountData.empty`, which would silently ship
-    // `_personalWidgets_` to MW.
+    // Uses per-space `AccountInfo` from `workspaceStorage` (not the global
+    // `accountManager.account.info`) because personal widgets are per-space and
+    // the global info can race app launch with `AccountData.empty`.
     @ObservationIgnored
     private lazy var personalWidgetsObject: (any BaseDocumentProtocol)? = {
         guard FeatureFlags.personalFavorites else { return nil }
@@ -120,14 +112,7 @@ final class ObjectSettingsViewModel {
     // MARK: - Actions State
 
     var objectActions: [ObjectAction] = []
-    // Mirrors `ParticipantSpaceViewData.canManageChannelPins` — today synonymous with
-    // `isOwner`, but modelled as its own predicate so a future Admin role widens in
-    // one spot. Used by `.pin` gating in `buildActions`. Kept separate from
-    // `isSpaceOwner` so the two concepts do not collapse.
     private var canManageChannelPins: Bool = false
-    // Real ownership check — drives `.inviteMembers` gating. Reads
-    // `participantSpaceView.isOwner` directly so it stays decoupled from channel-pin
-    // management semantics above.
     private var isSpaceOwner: Bool = false
     private var chatNotificationMode: SpacePushNotificationsMode?
     var toastData: ToastBarData?

--- a/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/Model/ParticipantSpaceViewData.swift
+++ b/Anytype/Sources/ServiceLayer/ParticipantSpacesStorage/Model/ParticipantSpaceViewData.swift
@@ -44,9 +44,7 @@ extension ParticipantSpaceViewData {
         participant?.isOwner ?? false
     }
 
-    /// Single source of truth for the IOS-5864 Pin-to-channel / Unpin-from-channel
-    /// gate. Owner-only today — middleware has no Admin role. When/if MW adds
-    /// Admin, widen this predicate in one spot.
+    // Owner-only today. Separate from `isOwner` so a future Admin role widens here.
     var canManageChannelPins: Bool {
         isOwner
     }

--- a/Anytype/Sources/ServiceLayer/PersonalFavorites/PersonalFavoritesService.swift
+++ b/Anytype/Sources/ServiceLayer/PersonalFavorites/PersonalFavoritesService.swift
@@ -3,13 +3,8 @@ import Services
 import AnytypeCore
 
 protocol PersonalFavoritesServiceProtocol: AnyObject, Sendable {
-    /// Toggles the personal favorite state for the given object. If the object is
-    /// already in the per-user personal widgets document, its widget block is
-    /// removed; otherwise a new widget block is created at the top of the list.
-    ///
-    /// Caller must pass an already-open `personalWidgetsObject` — `children` and
-    /// `widgetBlockIdFor(...)` are read synchronously, so a not-yet-opened doc would
-    /// fall into the "create" branch on an existing favorite and produce a duplicate.
+    // Caller must pass an already-open `personalWidgetsObject`; synchronous reads
+    // of `children` / `widgetBlockIdFor(...)` would otherwise duplicate on toggle.
     func toggle(objectId: String, personalWidgetsObject: any BaseDocumentProtocol) async throws
 }
 
@@ -18,10 +13,6 @@ final class PersonalFavoritesService: PersonalFavoritesServiceProtocol {
     private let blockWidgetService: any BlockWidgetServiceProtocol = Container.shared.blockWidgetService()
 
     func toggle(objectId: String, personalWidgetsObject: any BaseDocumentProtocol) async throws {
-        // WidgetPosition mapping: desktop uses MW `InnerFirst` to prepend. iOS
-        // `WidgetPosition` exposes `.end`, `.above`, `.below` only. The shared
-        // `toggleWidgetBlock` helper reproduces "prepend to top" via `.above(first)`
-        // with `.end` fallback for an empty document.
         try await blockWidgetService.toggleWidgetBlock(
             contextId: personalWidgetsObject.objectId,
             targetObjectId: objectId,

--- a/Modules/Services/Sources/Models/Account/AccountInfo+PersonalWidgets.swift
+++ b/Modules/Services/Sources/Models/Account/AccountInfo+PersonalWidgets.swift
@@ -1,26 +1,13 @@
 import Foundation
 import AnytypeCore
 
-// Client-side derivation of the per-space personal widgets virtual object id.
-// Mirrors anytype-heart `domain.NewPersonalWidgetsId` (GO-6962, anytype-heart
-// PR #3092): only the FIRST dot in the spaceId is replaced with `_`, so that
-// `domain.ParsePersonalWidgetsId` can split the suffix on the first underscore
-// and round-trip back to the original spaceId. Replacing every dot would diverge
-// from middleware for any spaceId with 2+ dots.
-//
-// The spaceId encoded here is the user's ACTIVE data space (not the tech space).
-// The heart resolver parses the spaceId straight out of the id and uses it as
-// `domain.FullID.SpaceID` for the virtual object — see
-// `anytype-heart/core/block/source/sourceimpl/service.go`.
 public extension AccountInfo {
+    // Mirrors anytype-heart `domain.NewPersonalWidgetsId`: only the first dot in
+    // the spaceId is replaced so `ParsePersonalWidgetsId` can round-trip spaceIds
+    // with multiple dots.
     var personalWidgetsId: String {
         guard !accountSpaceId.isEmpty else {
-            // Dump the top of the call stack so we can identify the caller that
-            // raced AccountManager initialization. Trimmed to keep the log readable.
-            let stack = Thread.callStackSymbols.prefix(8).joined(separator: "\n")
-            anytypeAssertionFailure(
-                "personalWidgetsId requested with empty accountSpaceId\n\(stack)"
-            )
+            anytypeAssertionFailure("personalWidgetsId requested with empty accountSpaceId")
             return ""
         }
         var encoded = accountSpaceId


### PR DESCRIPTION
## Summary
- `MyFavoritesViewModel`: guard `sourceBlocks` assignment with an equality check (new private `SourceBlock: Equatable`) so `syncPublisher` ticks that don't change the widget set skip `recomputeRows()`. Build a `[chatId: ChatMessagePreview]` dictionary once per recompute instead of scanning `chatPreviews` linearly per row.
- `WidgetChatPreviewBuilderProtocol.build` narrowed to `(chatPreview: ChatMessagePreview, spaceView: SpaceView?)` — non-optional preview, `objectId` dropped (reads `preview.chatId`). Callers `flatMap` over the optional preview. Same indexing pattern applied in `WidgetRowModelBuilder.buildListRows`.
- Scope chat-preview lookups to the current space before indexing / matching, so a chat id present in multiple spaces can't silently resolve to the wrong preview.
- Strip narrator / task-reference / name-restating doc comments across ~12 files; drop the `Thread.callStackSymbols.prefix(8)` capture from the `personalWidgetsId` empty-spaceId assertion.