### PR TITLE
IOS-6088 Fix sizes in Home picker popup

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/HomepageCreatePickerView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/HomepageCreatePickerView.swift
@@ -41,10 +41,15 @@ struct HomepageCreatePickerView: View {
             AnytypeText(Loc.HomepagePicker.title, style: .heading)
                 .foregroundStyle(Color.Text.primary)
                 .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .truncationMode(.tail)
+                .fixedSize(horizontal: false, vertical: true)
 
             AnytypeText(Loc.HomepagePicker.description, style: .previewTitle2Regular)
                 .foregroundStyle(Color.Text.primary)
                 .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .truncationMode(.tail)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/Thumbnails/HomepagePickerThumbnailCard.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/Thumbnails/HomepagePickerThumbnailCard.swift
@@ -9,6 +9,7 @@ struct HomepagePickerThumbnailCard: View {
         VStack(spacing: 7) {
             Image(asset: option.thumbnailAsset)
                 .resizable()
+                .aspectRatio(contentMode: .fit)
                 .frame(width: 88, height: 176)
 
             AnytypeText(option.title, style: .caption1Medium)

--- a/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/Thumbnails/HomepagePickerThumbnailCard.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomepagePicker/Thumbnails/HomepagePickerThumbnailCard.swift
@@ -9,8 +9,7 @@ struct HomepagePickerThumbnailCard: View {
         VStack(spacing: 7) {
             Image(asset: option.thumbnailAsset)
                 .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(height: 176)
+                .frame(width: 88, height: 176)
 
             AnytypeText(option.title, style: .caption1Medium)
                 .foregroundStyle(Color.Text.primary)
@@ -19,7 +18,7 @@ struct HomepagePickerThumbnailCard: View {
 
             AnytypeCircleCheckbox(checked: isSelected, size: 20)
         }
-        .frame(width: 88, height: 228)
+        .frame(width: 88)
         .contentShape(Rectangle())
     }
 }


### PR DESCRIPTION
## Summary

- Cap title and subtitle at 2 lines with tail truncation so long localizations wrap and truncate instead of overflowing or rendering on a single clipped line.
- Pin the thumbnail image to exactly 88×176 (matching Figma node 13086:36314) and keep its native aspect ratio with `.aspectRatio(.fit)` as a guard against future asset swaps.
- Let the thumbnail card's height follow content instead of a hard-coded 228, so long localized option titles can't clip.