### PR TITLE
IOS-6105 Fix crash after moving objects to/from Favorites or Pinned

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropModels.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropModels.swift
@@ -33,7 +33,7 @@ class DragItemProvider: NSItemProvider {
     var didEnd: (() -> Void)?
     deinit {
         // Deferred to the next runloop to avoid re-entrant @Binding mutation when deinit
-        // fires during SwiftUI graph tear-down or drag payload release (IOS-6105).
+        // fires during SwiftUI graph tear-down or drag payload release.
         let didEnd = didEnd
         DispatchQueue.main.async { didEnd?() }
     }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropModels.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropModels.swift
@@ -32,6 +32,9 @@ struct DropState<Data> {
 class DragItemProvider: NSItemProvider {
     var didEnd: (() -> Void)?
     deinit {
-        didEnd?()
+        // Deferred to the next runloop to avoid re-entrant @Binding mutation when deinit
+        // fires during SwiftUI graph tear-down or drag payload release (IOS-6105).
+        let didEnd = didEnd
+        DispatchQueue.main.async { didEnd?() }
     }
 }


### PR DESCRIPTION
## Summary
- Fix SIGABRT/Swift-exclusivity crash on Vault navigation after using Favorite/Unfavorite/Pin/Unpin from the widget long-press menu (all 3 attached crash reports share the same stack).
- Root cause: `DragItemProvider.deinit` synchronously invoked `didEnd?()`, which mutated a SwiftUI `@Binding` (`DragState.resetState()`). When deinit fired inside an autorelease pool drain during a SwiftUI update (`GraphHost.invalidate` on view teardown, or `DragPayload.__deallocating_deinit` mid-interaction), the binding setter re-entered `StoredLocation.isUpdating` and tripped the Swift exclusivity trap.
- Fix: defer the `didEnd` call to the next main-queue turn so the binding mutation never runs re-entrantly inside a SwiftUI update. Also fixes the same latent crash path in `LinkWidgetViewContainer`, which uses the same `anytypeVerticalDrag` modifier.