### PR TITLE
IOS-6106 Fix MyFavorites drag-cancel crash via per-row ViewModel refactor

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -197,7 +197,10 @@ private struct HomeWidgetsInternalView: View {
                 model.onTapMyFavoritesHeader()
             }
             if model.myFavoritesSectionIsExpanded {
-                MyFavoritesListView(model: myFavoritesViewModel)
+                MyFavoritesListView(
+                    model: myFavoritesViewModel,
+                    channelWidgetsObject: model.channelWidgetsObject
+                )
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -33,7 +33,7 @@ private struct HomeWidgetsInternalView: View {
 
             content
                 .animation(.default, value: model.widgetBlocks.count)
-                .animation(.default, value: model.myFavoritesViewModel?.rows.count)
+                .animation(.default, value: model.myFavoritesListViewModel?.rows.count)
 
             if context.showEmbeddedBottomPanel {
                 HomeBottomNavigationPanelView(
@@ -146,7 +146,7 @@ private struct HomeWidgetsInternalView: View {
                         HomeWidgetSubmoduleView(
                             widgetInfo: widgetInfo,
                             channelWidgetsObject: model.channelWidgetsObject,
-                            personalWidgetsObject: model.myFavoritesViewModel?.personalWidgetsObject,
+                            personalWidgetsObject: model.myFavoritesListViewModel?.personalWidgetsObject,
                             workspaceInfo: model.info,
                             homeState: $model.homeState,
                             output: model.output
@@ -171,7 +171,7 @@ private struct HomeWidgetsInternalView: View {
                             HomeWidgetSubmoduleView(
                                 widgetInfo: widgetInfo,
                                 channelWidgetsObject: model.channelWidgetsObject,
-                                personalWidgetsObject: model.myFavoritesViewModel?.personalWidgetsObject,
+                                personalWidgetsObject: model.myFavoritesListViewModel?.personalWidgetsObject,
                                 workspaceInfo: model.info,
                                 homeState: $model.homeState,
                                 output: model.output
@@ -191,16 +191,13 @@ private struct HomeWidgetsInternalView: View {
     @ViewBuilder
     private var myFavoritesWidget: some View {
         if FeatureFlags.personalFavorites,
-           let myFavoritesViewModel = model.myFavoritesViewModel,
-           myFavoritesViewModel.rows.isNotEmpty {
+           let myFavoritesListViewModel = model.myFavoritesListViewModel,
+           myFavoritesListViewModel.rows.isNotEmpty {
             HomeWidgetsGroupView(title: Loc.myFavorites) {
                 model.onTapMyFavoritesHeader()
             }
             if model.myFavoritesSectionIsExpanded {
-                MyFavoritesListView(
-                    model: myFavoritesViewModel,
-                    channelWidgetsObject: model.channelWidgetsObject
-                )
+                MyFavoritesListView(model: myFavoritesListViewModel)
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -93,7 +93,6 @@ final class HomeWidgetsViewModel {
             self.myFavoritesViewModel = MyFavoritesViewModel(
                 spaceId: info.accountSpaceId,
                 personalWidgetsObject: personalWidgetsObject,
-                channelWidgetsObject: channelWidgetsObject,
                 onObjectSelected: { [weak output] details in
                     output?.onObjectSelected(screenData: details.screenData())
                 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -64,7 +64,7 @@ final class HomeWidgetsViewModel {
     var unreadSectionIsExpanded: Bool = false
     var unreadChats: [UnreadChatWidgetData] = []
     var myFavoritesSectionIsExpanded: Bool = false
-    var myFavoritesViewModel: MyFavoritesViewModel?
+    var myFavoritesListViewModel: MyFavoritesListViewModel?
     private var supportsMultiChats: Bool = false
 
     var spaceId: String { info.accountSpaceId }
@@ -90,15 +90,16 @@ final class HomeWidgetsViewModel {
                 objectId: info.personalWidgetsId,
                 spaceId: info.accountSpaceId
             )
-            self.myFavoritesViewModel = MyFavoritesViewModel(
+            self.myFavoritesListViewModel = MyFavoritesListViewModel(
                 spaceId: info.accountSpaceId,
                 personalWidgetsObject: personalWidgetsObject,
+                channelWidgetsObject: channelWidgetsObject,
                 onObjectSelected: { [weak output] details in
                     output?.onObjectSelected(screenData: details.screenData())
                 }
             )
         } else {
-            self.myFavoritesViewModel = nil
+            self.myFavoritesListViewModel = nil
         }
         self.pinnedSectionIsExpanded = expandedService.isExpanded(id: Constants.pinnedSectionId, defaultValue: true)
         self.objectTypeSectionIsExpanded = expandedService.isExpanded(id: Constants.objectTypeSectionId, defaultValue: true)
@@ -200,10 +201,10 @@ final class HomeWidgetsViewModel {
     }
 
     private func startMyFavoritesTask() async {
-        // Drives the `MyFavoritesViewModel.rows` list — only spins up when the feature flag
+        // Drives the `MyFavoritesListViewModel.rows` list — only spins up when the feature flag
         // enabled the sub-viewmodel in `init`.
-        guard let myFavoritesViewModel else { return }
-        await myFavoritesViewModel.startSubscriptions()
+        guard let myFavoritesListViewModel else { return }
+        await myFavoritesListViewModel.startSubscriptions()
     }
 
     private func startCanEditSubscription() async {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
@@ -4,6 +4,7 @@ import Services
 
 struct MyFavoritesListView: View {
     let model: MyFavoritesViewModel
+    let channelWidgetsObject: any BaseDocumentProtocol
 
     @State private var favoritesDndState = DragState()
 
@@ -13,10 +14,9 @@ struct MyFavoritesListView: View {
                 MyFavoritesRowView(
                     row: row,
                     showDivider: index != model.rows.count - 1,
-                    channelWidgetsObject: model.channelWidgetsObject,
-                    personalWidgetsObject: model.personalWidgetsObject,
-                    canManageChannelPins: model.canManageChannelPins,
-                    isPinnedToChannel: model.pinnedToChannelObjectIds.contains(row.objectId)
+                    spaceId: model.spaceId,
+                    channelWidgetsObject: channelWidgetsObject,
+                    personalWidgetsObject: model.personalWidgetsObject
                 )
                 .contentShape(.dragPreview, RoundedRectangle(cornerRadius: 24, style: .continuous))
                 .anytypeVerticalDrag(itemId: row.id)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
@@ -1,10 +1,8 @@
 import Foundation
 import SwiftUI
-import Services
 
 struct MyFavoritesListView: View {
-    let model: MyFavoritesViewModel
-    let channelWidgetsObject: any BaseDocumentProtocol
+    let model: MyFavoritesListViewModel
 
     @State private var favoritesDndState = DragState()
 
@@ -15,8 +13,9 @@ struct MyFavoritesListView: View {
                     row: row,
                     showDivider: index != model.rows.count - 1,
                     spaceId: model.spaceId,
-                    channelWidgetsObject: channelWidgetsObject,
-                    personalWidgetsObject: model.personalWidgetsObject
+                    channelWidgetsObject: model.channelWidgetsObject,
+                    personalWidgetsObject: model.personalWidgetsObject,
+                    onObjectSelected: model.onObjectSelected
                 )
                 .contentShape(.dragPreview, RoundedRectangle(cornerRadius: 24, style: .continuous))
                 .anytypeVerticalDrag(itemId: row.id)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListViewModel.swift
@@ -4,12 +4,14 @@ import AnytypeCore
 
 @MainActor
 @Observable
-final class MyFavoritesViewModel {
+final class MyFavoritesListViewModel {
 
     // MARK: - DI
 
     @ObservationIgnored
     let personalWidgetsObject: any BaseDocumentProtocol
+    @ObservationIgnored
+    let channelWidgetsObject: any BaseDocumentProtocol
     @ObservationIgnored
     let onObjectSelected: (ObjectDetails) -> Void
 
@@ -20,11 +22,6 @@ final class MyFavoritesViewModel {
     @Injected(\.objectActionsService)
     private var objectActionsService: any ObjectActionsServiceProtocol
 
-    // MARK: - Source state
-
-    @ObservationIgnored
-    private var sourceBlocks: [SourceBlock] = []
-
     // MARK: - Published state
 
     var rows: [MyFavoritesRowData] = []
@@ -32,10 +29,12 @@ final class MyFavoritesViewModel {
     init(
         spaceId: String,
         personalWidgetsObject: any BaseDocumentProtocol,
+        channelWidgetsObject: any BaseDocumentProtocol,
         onObjectSelected: @escaping (ObjectDetails) -> Void
     ) {
         self.spaceId = spaceId
         self.personalWidgetsObject = personalWidgetsObject
+        self.channelWidgetsObject = channelWidgetsObject
         self.onObjectSelected = onObjectSelected
     }
 
@@ -48,36 +47,17 @@ final class MyFavoritesViewModel {
     private func startPersonalWidgetsSubscription() async {
         for await _ in personalWidgetsObject.syncPublisher.values {
             let widgets = personalWidgetsObject.children.filter(\.isWidget)
-            let next: [SourceBlock] = widgets.compactMap { block in
+            let newRows: [MyFavoritesRowData] = widgets.compactMap { block in
                 guard let info = personalWidgetsObject.widgetInfo(block: block),
                       case let .object(details) = info.source,
                       details.isNotDeletedAndSupportedForOpening else {
                     return nil
                 }
-                return SourceBlock(blockId: block.id, details: details)
+                return MyFavoritesRowData(id: block.id, details: details)
             }
-            guard sourceBlocks != next else { continue }
-            sourceBlocks = next
-            recomputeRows()
+            guard rows != newRows else { continue }
+            rows = newRows
         }
-    }
-
-    // MARK: - Row recomputation
-
-    private func recomputeRows() {
-        let onObjectSelected = self.onObjectSelected
-        let newRows: [MyFavoritesRowData] = sourceBlocks.map { block in
-            let details = block.details
-            return MyFavoritesRowData(
-                id: block.blockId,
-                objectId: details.id,
-                title: details.pluralTitle,
-                icon: details.objectIconImage,
-                onTap: { onObjectSelected(details) }
-            )
-        }
-        guard rows != newRows else { return }
-        rows = newRows
     }
 
     // MARK: - Drag-and-drop
@@ -103,9 +83,4 @@ final class MyFavoritesViewModel {
             )
         }
     }
-}
-
-private struct SourceBlock: Equatable {
-    let blockId: String
-    let details: ObjectDetails
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListViewModel.swift
@@ -22,6 +22,11 @@ final class MyFavoritesListViewModel {
     @Injected(\.objectActionsService)
     private var objectActionsService: any ObjectActionsServiceProtocol
 
+    // MARK: - Source state
+
+    @ObservationIgnored
+    private var sourceIds: [String] = []
+
     // MARK: - Published state
 
     var rows: [MyFavoritesRowData] = []
@@ -55,7 +60,15 @@ final class MyFavoritesListViewModel {
                 }
                 return MyFavoritesRowData(id: block.id, details: details)
             }
-            guard rows != newRows else { continue }
+            // Dedup on STRUCTURAL changes only (block-id list), not on detail-only emissions.
+            // - Compares against the persisted-order snapshot, not against `rows`, which `dropUpdate`
+            //   mutates into the optimistic drag order — comparing against `rows` would snap the list
+            //   back mid-drag on any unchanged-source emission.
+            // - Detail-only updates (renames, icon changes) are handled by per-row VMs via
+            //   `widgetTargetDetailsPublisher`, so the parent doesn't need to rebuild for those.
+            let newIds = newRows.map(\.id)
+            guard sourceIds != newIds else { continue }
+            sourceIds = newIds
             rows = newRows
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowContextMenu.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowContextMenu.swift
@@ -1,0 +1,29 @@
+import Foundation
+import SwiftUI
+
+struct MyFavoritesRowContextMenu: View {
+    let model: MyFavoritesRowContextMenuViewModel
+
+    var body: some View {
+        Button {
+            DispatchQueue.main.asyncAfter(deadline: .now() + menuDismissAnimationDelay) {
+                model.onFavoriteTap()
+            }
+        } label: {
+            Text(Loc.unfavorite)
+            Image(systemName: "star.fill")
+        }
+
+        if model.canManageChannelPins() {
+            let isPinnedToChannel = model.isPinnedToChannel()
+            Button {
+                DispatchQueue.main.asyncAfter(deadline: .now() + menuDismissAnimationDelay) {
+                    model.onChannelPinTap()
+                }
+            } label: {
+                Text(isPinnedToChannel ? Loc.unpinFromChannel : Loc.pinToChannel)
+                Image(systemName: isPinnedToChannel ? "pin.slash" : "pin")
+            }
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowContextMenuViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowContextMenuViewModel.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Services
+import AnytypeCore
+
+@MainActor
+final class MyFavoritesRowContextMenuViewModel {
+
+    let objectId: String
+    let spaceId: String
+    let channelWidgetsObject: any BaseDocumentProtocol
+    let personalWidgetsObject: any BaseDocumentProtocol
+
+    @Injected(\.widgetActionsViewCommonMenuProvider)
+    private var provider: any WidgetActionsViewCommonMenuProviderProtocol
+    @Injected(\.participantSpacesStorage)
+    private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
+
+    init(
+        objectId: String,
+        spaceId: String,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        personalWidgetsObject: any BaseDocumentProtocol
+    ) {
+        self.objectId = objectId
+        self.spaceId = spaceId
+        self.channelWidgetsObject = channelWidgetsObject
+        self.personalWidgetsObject = personalWidgetsObject
+    }
+
+    func onFavoriteTap() {
+        provider.onFavoriteTap(
+            targetObjectId: objectId,
+            personalWidgetsObject: personalWidgetsObject
+        )
+    }
+
+    func onChannelPinTap() {
+        provider.onChannelPinTap(
+            targetObjectId: objectId,
+            channelWidgetsObject: channelWidgetsObject
+        )
+    }
+
+    func canManageChannelPins() -> Bool {
+        participantSpacesStorage
+            .participantSpaceView(spaceId: spaceId)?
+            .canManageChannelPins ?? false
+    }
+
+    func isPinnedToChannel() -> Bool {
+        for block in channelWidgetsObject.children where block.isWidget {
+            guard let info = channelWidgetsObject.widgetInfo(block: block),
+                  case let .object(details) = info.source else { continue }
+            if details.id == objectId { return true }
+        }
+        return false
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowData.swift
@@ -5,6 +5,5 @@ struct MyFavoritesRowData: Identifiable, Equatable {
     let objectId: String
     let title: String
     let icon: Icon
-    let chatPreview: MessagePreviewModel?
     @EquatableNoop var onTap: @MainActor () -> Void
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowData.swift
@@ -1,9 +1,8 @@
 import Foundation
+import Services
 
 struct MyFavoritesRowData: Identifiable, Equatable {
     let id: String
-    let objectId: String
-    let title: String
-    let icon: Icon
-    @EquatableNoop var onTap: @MainActor () -> Void
+    let details: ObjectDetails
+    var objectId: String { details.id }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowInternalView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowInternalView.swift
@@ -1,0 +1,85 @@
+import Foundation
+import SwiftUI
+import Services
+
+struct MyFavoritesRowInternalView: View {
+    private let showDivider: Bool
+
+    @State private var rowModel: MyFavoritesRowViewModel
+
+    @Environment(\.shouldHideChatBadges) private var shouldHideChatBadges
+
+    init(
+        row: MyFavoritesRowData,
+        showDivider: Bool,
+        spaceId: String,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        personalWidgetsObject: any BaseDocumentProtocol,
+        onObjectSelected: @escaping (ObjectDetails) -> Void
+    ) {
+        self.showDivider = showDivider
+        _rowModel = State(initialValue: MyFavoritesRowViewModel(
+            widgetBlockId: row.id,
+            details: row.details,
+            spaceId: spaceId,
+            channelWidgetsObject: channelWidgetsObject,
+            personalWidgetsObject: personalWidgetsObject,
+            onObjectSelected: onObjectSelected
+        ))
+    }
+
+    var body: some View {
+        Button {
+            rowModel.onTap()
+        } label: {
+            HStack(spacing: 12) {
+                IconView(icon: rowModel.icon)
+                    .frame(width: 20, height: 20)
+
+                AnytypeText(rowModel.title, style: .bodySemibold)
+                    .foregroundStyle(Color.Text.primary)
+                    .lineLimit(1)
+
+                Spacer()
+
+                if let chatPreview = rowModel.badgeModel, chatPreview.hasVisibleCounters {
+                    chatBadges(chatPreview: chatPreview)
+                        .opacity(shouldHideChatBadges ? 0 : 1)
+                }
+            }
+            .padding(.horizontal, 16)
+            .frame(height: 48)
+            .fixTappableArea()
+        }
+        .buttonStyle(.plain)
+        .if(showDivider) {
+            $0.newDivider(leadingPadding: 16, trailingPadding: 16, color: .Widget.divider)
+        }
+        .background(Color.Background.widget)
+        .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .contextMenu {
+            MyFavoritesRowContextMenu(model: rowModel.menuViewModel)
+        }
+        .task {
+            await rowModel.startSubscriptions()
+        }
+    }
+
+    @ViewBuilder
+    private func chatBadges(chatPreview: MessagePreviewModel) -> some View {
+        HStack(spacing: 4) {
+            if chatPreview.hasUnreadReactions {
+                HeartBadge(style: chatPreview.reactionStyle)
+            }
+            if chatPreview.mentionCounter > 0 {
+                MentionBadge(style: chatPreview.mentionCounterStyle)
+            }
+            if chatPreview.shouldShowUnreadCounter {
+                CounterView(
+                    count: chatPreview.unreadCounter,
+                    style: chatPreview.unreadCounterStyle
+                )
+            }
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftUI
 import Services
-import AnytypeCore
 
 struct MyFavoritesRowView: View {
     let row: MyFavoritesRowData
@@ -9,6 +8,7 @@ struct MyFavoritesRowView: View {
     let spaceId: String
     let channelWidgetsObject: any BaseDocumentProtocol
     let personalWidgetsObject: any BaseDocumentProtocol
+    let onObjectSelected: (ObjectDetails) -> Void
 
     var body: some View {
         MyFavoritesRowInternalView(
@@ -16,158 +16,9 @@ struct MyFavoritesRowView: View {
             showDivider: showDivider,
             spaceId: spaceId,
             channelWidgetsObject: channelWidgetsObject,
-            personalWidgetsObject: personalWidgetsObject
+            personalWidgetsObject: personalWidgetsObject,
+            onObjectSelected: onObjectSelected
         )
         .id(row.id)
-    }
-}
-
-private struct MyFavoritesRowInternalView: View {
-    let row: MyFavoritesRowData
-    let showDivider: Bool
-    let spaceId: String
-    let channelWidgetsObject: any BaseDocumentProtocol
-    let personalWidgetsObject: any BaseDocumentProtocol
-
-    @State private var rowModel: MyFavoritesRowViewModel
-
-    @Environment(\.shouldHideChatBadges) private var shouldHideChatBadges
-
-    init(
-        row: MyFavoritesRowData,
-        showDivider: Bool,
-        spaceId: String,
-        channelWidgetsObject: any BaseDocumentProtocol,
-        personalWidgetsObject: any BaseDocumentProtocol
-    ) {
-        self.row = row
-        self.showDivider = showDivider
-        self.spaceId = spaceId
-        self.channelWidgetsObject = channelWidgetsObject
-        self.personalWidgetsObject = personalWidgetsObject
-        _rowModel = State(initialValue: MyFavoritesRowViewModel(objectId: row.objectId, spaceId: spaceId))
-    }
-
-    var body: some View {
-        Button {
-            row.onTap()
-        } label: {
-            HStack(spacing: 12) {
-                IconView(icon: row.icon)
-                    .frame(width: 20, height: 20)
-
-                AnytypeText(row.title, style: .bodySemibold)
-                    .foregroundStyle(Color.Text.primary)
-                    .lineLimit(1)
-
-                Spacer()
-
-                if let chatPreview = rowModel.badgeModel, chatPreview.hasVisibleCounters {
-                    chatBadges(chatPreview: chatPreview)
-                        .opacity(shouldHideChatBadges ? 0 : 1)
-                }
-            }
-            .padding(.horizontal, 16)
-            .frame(height: 48)
-            .fixTappableArea()
-        }
-        .buttonStyle(.plain)
-        .if(showDivider) {
-            $0.newDivider(leadingPadding: 16, trailingPadding: 16, color: .Widget.divider)
-        }
-        .background(Color.Background.widget)
-        .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 24, style: .continuous))
-        .contextMenu {
-            MyFavoritesRowContextMenu(
-                objectId: row.objectId,
-                spaceId: spaceId,
-                channelWidgetsObject: channelWidgetsObject,
-                personalWidgetsObject: personalWidgetsObject
-            )
-        }
-        .task {
-            await rowModel.startSubscriptions()
-        }
-    }
-
-    @ViewBuilder
-    private func chatBadges(chatPreview: MessagePreviewModel) -> some View {
-        HStack(spacing: 4) {
-            if chatPreview.hasUnreadReactions {
-                HeartBadge(style: chatPreview.reactionStyle)
-            }
-            if chatPreview.mentionCounter > 0 {
-                MentionBadge(style: chatPreview.mentionCounterStyle)
-            }
-            if chatPreview.shouldShowUnreadCounter {
-                CounterView(
-                    count: chatPreview.unreadCounter,
-                    style: chatPreview.unreadCounterStyle
-                )
-            }
-        }
-    }
-}
-
-private struct MyFavoritesRowContextMenu: View {
-    let objectId: String
-    let spaceId: String
-    let channelWidgetsObject: any BaseDocumentProtocol
-    let personalWidgetsObject: any BaseDocumentProtocol
-
-    @StateObject private var model = MyFavoritesRowContextMenuViewModel()
-
-    var body: some View {
-        Button {
-            DispatchQueue.main.asyncAfter(deadline: .now() + menuDismissAnimationDelay) {
-                model.provider.onFavoriteTap(
-                    targetObjectId: objectId,
-                    personalWidgetsObject: personalWidgetsObject
-                )
-            }
-        } label: {
-            Text(Loc.unfavorite)
-            Image(systemName: "star.fill")
-        }
-
-        if model.canManageChannelPins(spaceId: spaceId) {
-            let isPinnedToChannel = model.isPinnedToChannel(
-                objectId: objectId,
-                channelWidgetsObject: channelWidgetsObject
-            )
-            Button {
-                DispatchQueue.main.asyncAfter(deadline: .now() + menuDismissAnimationDelay) {
-                    model.provider.onChannelPinTap(
-                        targetObjectId: objectId,
-                        channelWidgetsObject: channelWidgetsObject
-                    )
-                }
-            } label: {
-                Text(isPinnedToChannel ? Loc.unpinFromChannel : Loc.pinToChannel)
-                Image(systemName: isPinnedToChannel ? "pin.slash" : "pin")
-            }
-        }
-    }
-}
-
-private final class MyFavoritesRowContextMenuViewModel: ObservableObject {
-    @Injected(\.widgetActionsViewCommonMenuProvider)
-    var provider: any WidgetActionsViewCommonMenuProviderProtocol
-    @Injected(\.participantSpacesStorage)
-    private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
-
-    func canManageChannelPins(spaceId: String) -> Bool {
-        participantSpacesStorage
-            .participantSpaceView(spaceId: spaceId)?
-            .canManageChannelPins ?? false
-    }
-
-    func isPinnedToChannel(objectId: String, channelWidgetsObject: any BaseDocumentProtocol) -> Bool {
-        for block in channelWidgetsObject.children where block.isWidget {
-            guard let info = channelWidgetsObject.widgetInfo(block: block),
-                  case let .object(details) = info.source else { continue }
-            if details.id == objectId { return true }
-        }
-        return false
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift
@@ -6,12 +6,47 @@ import AnytypeCore
 struct MyFavoritesRowView: View {
     let row: MyFavoritesRowData
     let showDivider: Bool
+    let spaceId: String
     let channelWidgetsObject: any BaseDocumentProtocol
     let personalWidgetsObject: any BaseDocumentProtocol
-    let canManageChannelPins: Bool
-    let isPinnedToChannel: Bool
+
+    var body: some View {
+        MyFavoritesRowInternalView(
+            row: row,
+            showDivider: showDivider,
+            spaceId: spaceId,
+            channelWidgetsObject: channelWidgetsObject,
+            personalWidgetsObject: personalWidgetsObject
+        )
+        .id(row.id)
+    }
+}
+
+private struct MyFavoritesRowInternalView: View {
+    let row: MyFavoritesRowData
+    let showDivider: Bool
+    let spaceId: String
+    let channelWidgetsObject: any BaseDocumentProtocol
+    let personalWidgetsObject: any BaseDocumentProtocol
+
+    @State private var rowModel: MyFavoritesRowViewModel
 
     @Environment(\.shouldHideChatBadges) private var shouldHideChatBadges
+
+    init(
+        row: MyFavoritesRowData,
+        showDivider: Bool,
+        spaceId: String,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        personalWidgetsObject: any BaseDocumentProtocol
+    ) {
+        self.row = row
+        self.showDivider = showDivider
+        self.spaceId = spaceId
+        self.channelWidgetsObject = channelWidgetsObject
+        self.personalWidgetsObject = personalWidgetsObject
+        _rowModel = State(initialValue: MyFavoritesRowViewModel(objectId: row.objectId, spaceId: spaceId))
+    }
 
     var body: some View {
         Button {
@@ -27,7 +62,7 @@ struct MyFavoritesRowView: View {
 
                 Spacer()
 
-                if let chatPreview = row.chatPreview, chatPreview.hasVisibleCounters {
+                if let chatPreview = rowModel.badgeModel, chatPreview.hasVisibleCounters {
                     chatBadges(chatPreview: chatPreview)
                         .opacity(shouldHideChatBadges ? 0 : 1)
                 }
@@ -45,11 +80,13 @@ struct MyFavoritesRowView: View {
         .contextMenu {
             MyFavoritesRowContextMenu(
                 objectId: row.objectId,
+                spaceId: spaceId,
                 channelWidgetsObject: channelWidgetsObject,
-                personalWidgetsObject: personalWidgetsObject,
-                canManageChannelPins: canManageChannelPins,
-                isPinnedToChannel: isPinnedToChannel
+                personalWidgetsObject: personalWidgetsObject
             )
+        }
+        .task {
+            await rowModel.startSubscriptions()
         }
     }
 
@@ -74,10 +111,9 @@ struct MyFavoritesRowView: View {
 
 private struct MyFavoritesRowContextMenu: View {
     let objectId: String
+    let spaceId: String
     let channelWidgetsObject: any BaseDocumentProtocol
     let personalWidgetsObject: any BaseDocumentProtocol
-    let canManageChannelPins: Bool
-    let isPinnedToChannel: Bool
 
     @StateObject private var model = MyFavoritesRowContextMenuViewModel()
 
@@ -94,7 +130,11 @@ private struct MyFavoritesRowContextMenu: View {
             Image(systemName: "star.fill")
         }
 
-        if canManageChannelPins {
+        if model.canManageChannelPins(spaceId: spaceId) {
+            let isPinnedToChannel = model.isPinnedToChannel(
+                objectId: objectId,
+                channelWidgetsObject: channelWidgetsObject
+            )
             Button {
                 DispatchQueue.main.asyncAfter(deadline: .now() + menuDismissAnimationDelay) {
                     model.provider.onChannelPinTap(
@@ -113,4 +153,21 @@ private struct MyFavoritesRowContextMenu: View {
 private final class MyFavoritesRowContextMenuViewModel: ObservableObject {
     @Injected(\.widgetActionsViewCommonMenuProvider)
     var provider: any WidgetActionsViewCommonMenuProviderProtocol
+    @Injected(\.participantSpacesStorage)
+    private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
+
+    func canManageChannelPins(spaceId: String) -> Bool {
+        participantSpacesStorage
+            .participantSpaceView(spaceId: spaceId)?
+            .canManageChannelPins ?? false
+    }
+
+    func isPinnedToChannel(objectId: String, channelWidgetsObject: any BaseDocumentProtocol) -> Bool {
+        for block in channelWidgetsObject.children where block.isWidget {
+            guard let info = channelWidgetsObject.widgetInfo(block: block),
+                  case let .object(details) = info.source else { continue }
+            if details.id == objectId { return true }
+        }
+        return false
+    }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowViewModel.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Services
+import AnytypeCore
+
+@MainActor
+@Observable
+final class MyFavoritesRowViewModel {
+
+    // MARK: - DI
+
+    @ObservationIgnored
+    private let objectId: String
+    @ObservationIgnored
+    private let spaceId: String
+
+    @ObservationIgnored
+    @Injected(\.chatMessagesPreviewsStorage)
+    private var chatMessagesPreviewsStorage: any ChatMessagesPreviewsStorageProtocol
+    @ObservationIgnored
+    @Injected(\.spaceViewsStorage)
+    private var spaceViewsStorage: any SpaceViewsStorageProtocol
+    @ObservationIgnored
+    @Injected(\.widgetChatPreviewBuilder)
+    private var chatPreviewBuilder: any WidgetChatPreviewBuilderProtocol
+
+    // MARK: - State
+
+    @ObservationIgnored
+    private var chatPreviews: [ChatMessagePreview] = []
+
+    private(set) var badgeModel: MessagePreviewModel?
+
+    init(objectId: String, spaceId: String) {
+        self.objectId = objectId
+        self.spaceId = spaceId
+    }
+
+    func startSubscriptions() async {
+        await startChatPreviewsSubscription()
+    }
+
+    // MARK: - Private
+
+    private func startChatPreviewsSubscription() async {
+        for await previews in await chatMessagesPreviewsStorage.previewsSequence {
+            chatPreviews = previews
+            updateBadgeModel()
+        }
+    }
+
+    private func updateBadgeModel() {
+        let spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)
+        badgeModel = chatPreviews.first(where: { $0.chatId == objectId }).flatMap {
+            chatPreviewBuilder.build(chatPreview: $0, spaceView: spaceView)
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowViewModel.swift
@@ -6,12 +6,20 @@ import AnytypeCore
 @Observable
 final class MyFavoritesRowViewModel {
 
-    // MARK: - DI
+    // MARK: - Construction context
+
+    let widgetBlockId: String
+    let spaceId: String
+    let channelWidgetsObject: any BaseDocumentProtocol
+    let personalWidgetsObject: any BaseDocumentProtocol
+    let menuViewModel: MyFavoritesRowContextMenuViewModel
 
     @ObservationIgnored
-    private let objectId: String
-    @ObservationIgnored
-    private let spaceId: String
+    private let onObjectSelected: (ObjectDetails) -> Void
+
+    var objectId: String { details.id }
+
+    // MARK: - DI
 
     @ObservationIgnored
     @Injected(\.chatMessagesPreviewsStorage)
@@ -26,32 +34,81 @@ final class MyFavoritesRowViewModel {
     // MARK: - State
 
     @ObservationIgnored
-    private var chatPreviews: [ChatMessagePreview] = []
+    private var details: ObjectDetails
+    @ObservationIgnored
+    private var chatPreview: ChatMessagePreview?
 
+    private(set) var title: String
+    private(set) var icon: Icon?
     private(set) var badgeModel: MessagePreviewModel?
 
-    init(objectId: String, spaceId: String) {
-        self.objectId = objectId
+    init(
+        widgetBlockId: String,
+        details: ObjectDetails,
+        spaceId: String,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        personalWidgetsObject: any BaseDocumentProtocol,
+        onObjectSelected: @escaping (ObjectDetails) -> Void
+    ) {
+        self.widgetBlockId = widgetBlockId
+        self.details = details
         self.spaceId = spaceId
+        self.channelWidgetsObject = channelWidgetsObject
+        self.personalWidgetsObject = personalWidgetsObject
+        self.onObjectSelected = onObjectSelected
+        self.title = details.pluralTitle
+        self.icon = details.objectIconImage
+        self.menuViewModel = MyFavoritesRowContextMenuViewModel(
+            objectId: details.id,
+            spaceId: spaceId,
+            channelWidgetsObject: channelWidgetsObject,
+            personalWidgetsObject: personalWidgetsObject
+        )
+    }
+
+    func onTap() {
+        onObjectSelected(details)
     }
 
     func startSubscriptions() async {
-        await startChatPreviewsSubscription()
+        async let detailsSub: () = startDetailsSubscription()
+        async let chatPreviewsSub: () = startChatPreviewsSubscription()
+        async let spaceViewSub: () = startSpaceViewSubscription()
+        _ = await (detailsSub, chatPreviewsSub, spaceViewSub)
     }
 
     // MARK: - Private
 
+    private func startDetailsSubscription() async {
+        for await details in personalWidgetsObject.widgetTargetDetailsPublisher(widgetBlockId: widgetBlockId).values {
+            self.details = details
+            title = details.pluralTitle
+            icon = details.objectIconImage
+            updateBadgeModel()
+        }
+    }
+
     private func startChatPreviewsSubscription() async {
         for await previews in await chatMessagesPreviewsStorage.previewsSequence {
-            chatPreviews = previews
+            let next = previews.first(where: { $0.chatId == objectId })
+            guard chatPreview != next else { continue }
+            chatPreview = next
+            updateBadgeModel()
+        }
+    }
+
+    private func startSpaceViewSubscription() async {
+        for await _ in spaceViewsStorage.spaceViewPublisher(spaceId: spaceId).removeDuplicates().values {
             updateBadgeModel()
         }
     }
 
     private func updateBadgeModel() {
         let spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)
-        badgeModel = chatPreviews.first(where: { $0.chatId == objectId }).flatMap {
+        let next = chatPreview.flatMap {
             chatPreviewBuilder.build(chatPreview: $0, spaceView: spaceView)
         }
+        guard badgeModel != next else { return }
+        badgeModel = next
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift
@@ -11,69 +11,38 @@ final class MyFavoritesViewModel {
     @ObservationIgnored
     let personalWidgetsObject: any BaseDocumentProtocol
     @ObservationIgnored
-    let channelWidgetsObject: any BaseDocumentProtocol
-    @ObservationIgnored
     let onObjectSelected: (ObjectDetails) -> Void
 
     @ObservationIgnored
-    private let spaceId: String
+    let spaceId: String
 
     @ObservationIgnored
     @Injected(\.objectActionsService)
     private var objectActionsService: any ObjectActionsServiceProtocol
-    @ObservationIgnored
-    @Injected(\.chatMessagesPreviewsStorage)
-    private var chatMessagesPreviewsStorage: any ChatMessagesPreviewsStorageProtocol
-    @ObservationIgnored
-    @Injected(\.spaceViewsStorage)
-    private var spaceViewsStorage: any SpaceViewsStorageProtocol
-    @ObservationIgnored
-    @Injected(\.participantSpacesStorage)
-    private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
-    @ObservationIgnored
-    @Injected(\.widgetChatPreviewBuilder)
-    private var chatPreviewBuilder: any WidgetChatPreviewBuilderProtocol
 
     // MARK: - Source state
 
     @ObservationIgnored
     private var sourceBlocks: [SourceBlock] = []
-    @ObservationIgnored
-    private var chatPreviews: [ChatMessagePreview] = []
-    @ObservationIgnored
-    private var spaceView: SpaceView?
 
     // MARK: - Published state
 
     var rows: [MyFavoritesRowData] = []
-    var pinnedToChannelObjectIds: Set<String> = []
-
-    var canManageChannelPins: Bool {
-        participantSpacesStorage
-            .participantSpaceView(spaceId: spaceId)?
-            .canManageChannelPins ?? false
-    }
 
     init(
         spaceId: String,
         personalWidgetsObject: any BaseDocumentProtocol,
-        channelWidgetsObject: any BaseDocumentProtocol,
         onObjectSelected: @escaping (ObjectDetails) -> Void
     ) {
         self.spaceId = spaceId
         self.personalWidgetsObject = personalWidgetsObject
-        self.channelWidgetsObject = channelWidgetsObject
         self.onObjectSelected = onObjectSelected
     }
 
     // MARK: - Subscriptions
 
     func startSubscriptions() async {
-        async let personalSub: () = startPersonalWidgetsSubscription()
-        async let channelSub: () = startChannelPinsSubscription()
-        async let chatPreviewsSub: () = startChatPreviewsSubscription()
-        async let spaceViewSub: () = startSpaceViewSubscription()
-        _ = await (personalSub, channelSub, chatPreviewsSub, spaceViewSub)
+        await startPersonalWidgetsSubscription()
     }
 
     private func startPersonalWidgetsSubscription() async {
@@ -93,53 +62,17 @@ final class MyFavoritesViewModel {
         }
     }
 
-    private func startChannelPinsSubscription() async {
-        for await _ in channelWidgetsObject.syncPublisher.values {
-            var next: Set<String> = []
-            for block in channelWidgetsObject.children where block.isWidget {
-                guard let info = channelWidgetsObject.widgetInfo(block: block),
-                      case let .object(details) = info.source else { continue }
-                next.insert(details.id)
-            }
-            guard pinnedToChannelObjectIds != next else { continue }
-            pinnedToChannelObjectIds = next
-        }
-    }
-
-    private func startChatPreviewsSubscription() async {
-        for await previews in await chatMessagesPreviewsStorage.previewsSequence {
-            chatPreviews = previews
-            recomputeRows()
-        }
-    }
-
-    private func startSpaceViewSubscription() async {
-        for await spaceView in spaceViewsStorage.spaceViewPublisher(spaceId: spaceId).values {
-            self.spaceView = spaceView
-            recomputeRows()
-        }
-    }
-
     // MARK: - Row recomputation
 
     private func recomputeRows() {
         let onObjectSelected = self.onObjectSelected
-        let spaceView = self.spaceView
-        let previewsByChatId = Dictionary(
-            chatPreviews.lazy.map { ($0.chatId, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
         let newRows: [MyFavoritesRowData] = sourceBlocks.map { block in
             let details = block.details
-            let chatPreview = previewsByChatId[details.id].flatMap {
-                chatPreviewBuilder.build(chatPreview: $0, spaceView: spaceView)
-            }
             return MyFavoritesRowData(
                 id: block.blockId,
                 objectId: details.id,
                 title: details.pluralTitle,
                 icon: details.objectIconImage,
-                chatPreview: chatPreview,
                 onTap: { onObjectSelected(details) }
             )
         }

--- a/docs/plans/20260424-ios-6106-my-favorites-per-row-vm.md
+++ b/docs/plans/20260424-ios-6106-my-favorites-per-row-vm.md
@@ -179,14 +179,14 @@ Align `MyFavorites` architecture with `blockWidgets`: parent VM owns only the st
 **Files:**
 - Create: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowViewModel.swift`
 
-- [ ] create `@MainActor @Observable` final class `MyFavoritesRowViewModel`
-- [ ] injections (`@ObservationIgnored @Injected`): `chatMessagesPreviewsStorage`, `spaceViewsStorage`, `widgetChatPreviewBuilder`
-- [ ] initializer `init(objectId: String, spaceId: String)`
-- [ ] stored (`@ObservationIgnored`): `objectId`, `spaceId`, `chatPreviews: [ChatMessagePreview] = []`
-- [ ] exposed: `private(set) var badgeModel: MessagePreviewModel?`
-- [ ] `func startSubscriptions() async` → runs `startChatPreviewsSubscription()`
-- [ ] `startChatPreviewsSubscription()` iterates `chatMessagesPreviewsStorage.previewsSequence`, assigns `chatPreviews`, calls `updateBadgeModel()`
-- [ ] `updateBadgeModel()`: find preview where `chatId == objectId`, read `spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)`, build via `chatPreviewBuilder.build(chatPreview:spaceView:)` — copy shape from `LinkWidgetViewModel.updateBadgeModel`
+- [x] create `@MainActor @Observable` final class `MyFavoritesRowViewModel`
+- [x] injections (`@ObservationIgnored @Injected`): `chatMessagesPreviewsStorage`, `spaceViewsStorage`, `widgetChatPreviewBuilder`
+- [x] initializer `init(objectId: String, spaceId: String)`
+- [x] stored (`@ObservationIgnored`): `objectId`, `spaceId`, `chatPreviews: [ChatMessagePreview] = []`
+- [x] exposed: `private(set) var badgeModel: MessagePreviewModel?`
+- [x] `func startSubscriptions() async` → runs `startChatPreviewsSubscription()`
+- [x] `startChatPreviewsSubscription()` iterates `chatMessagesPreviewsStorage.previewsSequence`, assigns `chatPreviews`, calls `updateBadgeModel()`
+- [x] `updateBadgeModel()`: find preview where `chatId == objectId`, read `spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)`, build via `chatPreviewBuilder.build(chatPreview:spaceView:)` — copy shape from `LinkWidgetViewModel.updateBadgeModel`
 
 #### Task A2: Add `MyFavoritesRowInternalView` + wire the per-row VM + plumb `spaceId`
 
@@ -195,13 +195,13 @@ Align `MyFavorites` architecture with `blockWidgets`: parent VM owns only the st
 - Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift` (pass `spaceId` to each row)
 - Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift` (outer + new internal view)
 
-- [ ] remove `private` from `spaceId` on `MyFavoritesViewModel` (or expose via a public `let`/computed accessor) so the view can read it
-- [ ] in `MyFavoritesListView.swift`, pass `spaceId: model.spaceId` into each `MyFavoritesRowView`
-- [ ] split `MyFavoritesRowView` — the outer struct now wraps `MyFavoritesRowInternalView(...).id(row.id)`, threading through the existing parameters including `canManageChannelPins` and `isPinnedToChannel` (these are removed in Task A3; leave them wired for now so the project keeps compiling)
-- [ ] inside `MyFavoritesRowInternalView`, hold `@State private var rowModel: MyFavoritesRowViewModel`; init from `(row.objectId, spaceId)` exactly like `LinkWidgetInternalView` inits `LinkWidgetViewModel`
-- [ ] add `.task { await rowModel.startSubscriptions() }` on the internal view's body
-- [ ] in the chat-badge branch of the body, replace `row.chatPreview` with `rowModel.badgeModel`. `MyFavoritesRowData.chatPreview` still exists and is still populated by the parent VM at this point — just stop reading it from the view.
-- [ ] **keep `.setZeroOpacity(...)` and `.anytypeVerticalDrag(itemId: row.id)` at list-level in `MyFavoritesListView`** — do not move them into `MyFavoritesRowInternalView`
+- [x] remove `private` from `spaceId` on `MyFavoritesViewModel` (or expose via a public `let`/computed accessor) so the view can read it
+- [x] in `MyFavoritesListView.swift`, pass `spaceId: model.spaceId` into each `MyFavoritesRowView`
+- [x] split `MyFavoritesRowView` — the outer struct now wraps `MyFavoritesRowInternalView(...).id(row.id)`, threading through the existing parameters including `canManageChannelPins` and `isPinnedToChannel` (these are removed in Task A3; leave them wired for now so the project keeps compiling)
+- [x] inside `MyFavoritesRowInternalView`, hold `@State private var rowModel: MyFavoritesRowViewModel`; init from `(row.objectId, spaceId)` exactly like `LinkWidgetInternalView` inits `LinkWidgetViewModel`
+- [x] add `.task { await rowModel.startSubscriptions() }` on the internal view's body
+- [x] in the chat-badge branch of the body, replace `row.chatPreview` with `rowModel.badgeModel`. `MyFavoritesRowData.chatPreview` still exists and is still populated by the parent VM at this point — just stop reading it from the view.
+- [x] **keep `.setZeroOpacity(...)` and `.anytypeVerticalDrag(itemId: row.id)` at list-level in `MyFavoritesListView`** — do not move them into `MyFavoritesRowInternalView`
 
 #### Task A3: Move pin flags + can-manage flag into the context-menu VM
 
@@ -209,16 +209,16 @@ Align `MyFavorites` architecture with `blockWidgets`: parent VM owns only the st
 - Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift`
 - Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift`
 
-- [ ] add `func isPinnedToChannel(objectId: String, channelWidgetsObject: any BaseDocumentProtocol) -> Bool` to `MyFavoritesRowContextMenuViewModel` — iterate `channelWidgetsObject.children` filtered by `isWidget`, match `.object(details)` with `details.id == objectId`
-- [ ] add `@Injected(\.participantSpacesStorage) private var participantSpacesStorage` plus `func canManageChannelPins(spaceId: String) -> Bool` reading `participantSpacesStorage.participantSpaceView(spaceId:)?.canManageChannelPins ?? false`
-- [ ] keep `MyFavoritesRowContextMenuViewModel` as `ObservableObject` used with `@StateObject` — no `@Published` added
-- [ ] update the inner `MyFavoritesRowContextMenu`:
+- [x] add `func isPinnedToChannel(objectId: String, channelWidgetsObject: any BaseDocumentProtocol) -> Bool` to `MyFavoritesRowContextMenuViewModel` — iterate `channelWidgetsObject.children` filtered by `isWidget`, match `.object(details)` with `details.id == objectId`
+- [x] add `@Injected(\.participantSpacesStorage) private var participantSpacesStorage` plus `func canManageChannelPins(spaceId: String) -> Bool` reading `participantSpacesStorage.participantSpaceView(spaceId:)?.canManageChannelPins ?? false`
+- [x] keep `MyFavoritesRowContextMenuViewModel` as `ObservableObject` used with `@StateObject` — no `@Published` added
+- [x] update the inner `MyFavoritesRowContextMenu`:
   - drop `canManageChannelPins: Bool` and `isPinnedToChannel: Bool` from its parameters
   - add `let spaceId: String`
   - in `body`, replace the static `canManageChannelPins` / `isPinnedToChannel` reads with `model.canManageChannelPins(spaceId: spaceId)` and `model.isPinnedToChannel(objectId: objectId, channelWidgetsObject: channelWidgetsObject)` — these are evaluated lazily when SwiftUI renders the menu on long-press
-- [ ] drop `canManageChannelPins` and `isPinnedToChannel` from `MyFavoritesRowView` and `MyFavoritesRowInternalView` parameters; keep `channelWidgetsObject`, `personalWidgetsObject`, `spaceId`
-- [ ] update the `.contextMenu { MyFavoritesRowContextMenu(...) }` invocation to the new parameter shape
-- [ ] in `MyFavoritesListView.swift`, stop passing `canManageChannelPins` and `pinnedToChannelObjectIds.contains(...)`; pass `spaceId: model.spaceId` instead
+- [x] drop `canManageChannelPins` and `isPinnedToChannel` from `MyFavoritesRowView` and `MyFavoritesRowInternalView` parameters; keep `channelWidgetsObject`, `personalWidgetsObject`, `spaceId`
+- [x] update the `.contextMenu { MyFavoritesRowContextMenu(...) }` invocation to the new parameter shape
+- [x] in `MyFavoritesListView.swift`, stop passing `canManageChannelPins` and `pinnedToChannelObjectIds.contains(...)`; pass `spaceId: model.spaceId` instead
 
 #### Task A4: Trim the parent `MyFavoritesViewModel`
 
@@ -229,16 +229,16 @@ Align `MyFavorites` architecture with `blockWidgets`: parent VM owns only the st
 - Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift`
 - Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift` (if it currently reads `myFavoritesViewModel.channelWidgetsObject`)
 
-- [ ] in `MyFavoritesRowData.swift`: drop `chatPreview: MessagePreviewModel?`
-- [ ] in `MyFavoritesViewModel.swift`:
+- [x] in `MyFavoritesRowData.swift`: drop `chatPreview: MessagePreviewModel?`
+- [x] in `MyFavoritesViewModel.swift`:
   - delete `startChatPreviewsSubscription`, `startSpaceViewSubscription`, `startChannelPinsSubscription`, and their stored state (`chatPreviews`, `spaceView`, `pinnedToChannelObjectIds`)
   - delete computed `canManageChannelPins`
   - delete injections: `chatMessagesPreviewsStorage`, `spaceViewsStorage`, `participantSpacesStorage`, `widgetChatPreviewBuilder`
   - simplify `startSubscriptions()` to run only `startPersonalWidgetsSubscription()`
   - shrink `recomputeRows()` to build `MyFavoritesRowData(id: block.blockId, objectId: details.id, title: details.pluralTitle, icon: details.objectIconImage, onTap: { onObjectSelected(details) })` only
   - drop `channelWidgetsObject` parameter from `init` — no longer read by the VM after Task A3
-- [ ] in `HomeWidgetsViewModel.init`, update the `MyFavoritesViewModel(...)` invocation to match the new init
-- [ ] in `HomeWidgetsView.swift` (and `MyFavoritesListView.swift` if applicable), the places that previously read `myFavoritesViewModel.channelWidgetsObject` switch to reading `model.channelWidgetsObject` from the parent `HomeWidgetsViewModel` (same reference — both used to point to the same document) and pass it down explicitly where needed
+- [x] in `HomeWidgetsViewModel.init`, update the `MyFavoritesViewModel(...)` invocation to match the new init
+- [x] in `HomeWidgetsView.swift` (and `MyFavoritesListView.swift` if applicable), the places that previously read `myFavoritesViewModel.channelWidgetsObject` switch to reading `model.channelWidgetsObject` from the parent `HomeWidgetsViewModel` (same reference — both used to point to the same document) and pass it down explicitly where needed
 
 #### Phase A hand-off (end of PR 1)
 

--- a/docs/plans/20260424-ios-6106-my-favorites-per-row-vm.md
+++ b/docs/plans/20260424-ios-6106-my-favorites-per-row-vm.md
@@ -1,0 +1,326 @@
+# IOS-6106 My Favorites Per-Row ViewModel Refactor
+
+## Overview
+
+Fix the IOS-6106 drag-cancel crash (`EXC_BAD_ACCESS` in `AG::Graph::value_ref` → `SwiftUI DragAndDropBridge.dragInteraction(_:previewForCancelling:withDefault:)`) by removing high-frequency external subscriptions from the parent `MyFavoritesViewModel` and relocating per-row state (chat badge, channel-pin flag, can-manage-channel-pins flag) into per-row ownership that mirrors how block widgets are wired (`LinkWidgetViewModel` inside `LinkWidgetInternalView`).
+
+Crash context: EXC_BAD_ACCESS at 0x1a8 in AttributeGraph → SwiftUI drag-cancel preview lookup on iOS 26.3.1 (iPhone 17 Pro). Stack resolved; log reviewed privately — not committed.
+
+Linear: IOS-6106. Parent: IOS-5864 Personal Favorites. Branch: `ios-6106-crash-after-dnd-of-the-object-down-the-screen-widget`.
+
+**Acceptance criterion**: no `EXC_BAD_ACCESS` on drag cancel for MyFavorites rows on iOS 26.3+; chat badges continue to update live; IOS-6104/6105 behavior preserved; block-widgets reorder (same delegate) not regressed — including the "user drags outside the pinned section and releases" path.
+
+Two prior fixes already landed in this area and must not regress:
+- **PR #4871 (IOS-6104)**: `setZeroOpacity` guarded with `dragInProgress` so long-press→context-menu does not hide the row.
+- **PR #4872 (IOS-6105)**: `DragItemProvider.deinit` defers `didEnd?()` via `DispatchQueue.main.async` to avoid `@Binding` re-entry.
+
+## Shipping as two independent PRs
+
+The work is split into two phases, each self-contained and independently verifiable. Pick either to ship alone if needed; together they cover the full story.
+
+- **Phase A — per-row ViewModel refactor** (PR 1, expected crash fix). Eliminates the churn on `MyFavoritesViewModel.rows` caused by chat/space/pin traffic. Verifiable on its own with the IOS-6106 reproducer: after Phase A alone, dragging to the bottom should no longer crash.
+- **Phase B — DnD commit-on-drag-end** (PR 2, UX + hygiene). Moves the server RPC off `dropExited` to actual drag-end. Verifiable on its own as "drop outside MyFavorites zone still commits the last in-zone visual position" (matching block-widgets behavior today, and matching the user's explicit UX ask on IOS-6106). Also removes a residual mid-drag server-round-trip that could re-provoke the crash in future.
+
+The branch is already `ios-6106-...`. Plan of record: open PR 1 for Phase A first (merge independently). Then either continue on the same branch or cut a new branch off develop for Phase B. Either is fine as long as Phase B does not piggy-back on unmerged Phase A changes.
+
+## Context (from discovery)
+
+**Files in scope**:
+- `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift`
+- `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift`
+- `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift`
+- `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowData.swift`
+- `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift`
+- `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift`
+- `Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropVerticalDelegate.swift`
+- `Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/View+DragAndDrop.swift`
+- `Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropModels.swift`
+
+**Patterns to copy (block widgets)**:
+- `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Link/LinkWidgetViewModel.swift` (per-row badge VM, lazy `spaceView` read)
+- `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Link/LinkWidgetView.swift` (`.id(widgetBlockId)` + `@State` per-row VM + `.task { await model.startSubscriptions() }`)
+
+**Mock / test-suite situation** (pre-resolved): no XCTest suites for `MyFavoritesViewModel`, `LinkWidgetViewModel`, or similar SwiftUI VMs in this module; no `ChatMessagesPreviewsStorageMock` for tests (existing `SpaceViewsStorageMock` lives under `Anytype/Sources/PreviewMocks/` and serves SwiftUI previews only). Project convention for thin SwiftUI view-model glue is **no new unit tests** — manual QA is the verification path. This plan follows that convention.
+
+## Discovered design (current, crashing)
+
+`MyFavoritesViewModel` owns a fat `rows: [MyFavoritesRowData]` array and a single `recomputeRows()` called from **four** async streams, with only one being high-frequency:
+
+```
+personalWidgetsObject.syncPublisher           → structural (add/remove/reorder)   [low freq]
+chatMessagesPreviewsStorage.previewsSequence  → per-row chat badge                 [HIGH freq: every message / read / typing]
+spaceViewsStorage.spaceViewPublisher          → per-row badge formatting           [low-to-medium freq]
+channelWidgetsObject.syncPublisher            → pinnedToChannelObjectIds Set       [low freq]
+```
+
+Plus a computed property `canManageChannelPins` reading `participantSpacesStorage` on each evaluation.
+
+`MyFavoritesRowData` carries `chatPreview: MessagePreviewModel?` inline, so **every chat tick rebuilds every row struct and re-assigns `rows`**. The `@Observable` property `pinnedToChannelObjectIds` also invalidates the list view on every channelWidgets sync.
+
+During an active drag session, this causes the `ForEach(Array(model.rows.enumerated()), id: \.element.id)` body in `MyFavoritesListView` to re-evaluate under the live UIKit drag interaction. Under iOS 26, the row's attached `.contentShape(.dragPreview, RoundedRectangle(cornerRadius: 24, ...))` node gets evicted from SwiftUI's AttributeGraph. When the user releases outside every drop zone, UIKit plays the cancel animation and asks SwiftUI for the source preview via `previewForCancelling`, which re-enters the AttributeGraph to rebuild it. The node is gone → null deref at `0x1a8`.
+
+Compounded by `DragAndDropVerticalDelegate.dropExited` firing `dropFinish` (the `objectActionsService.move(...)` RPC) mid-drag, whose response triggers yet another `recomputeRows()` while the drag is still live.
+
+Block widgets (same DnD stack, same delegate) do **not** crash because:
+- `HomeWidgetsViewModel.widgetBlocks` is a skinny `[BlockWidgetInfo]` updated only from `channelWidgetsObject.syncPublisher`. Chat previews and space-view traffic never touch it.
+- Per-widget state (chat badge, name, icon, drag id) lives in child `@State` ViewModels (e.g., `LinkWidgetViewModel`) instantiated inside each row view with `.id(widgetBlockId)`, each subscribing independently. Parent array stays stable under chat traffic.
+
+## Proposed design (target, mirrors block widgets)
+
+1. **Skinny `MyFavoritesRowData`**: drop `chatPreview`. Keep `id`, `objectId`, `title`, `icon`, `onTap`. **`id` stays the widget block id** (not object id) because `MyFavoritesViewModel.dropFinish` passes `from.data.id` as the `blockId` argument to `objectActionsService.move(...)` — changing `id` semantics would silently break reorder persistence.
+2. **Skinny parent `MyFavoritesViewModel`**: keep ONLY `personalWidgetsObject.syncPublisher`. Delete `startChatPreviewsSubscription`, `startSpaceViewSubscription`, `startChannelPinsSubscription`. Delete `pinnedToChannelObjectIds`, `canManageChannelPins`, `chatPreviews`, `spaceView`, `previewsByChatId`. Drop `chatMessagesPreviewsStorage`, `spaceViewsStorage`, `participantSpacesStorage`, `widgetChatPreviewBuilder` injections. Drop `channelWidgetsObject` from the VM entirely (not used after the refactor); call sites that still need it read it from `HomeWidgetsViewModel.channelWidgetsObject` directly. Expose `spaceId` publicly so the list view can forward it to per-row VMs.
+3. **New `MyFavoritesRowViewModel`** — `@MainActor @Observable` final class. Signature: `init(objectId: String, spaceId: String)`. (Unlike `LinkWidgetViewModel` we pass raw ids because there is no widget-block document layer under a favorites row — identity is the target object id.) Injections: `chatMessagesPreviewsStorage`, `spaceViewsStorage`, `widgetChatPreviewBuilder`. Exposes `private(set) var badgeModel: MessagePreviewModel?`. `startSubscriptions()` runs `startChatPreviewsSubscription()` which iterates `chatMessagesPreviewsStorage.previewsSequence`, stores latest, calls `updateBadgeModel()`. `updateBadgeModel()` looks up preview by `chatId == objectId`, reads `spaceView` via `spaceViewsStorage.spaceView(spaceId:)` (lazy, synchronous), builds via `chatPreviewBuilder.build(chatPreview:spaceView:)` — same shape as `LinkWidgetViewModel.updateBadgeModel`.
+4. **Per-row VM instantiation**: split `MyFavoritesRowView` into an outer `MyFavoritesRowView` + internal `MyFavoritesRowInternalView` (mirror `LinkWidgetView` / `LinkWidgetInternalView`). The outer wraps `MyFavoritesRowInternalView(...).id(row.id)`. The internal view holds `@State private var rowModel: MyFavoritesRowViewModel` initialized from `(row.objectId, spaceId)`, wires `.task { await rowModel.startSubscriptions() }`. **`.setZeroOpacity(...)` and `.anytypeVerticalDrag(itemId: row.id)` stay at the list-level (in `MyFavoritesListView`), not inside the internal view** — they depend on `@Environment(\.anytypeDragState)` injected by `AnytypeVerticalDropViewModifier` on the list wrapper.
+5. **Pin flags on-demand, not observed**: `isPinnedToChannel` and `canManageChannelPins` move into `MyFavoritesRowContextMenuViewModel` as synchronous reads. The VM **stays an `ObservableObject` used with `@StateObject`** — we just add two synchronous methods. No new `@Published` state. SwiftUI evaluates `.contextMenu { ... }` content lazily on presentation, so synchronous reads at that moment are sufficient; staleness within a single menu session is acceptable.
+6. **DnD hygiene — commit on drag end, not zone exit** (Phase B; detailed wire-up below).
+
+Held in reserve, not in scope: `.onDrag(_:preview:)` switch in `AnytypeVerticalDragViewModifier`. Only reach for it if the crash still reproduces after both phases land.
+
+### Phase B wire-up (resolved here, not at code time)
+
+Today: `DragAndDropVerticalDelegate.dropExited` calls `dropFinish(from, to)` → server RPC while user is still dragging. We defer the RPC to **actual drag end** (drop-inside OR drag-cancel outside) so the round-trip and the resulting `recomputeRows` never run during a live drag.
+
+Design (Phase B):
+- New class in `DragAndDropModels.swift`, sibling to `DragAndDropFrames`:
+  ```swift
+  final class DragAndDropPendingCommit {
+      var commit: (() -> Void)?
+  }
+  ```
+- New env key mirroring `\.anytypeDragAndDropFrames`:
+  ```swift
+  extension EnvironmentValues {
+      @Entry var anytypeDragAndDropPendingCommit = DragAndDropPendingCommit()
+  }
+  ```
+- `AnytypeVerticalDropViewModifier` creates `@State private var pendingCommit = DragAndDropPendingCommit()` and injects it via `.environment(\.anytypeDragAndDropPendingCommit, pendingCommit)` alongside the existing frames env.
+- `DragAndDropVerticalDelegate` takes `pendingCommit: DragAndDropPendingCommit` as a property (sibling of `framesStorage`). In `dropUpdated`, after computing `(fromElement, toElement)`, it assigns:
+  ```swift
+  pendingCommit.commit = { [dropFinish] in dropFinish(fromElement, toElement) }
+  ```
+  (struct values captured by copy — no `@Binding`s, no view types).
+- `dropExited` no longer calls `dropFinish`. It only resets the visual drop state (`dropState.resetState()`). `pendingCommit.commit` stays intact so the drag-end path can fire it.
+- `performDrop`, on in-zone success: invokes `dropFinish(from, to)` as today, then sets `pendingCommit.commit = nil` before returning (so drag-end does not double-commit). On the guard-else path, also clears `pendingCommit.commit = nil` defensively.
+- `AnytypeVerticalDragViewModifier` reads `@Environment(\.anytypeDragAndDropPendingCommit)` and wires the drag-end hook inside `.onDrag`:
+  ```swift
+  let pendingCommit = self.pendingCommit
+  provider.didEnd = {
+      state.resetState()
+      let commit = pendingCommit.commit
+      pendingCommit.commit = nil
+      commit?()   // fires RPC only if performDrop did not clear it
+  }
+  ```
+  The existing `DispatchQueue.main.async` inside `DragItemProvider.deinit` (IOS-6105 fix) stays untouched.
+
+Works for **both consumers** (MyFavorites AND `HomeWidgetsView.blockWidgets`) because the plumbing lives on the generic modifiers, not on either call site. Each consumer uses its own `@State` `DragAndDropPendingCommit` instance (since each `AnytypeVerticalDropViewModifier` has its own).
+
+## Development Approach
+
+- **testing approach**: Regular (code first). No new unit tests — matches project convention for SwiftUI view-model glue in this module.
+- complete each task fully before moving to the next
+- make small, focused changes — **every intermediate task inside a phase must leave the project compiling**
+- **do NOT run the simulator build after each task** — simulator builds are slow; verify only at phase boundaries
+- update this plan file when scope changes during implementation (`➕` for additions, `⚠️` for blockers)
+- maintain backward compatibility
+- do not regress IOS-6104 or IOS-6105
+- tasks are numbered `A1…A5` and `B1` so work can be resumed mid-phase across multiple sessions — mark tasks `[x]` as you go; the plan file is the source of truth
+
+## Testing Strategy
+
+- **unit tests**: none (per project convention + mock availability).
+- **e2e tests**: project has none — skip.
+- **manual QA** — verifies the fix on real hardware. Run at phase-end, not per task:
+  - **IOS-6106 reproducer** (Phase A acceptance): iPhone 17 Pro on iOS 26.3.1 (simulator is not authoritative for this crash — the AttributeGraph eviction is iOS-26-specific). 5–10 favorites, long-press a row, drag to the very bottom past Types toward the Bin, release → no crash.
+  - **Mid-drag sync churn** (Phase A, defense-in-depth): while dragging, trigger a `personalWidgetsObject` sync event (add a favorite on a second device signed in to the same account), then cancel by releasing outside → no crash.
+- **Regression walk-through** — run at each phase-end:
+  - IOS-6104: long-press a MyFavorites row, context menu appears, dismiss without action → row stays visible.
+  - IOS-6105: Favorite / Unfavorite / Pin / Unpin from widget long-press menu → navigate to Vault → no SIGABRT.
+  - Chat badges on MyFavorites rows update in real time.
+  - Pin / Unpin to channel menu item shows the correct label for Owner/Admin; hidden for Member/Viewer.
+  - Drag-reorder within MyFavorites persists on drop inside the zone.
+  - Drag-reorder within block widgets (`HomeWidgetsView.blockWidgets`, same delegate): drop inside the pinned section still commits. **For Phase B**: drop outside the pinned section also commits (was working today via `dropExited`; after Phase B it fires from the drag-end path) — explicitly verify.
+
+## Progress Tracking
+
+- mark completed items with `[x]` immediately when done (this file is the single source of truth across sessions)
+- add newly discovered tasks with `➕` prefix
+- document issues/blockers with `⚠️` prefix
+- update plan if implementation deviates from original scope
+
+## Solution Overview
+
+Align `MyFavorites` architecture with `blockWidgets`: parent VM owns only the structural list; per-row VMs own per-row state. This eliminates chat-preview-driven churn on the parent array that is evicting drag-preview attributes from SwiftUI's graph mid-drag. The DnD hygiene change (Phase B) moves the server RPC off the mid-drag `dropExited` path via a shared `DragAndDropPendingCommit` environment box, giving the user the "drop outside = commit last visual state" UX while preserving the block-widgets consumer.
+
+## Technical Details
+
+- `MyFavoritesRowViewModel(objectId: String, spaceId: String)` — no block/document wrapper; identity is the target object id.
+- Per-row VM is `@State private var model: MyFavoritesRowViewModel` inside `MyFavoritesRowInternalView`, initialized from `(row.objectId, spaceId)`, exactly like `LinkWidgetInternalView`.
+- `MyFavoritesRowContextMenuViewModel` stays an `ObservableObject`/`@StateObject`; we add two synchronous methods, no `@Published` additions.
+- `DragAndDropPendingCommit` is a reference-type box (mirror of `DragAndDropFrames`), held by the drop modifier as `@State`, exposed via `@Environment` to drag children.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): Swift source edits under `Anytype/Sources/...`.
+- **Post-Completion** (no checkboxes): device-based reproducer validation and regression walk-through per phase.
+
+## Implementation Steps
+
+### Phase A — Per-row ViewModel refactor (PR 1)
+
+**Goal**: stop `MyFavoritesViewModel.rows` from being rebuilt on chat / space / pin traffic. Expected to close IOS-6106 on its own.
+
+**Branch**: `ios-6106-crash-after-dnd-of-the-object-down-the-screen-widget` (current).
+
+**Working agreement**: every intermediate task inside Phase A must leave the project compiling. No simulator build required between tasks.
+
+#### Task A1: Add `MyFavoritesRowViewModel` (new file, standalone)
+
+**Files:**
+- Create: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowViewModel.swift`
+
+- [ ] create `@MainActor @Observable` final class `MyFavoritesRowViewModel`
+- [ ] injections (`@ObservationIgnored @Injected`): `chatMessagesPreviewsStorage`, `spaceViewsStorage`, `widgetChatPreviewBuilder`
+- [ ] initializer `init(objectId: String, spaceId: String)`
+- [ ] stored (`@ObservationIgnored`): `objectId`, `spaceId`, `chatPreviews: [ChatMessagePreview] = []`
+- [ ] exposed: `private(set) var badgeModel: MessagePreviewModel?`
+- [ ] `func startSubscriptions() async` → runs `startChatPreviewsSubscription()`
+- [ ] `startChatPreviewsSubscription()` iterates `chatMessagesPreviewsStorage.previewsSequence`, assigns `chatPreviews`, calls `updateBadgeModel()`
+- [ ] `updateBadgeModel()`: find preview where `chatId == objectId`, read `spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)`, build via `chatPreviewBuilder.build(chatPreview:spaceView:)` — copy shape from `LinkWidgetViewModel.updateBadgeModel`
+
+#### Task A2: Add `MyFavoritesRowInternalView` + wire the per-row VM + plumb `spaceId`
+
+**Files:**
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift` (expose `spaceId` publicly)
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift` (pass `spaceId` to each row)
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift` (outer + new internal view)
+
+- [ ] remove `private` from `spaceId` on `MyFavoritesViewModel` (or expose via a public `let`/computed accessor) so the view can read it
+- [ ] in `MyFavoritesListView.swift`, pass `spaceId: model.spaceId` into each `MyFavoritesRowView`
+- [ ] split `MyFavoritesRowView` — the outer struct now wraps `MyFavoritesRowInternalView(...).id(row.id)`, threading through the existing parameters including `canManageChannelPins` and `isPinnedToChannel` (these are removed in Task A3; leave them wired for now so the project keeps compiling)
+- [ ] inside `MyFavoritesRowInternalView`, hold `@State private var rowModel: MyFavoritesRowViewModel`; init from `(row.objectId, spaceId)` exactly like `LinkWidgetInternalView` inits `LinkWidgetViewModel`
+- [ ] add `.task { await rowModel.startSubscriptions() }` on the internal view's body
+- [ ] in the chat-badge branch of the body, replace `row.chatPreview` with `rowModel.badgeModel`. `MyFavoritesRowData.chatPreview` still exists and is still populated by the parent VM at this point — just stop reading it from the view.
+- [ ] **keep `.setZeroOpacity(...)` and `.anytypeVerticalDrag(itemId: row.id)` at list-level in `MyFavoritesListView`** — do not move them into `MyFavoritesRowInternalView`
+
+#### Task A3: Move pin flags + can-manage flag into the context-menu VM
+
+**Files:**
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowView.swift`
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift`
+
+- [ ] add `func isPinnedToChannel(objectId: String, channelWidgetsObject: any BaseDocumentProtocol) -> Bool` to `MyFavoritesRowContextMenuViewModel` — iterate `channelWidgetsObject.children` filtered by `isWidget`, match `.object(details)` with `details.id == objectId`
+- [ ] add `@Injected(\.participantSpacesStorage) private var participantSpacesStorage` plus `func canManageChannelPins(spaceId: String) -> Bool` reading `participantSpacesStorage.participantSpaceView(spaceId:)?.canManageChannelPins ?? false`
+- [ ] keep `MyFavoritesRowContextMenuViewModel` as `ObservableObject` used with `@StateObject` — no `@Published` added
+- [ ] update the inner `MyFavoritesRowContextMenu`:
+  - drop `canManageChannelPins: Bool` and `isPinnedToChannel: Bool` from its parameters
+  - add `let spaceId: String`
+  - in `body`, replace the static `canManageChannelPins` / `isPinnedToChannel` reads with `model.canManageChannelPins(spaceId: spaceId)` and `model.isPinnedToChannel(objectId: objectId, channelWidgetsObject: channelWidgetsObject)` — these are evaluated lazily when SwiftUI renders the menu on long-press
+- [ ] drop `canManageChannelPins` and `isPinnedToChannel` from `MyFavoritesRowView` and `MyFavoritesRowInternalView` parameters; keep `channelWidgetsObject`, `personalWidgetsObject`, `spaceId`
+- [ ] update the `.contextMenu { MyFavoritesRowContextMenu(...) }` invocation to the new parameter shape
+- [ ] in `MyFavoritesListView.swift`, stop passing `canManageChannelPins` and `pinnedToChannelObjectIds.contains(...)`; pass `spaceId: model.spaceId` instead
+
+#### Task A4: Trim the parent `MyFavoritesViewModel`
+
+**Files:**
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesViewModel.swift`
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowData.swift`
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift`
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift`
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift` (if it currently reads `myFavoritesViewModel.channelWidgetsObject`)
+
+- [ ] in `MyFavoritesRowData.swift`: drop `chatPreview: MessagePreviewModel?`
+- [ ] in `MyFavoritesViewModel.swift`:
+  - delete `startChatPreviewsSubscription`, `startSpaceViewSubscription`, `startChannelPinsSubscription`, and their stored state (`chatPreviews`, `spaceView`, `pinnedToChannelObjectIds`)
+  - delete computed `canManageChannelPins`
+  - delete injections: `chatMessagesPreviewsStorage`, `spaceViewsStorage`, `participantSpacesStorage`, `widgetChatPreviewBuilder`
+  - simplify `startSubscriptions()` to run only `startPersonalWidgetsSubscription()`
+  - shrink `recomputeRows()` to build `MyFavoritesRowData(id: block.blockId, objectId: details.id, title: details.pluralTitle, icon: details.objectIconImage, onTap: { onObjectSelected(details) })` only
+  - drop `channelWidgetsObject` parameter from `init` — no longer read by the VM after Task A3
+- [ ] in `HomeWidgetsViewModel.init`, update the `MyFavoritesViewModel(...)` invocation to match the new init
+- [ ] in `HomeWidgetsView.swift` (and `MyFavoritesListView.swift` if applicable), the places that previously read `myFavoritesViewModel.channelWidgetsObject` switch to reading `model.channelWidgetsObject` from the parent `HomeWidgetsViewModel` (same reference — both used to point to the same document) and pass it down explicitly where needed
+
+#### Phase A hand-off (end of PR 1)
+
+- [ ] full Xcode build passes
+- [ ] manual QA (on iOS 26.3+ device, real hardware):
+  - IOS-6106 reproducer: 5×, no crash
+  - IOS-6104 regression: long-press + context-menu dismiss, row visible
+  - IOS-6105 regression: Favorite/Unfavorite/Pin/Unpin → Vault → no SIGABRT
+  - chat badges update live on MyFavorites rows
+  - Pin/Unpin menu item shows correct label, hidden for Member/Viewer
+  - reorder-within-zone persists
+  - block-widgets drag-reorder still works (same delegate)
+- [ ] open PR 1 titled e.g. `IOS-6106 MyFavorites per-row ViewModel refactor`; commit trailer `IOS-6106`; "Release" label per workflow
+- [ ] merge PR 1 before starting Phase B (or continue on a new branch cut off develop post-merge — either way, Phase B should not stack on unmerged Phase A)
+
+---
+
+### Phase B — DnD commit-on-drag-end hygiene (PR 2)
+
+**Goal**: move the server RPC off `dropExited` to actual drag-end for both MyFavorites and block widgets. Matches user-requested UX ("drop outside = commit last visual state") and eliminates a residual mid-drag server round-trip.
+
+**Branch**: after Phase A merges, cut a new branch (e.g. `ios-6106-dnd-commit-on-drag-end`) off develop. Do NOT stack on unmerged Phase A.
+
+**Working agreement**: every intermediate task inside Phase B must leave the project compiling. No simulator build required between tasks.
+
+#### Task B1: Introduce `DragAndDropPendingCommit` + commit-on-drag-end plumbing
+
+**Files:**
+- Modify: `Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropModels.swift`
+- Modify: `Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/View+DragAndDrop.swift`
+- Modify: `Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropVerticalDelegate.swift`
+
+- [ ] in `DragAndDropModels.swift`:
+  - add `final class DragAndDropPendingCommit { var commit: (() -> Void)? }`
+  - add `@Entry var anytypeDragAndDropPendingCommit: DragAndDropPendingCommit = DragAndDropPendingCommit()` on `EnvironmentValues` (mirror `DragAndDropFrames` / `anytypeDragAndDropFrames`)
+  - **do not touch** `DragItemProvider.deinit` — the `DispatchQueue.main.async` defer from IOS-6105 stays
+- [ ] in `View+DragAndDrop.swift`:
+  - in `AnytypeVerticalDropViewModifier`: `@State private var pendingCommit = DragAndDropPendingCommit()`; add `.environment(\.anytypeDragAndDropPendingCommit, pendingCommit)` alongside the existing frames env; pass `pendingCommit` into `DragAndDropVerticalDelegate`
+  - in `AnytypeVerticalDragViewModifier`: `@Environment(\.anytypeDragAndDropPendingCommit) private var pendingCommit`; inside `.onDrag`, capture by value and wire `provider.didEnd`:
+    ```swift
+    let pendingCommit = self.pendingCommit
+    provider.didEnd = {
+        state.resetState()
+        let commit = pendingCommit.commit
+        pendingCommit.commit = nil
+        commit?()
+    }
+    ```
+- [ ] in `DragAndDropVerticalDelegate.swift`:
+  - add `let pendingCommit: DragAndDropPendingCommit` property (sibling of `framesStorage`)
+  - in `dropUpdated`, immediately after computing `(fromElement, toElement)`: `pendingCommit.commit = { [dropFinish] in dropFinish(fromElement, toElement) }` (struct values captured by copy; no bindings, no view types)
+  - in `dropExited`: **remove** the `dropFinish(fromElement, toElement)` call; keep `dropState.resetState()`. Do NOT touch `pendingCommit.commit`.
+  - in `performDrop` success path: call `dropFinish(from, to)` as today inside `withAnimation`, then `pendingCommit.commit = nil` before returning. On the guard-else (no elements) path: also set `pendingCommit.commit = nil` defensively.
+
+#### Phase B hand-off (end of PR 2)
+
+- [ ] full Xcode build passes
+- [ ] manual DnD verification on real hardware:
+  - MyFavorites: drop inside zone → persists (happy path)
+  - MyFavorites: drop outside zone (drag near Bin and release) → persists last in-zone position if one was captured during the drag; nothing persists if the drag never entered the zone; no crash
+  - MyFavorites: start drag but release immediately without entering the zone → no commit, no crash
+  - Pinned block widgets: drop inside the section → persists
+  - Pinned block widgets: drag outside the section and release → **still persists** (this is the key regression check — `dropExited` no longer commits, so the path must be carried by the drag-end hook)
+  - IOS-6104/6105 regression checks (same as Phase A) still pass
+- [ ] open PR 2 titled e.g. `IOS-6106 DnD commit on drag-end`; commit trailer `IOS-6106`; "Release" label per workflow
+
+---
+
+### Final housekeeping (after both PRs merge)
+
+- [ ] move this plan file to `docs/plans/completed/` (create dir if needed: `mkdir -p docs/plans/completed`)
+
+## Post-Completion
+
+*Manual / external verification — informational, no checkboxes.*
+
+**Device verification**:
+- The IOS-6106 crash is iOS-26-specific (AttributeGraph eviction behavior); the reproducer MUST be run on an iOS 26.3+ device. Simulator verification is a nice-to-have but not authoritative.
+- One pass on an iOS 18.x device to confirm no behavior change on the legacy SwiftUI graph.
+
+**Coordination**:
+- No middleware changes; no backend coordination required.
+
+**Fallback (if crash still reproduces after both phases land)**:
+- Switch `AnytypeVerticalDragViewModifier` to `.onDrag(_:preview:)` with an explicit preview view snapshot. Bypasses the `previewForCancelling` AttributeGraph path entirely. Open as a separate follow-up issue only if needed.


### PR DESCRIPTION
## Summary

- Closes IOS-6106 (EXC_BAD_ACCESS in AttributeGraph during drag-cancel of a MyFavorites row on iOS 26.3+).
- Phase A only — refactors `MyFavorites` to mirror block-widgets architecture: parent VM owns only the structural row list; per-row state (chat badge, title/icon, menu actions) lives in `@State`-owned `MyFavoritesRowViewModel`s. Eliminates parent-array churn that was evicting the drag-preview AttributeGraph node mid-drag.
- Phase B (DnD commit-on-drag-end via `DragAndDropPendingCommit`) is intentionally deferred to a separate branch off develop, per the original plan.