### PR TITLE
IOS-6095 Rename sidebar 'Objects' header to 'Types'

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -204,7 +204,7 @@ private struct HomeWidgetsInternalView: View {
 
     @ViewBuilder
     private var objectTypeWidgets: some View {
-        HomeWidgetsGroupView(title: Loc.objects, onTap: {
+        HomeWidgetsGroupView(title: Loc.types, onTap: {
             model.onTapObjectTypeHeader()
         }, onCreate: nil)
         if model.objectTypeSectionIsExpanded {


### PR DESCRIPTION
## Summary
- Rename sidebar section header from "Objects" to "Types" — the section lists object types, not objects.
- Uses existing `Loc.types` key; no new localization entries.

Linear: [IOS-6095](https://linear.app/anytype/issue/IOS-6095/change-objects-to-types-in-sidebar)