### PR TITLE
IOS-6002 Comment count badge on discuss button (UI)

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -110,7 +110,6 @@ private struct HomeBottomNavigationPanelViewInternal: View {
             }
             .padding(.horizontal, 12)
             .frame(minHeight: 48)
-            .contentShape(Capsule())
         }
         .glassEffectInteractiveIOS26(in: Capsule())
         .animation(.bouncy, value: hasCount)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -112,8 +112,8 @@ private struct HomeBottomNavigationPanelViewInternal: View {
             .frame(minHeight: 48)
         }
         .glassEffectInteractiveIOS26(in: Capsule())
-        .animation(.bouncy, value: hasCount)
-        .animation(.smooth, value: model.commentsCount)
+        .animation(.snappy(duration: 0.35), value: hasCount)
+        .animation(.snappy(duration: 0.25), value: model.commentsCount)
     }
 
     @ViewBuilder

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -94,15 +94,27 @@ private struct HomeBottomNavigationPanelViewInternal: View {
     }
 
     private var discussIsland: some View {
-        Button {
+        let hasCount = model.commentsCount > 0
+        return Button {
             model.onTapDiscuss()
         } label: {
-            Image(systemName: "message")
-                .foregroundStyle(Color.Control.primary)
-                .frame(width: 48, height: 48)
-                .contentShape(Circle())
+            HStack(spacing: 3) {
+                Image(systemName: "message")
+                    .foregroundStyle(Color.Control.primary)
+                if hasCount {
+                    AnytypeText("\(model.commentsCount)", style: .previewTitle2Medium)
+                        .foregroundStyle(Color.Text.primary)
+                        .contentTransition(.numericText())
+                        .transition(.opacity.combined(with: .scale(scale: 0.5, anchor: .leading)))
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(minHeight: 48)
+            .contentShape(Capsule())
         }
-        .glassEffectInteractiveIOS26(in: Circle())
+        .glassEffectInteractiveIOS26(in: Capsule())
+        .animation(.bouncy, value: hasCount)
+        .animation(.smooth, value: model.commentsCount)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Render the comment count inline on the discuss button as an always-capsule Liquid Glass surface (12pt horizontal padding, 3pt gap to icon)
- Counter uses `AnytypeText` with `previewTitle2Medium` matching Figma 11172-5099, and `.contentTransition(.numericText())` for digit-roll updates
- Bouncy animation when the counter appears/disappears (`hasCount` toggle); smooth animation on value-only changes (e.g., 5 → 6)