### PR TITLE
IOS-6084 Fix long-tap and drag interactions on My Favorites rows

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -33,6 +33,7 @@ private struct HomeWidgetsInternalView: View {
 
             content
                 .animation(.default, value: model.widgetBlocks.count)
+                .animation(.default, value: model.myFavoritesViewModel?.rows.count)
 
             if context.showEmbeddedBottomPanel {
                 HomeBottomNavigationPanelView(

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
@@ -18,13 +18,13 @@ struct MyFavoritesListView: View {
                     canManageChannelPins: model.canManageChannelPins,
                     isPinnedToChannel: model.pinnedToChannelObjectIds.contains(row.objectId)
                 )
-                .setZeroOpacity(favoritesDndState.dragInitiateId == row.id)
+                .contentShape(.dragPreview, RoundedRectangle(cornerRadius: 24, style: .continuous))
                 .anytypeVerticalDrag(itemId: row.id)
+                .setZeroOpacity(favoritesDndState.dragInitiateId == row.id)
             }
         }
         .background(Color.Background.widget)
         .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
-        .contentShape(.dragPreview, RoundedRectangle(cornerRadius: 24, style: .continuous))
         .anytypeVerticalDrop(data: model.rows, state: $favoritesDndState) { from, to in
             model.dropUpdate(from: from, to: to)
         } dropFinish: { from, to in

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift
@@ -40,6 +40,8 @@ struct MyFavoritesRowView: View {
         .if(showDivider) {
             $0.newDivider(leadingPadding: 16, trailingPadding: 16, color: .Widget.divider)
         }
+        .background(Color.Background.widget)
+        .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 24, style: .continuous))
         .contextMenu {
             MyFavoritesRowContextMenu(
                 objectId: row.objectId,


### PR DESCRIPTION
## Summary

- Fixes the context-menu long-press preview on My Favorites rows: adds a solid widget-background and `.contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 24))` so the preview no longer renders transparent with wrong corners.
- Fixes empty/ghost drag preview: reorders row modifiers to `.contentShape(.dragPreview)` → `.anytypeVerticalDrag` → `.setZeroOpacity`, so UIKit captures the source view before the opacity suppression flips on. Also moves the drag-preview shape from the list container to each row (the dragged unit).
- Animates favorite add/remove: extends the existing count-driven animation in `HomeWidgetsView` to also watch `myFavoritesViewModel.rows.count`, so Unfavorite and reorder transitions match the Pinned widget feel.