### PR TITLE
IOS-6104 Fix My Favorites row vanishing after context menu dismiss

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
@@ -20,7 +20,7 @@ struct MyFavoritesListView: View {
                 )
                 .contentShape(.dragPreview, RoundedRectangle(cornerRadius: 24, style: .continuous))
                 .anytypeVerticalDrag(itemId: row.id)
-                .setZeroOpacity(favoritesDndState.dragInitiateId == row.id)
+                .setZeroOpacity(favoritesDndState.dragInitiateId == row.id && favoritesDndState.dragInProgress)
             }
         }
         .background(Color.Background.widget)


### PR DESCRIPTION
## Summary
- Guard `setZeroOpacity` in `MyFavoritesListView` with `dragInProgress` so the row only fades out during a real drag, not while a long-press context menu is open.
- `onDrag` fires during the long-press lift and sets `dragInitiateId`, but `dragInProgress` only flips true inside `dropEntered`. Without the extra guard, selecting a context menu item (or just lifting off) left the row hidden until `NSItemProvider.deinit` eventually ran.
- Mirrors the existing guard in `LinkWidgetViewContainer.isDragging()`.