### PR TITLE
IOS-6106 Fix My Favorites drag edge drops + drag provider factory

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropModels.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropModels.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 extension EnvironmentValues {
     @Entry var anytypeDragState: Binding<DragState> = .constant(DragState())
+    @Entry var anytypeDragAndDropPendingCommit = DragAndDropPendingCommit()
 }
 
 struct DropDataElement<Data> {
@@ -29,8 +30,13 @@ struct DropState<Data> {
     }
 }
 
+final class DragAndDropPendingCommit {
+    var commit: (() -> Void)?
+}
+
 class DragItemProvider: NSItemProvider {
     var didEnd: (() -> Void)?
+
     deinit {
         // Deferred to the next runloop to avoid re-entrant @Binding mutation when deinit
         // fires during SwiftUI graph tear-down or drag payload release.

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropVerticalDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropVerticalDelegate.swift
@@ -7,6 +7,7 @@ struct DragAndDropVerticalDelegate<Data>: DropDelegate where Data: Identifiable<
     @Binding var dragState: DragState
     @Binding var dropState: DropState<Data>
     let framesStorage: DragAndDropFrames
+    let pendingCommit: DragAndDropPendingCommit
     let dropUpdate: (_ from: DropDataElement<Data>, _ to: DropDataElement<Data>) -> Void
     let dropFinish: (_ from: DropDataElement<Data>, _ to: DropDataElement<Data>) -> Void
     
@@ -48,6 +49,9 @@ struct DragAndDropVerticalDelegate<Data>: DropDelegate where Data: Identifiable<
         
         dropState.fromElement = fromElement
         dropState.toElement = toElement
+        pendingCommit.commit = { [dropFinish] in
+            dropFinish(fromElement, toElement)
+        }
         
         withAnimation {
             dropUpdate(fromElement, toElement)
@@ -57,29 +61,36 @@ struct DragAndDropVerticalDelegate<Data>: DropDelegate where Data: Identifiable<
     }
     
     func dropExited(info: DropInfo) {
-        guard let fromElement = dropState.fromElement,
-              let toElement = dropState.toElement else {
-            return
-        }
-        
         dropState.resetState()
-
-        dropFinish(fromElement, toElement)
+        // Keep `dragInProgress` while a pending commit exists. Edge drops often leave
+        // the drop zone before the drag provider ends; clearing the active state here
+        // makes the source row reappear and can switch the preview to "not allowed".
+        if pendingCommit.commit == nil {
+            dragState.dragInProgress = false
+        }
     }
     
     func performDrop(info: DropInfo) -> Bool {
         guard let fromElement = dropState.fromElement,
               let toElement = dropState.toElement else {
+            let commit = pendingCommit.commit
+            pendingCommit.commit = nil
+            // `performDrop` can arrive after `dropExited` has reset `dropState`,
+            // while `pendingCommit` still contains the last valid in-zone reorder.
+            // Treat that as an accepted edge-drop; returning `false` makes iOS show
+            // the "not allowed" badge and can snap the source row back.
             withAnimation {
                 fullClear()
+                commit?()
             }
-            return false
+            return commit.isNotNil
         }
 
         withAnimation {
             fullClear()
             dropFinish(fromElement, toElement)
         }
+        pendingCommit.commit = nil
 
         return true
     }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/View+DragAndDrop.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/View+DragAndDrop.swift
@@ -2,38 +2,42 @@ import Foundation
 import SwiftUI
 import UniformTypeIdentifiers
 
+private extension DragItemProvider {
+    static func anytypeProvider(
+        itemId: String,
+        state: Binding<DragState>,
+        pendingCommit: DragAndDropPendingCommit
+    ) -> DragItemProvider {
+        state.wrappedValue.dragInitiateId = itemId
+
+        let provider = DragItemProvider(object: "\(itemId)" as NSString)
+        provider.didEnd = {
+            let commit = pendingCommit.commit
+            pendingCommit.commit = nil
+            if let commit {
+                state.wrappedValue.resetState()
+                commit()
+            } else if !state.wrappedValue.dragInProgress {
+                state.wrappedValue.resetState()
+            }
+            // else: iOS can deallocate a transient drag provider while the actual drag
+            // session is still active. Resetting here would make SwiftUI treat the row
+            // as non-draggable mid-gesture (shows "not allowed" badge / row reappears).
+        }
+        return provider
+    }
+}
+
 struct AnytypeVerticalDragViewModifier: ViewModifier {
     let itemId: String
-    @Environment(\.anytypeDragState) @Binding var state: DragState
-    @Environment(\.anytypeDragAndDropFrames) var framesStorage
+    @Environment(\.anytypeDragState) private var state: Binding<DragState>
+    @Environment(\.anytypeDragAndDropFrames) private var framesStorage
     @Environment(\.anytypeDragAndDropPendingCommit) private var pendingCommit
 
     func body(content: Content) -> some View {
         content
             .onDrag {
-                state.dragInitiateId = itemId
-
-                let provider = DragItemProvider(object: "\(itemId)" as NSString)
-                let pendingCommit = self.pendingCommit
-
-                provider.didEnd = {
-                    let commit = pendingCommit.commit
-                    pendingCommit.commit = nil
-                    if let commit {
-                        state.resetState()
-                        commit()
-                    } else if !state.dragInProgress {
-                        state.resetState()
-                    } else {
-                        // iOS can deallocate a transient drag provider while the actual drag
-                        // session is still active. Resetting here makes SwiftUI treat the row
-                        // as non-draggable mid-gesture, which shows the "not allowed" badge and
-                        // puts the source row back into the list.
-                        return
-                    }
-                }
-
-                return provider
+                DragItemProvider.anytypeProvider(itemId: itemId, state: state, pendingCommit: pendingCommit)
             }
             .readFrame(space: .named("anytypeDropSpace")) { frame in
                 framesStorage.frames[itemId] = frame
@@ -54,36 +58,14 @@ extension View {
 struct AnytypeVerticalDragWithPreviewViewModifier<Preview: View>: ViewModifier {
     let itemId: String
     let preview: () -> Preview
-    @Environment(\.anytypeDragState) @Binding var state: DragState
-    @Environment(\.anytypeDragAndDropFrames) var framesStorage
+    @Environment(\.anytypeDragState) private var state: Binding<DragState>
+    @Environment(\.anytypeDragAndDropFrames) private var framesStorage
     @Environment(\.anytypeDragAndDropPendingCommit) private var pendingCommit
 
     func body(content: Content) -> some View {
         content
             .onDrag {
-                state.dragInitiateId = itemId
-
-                let provider = DragItemProvider(object: "\(itemId)" as NSString)
-                let pendingCommit = self.pendingCommit
-
-                provider.didEnd = {
-                    let commit = pendingCommit.commit
-                    pendingCommit.commit = nil
-                    if let commit {
-                        state.resetState()
-                        commit()
-                    } else if !state.dragInProgress {
-                        state.resetState()
-                    } else {
-                        // iOS can deallocate a transient drag provider while the actual drag
-                        // session is still active. Resetting here makes SwiftUI treat the row
-                        // as non-draggable mid-gesture, which shows the "not allowed" badge and
-                        // puts the source row back into the list.
-                        return
-                    }
-                }
-
-                return provider
+                DragItemProvider.anytypeProvider(itemId: itemId, state: state, pendingCommit: pendingCommit)
             } preview: {
                 preview()
             }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/View+DragAndDrop.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/View+DragAndDrop.swift
@@ -6,18 +6,33 @@ struct AnytypeVerticalDragViewModifier: ViewModifier {
     let itemId: String
     @Environment(\.anytypeDragState) @Binding var state: DragState
     @Environment(\.anytypeDragAndDropFrames) var framesStorage
-    
+    @Environment(\.anytypeDragAndDropPendingCommit) private var pendingCommit
+
     func body(content: Content) -> some View {
         content
             .onDrag {
                 state.dragInitiateId = itemId
-                
+
                 let provider = DragItemProvider(object: "\(itemId)" as NSString)
+                let pendingCommit = self.pendingCommit
 
                 provider.didEnd = {
-                    state.resetState()
+                    let commit = pendingCommit.commit
+                    pendingCommit.commit = nil
+                    if let commit {
+                        state.resetState()
+                        commit()
+                    } else if !state.dragInProgress {
+                        state.resetState()
+                    } else {
+                        // iOS can deallocate a transient drag provider while the actual drag
+                        // session is still active. Resetting here makes SwiftUI treat the row
+                        // as non-draggable mid-gesture, which shows the "not allowed" badge and
+                        // puts the source row back into the list.
+                        return
+                    }
                 }
-                
+
                 return provider
             }
             .readFrame(space: .named("anytypeDropSpace")) { frame in
@@ -30,9 +45,60 @@ extension View {
     func anytypeVerticalDrag<Data: Identifiable<String>>(item: Data) -> some View {
         modifier(AnytypeVerticalDragViewModifier(itemId: item.id))
     }
-    
+
     func anytypeVerticalDrag(itemId: String) -> some View {
         modifier(AnytypeVerticalDragViewModifier(itemId: itemId))
+    }
+}
+
+struct AnytypeVerticalDragWithPreviewViewModifier<Preview: View>: ViewModifier {
+    let itemId: String
+    let preview: () -> Preview
+    @Environment(\.anytypeDragState) @Binding var state: DragState
+    @Environment(\.anytypeDragAndDropFrames) var framesStorage
+    @Environment(\.anytypeDragAndDropPendingCommit) private var pendingCommit
+
+    func body(content: Content) -> some View {
+        content
+            .onDrag {
+                state.dragInitiateId = itemId
+
+                let provider = DragItemProvider(object: "\(itemId)" as NSString)
+                let pendingCommit = self.pendingCommit
+
+                provider.didEnd = {
+                    let commit = pendingCommit.commit
+                    pendingCommit.commit = nil
+                    if let commit {
+                        state.resetState()
+                        commit()
+                    } else if !state.dragInProgress {
+                        state.resetState()
+                    } else {
+                        // iOS can deallocate a transient drag provider while the actual drag
+                        // session is still active. Resetting here makes SwiftUI treat the row
+                        // as non-draggable mid-gesture, which shows the "not allowed" badge and
+                        // puts the source row back into the list.
+                        return
+                    }
+                }
+
+                return provider
+            } preview: {
+                preview()
+            }
+            .readFrame(space: .named("anytypeDropSpace")) { frame in
+                framesStorage.frames[itemId] = frame
+            }
+    }
+}
+
+extension View {
+    func anytypeVerticalDrag<Preview: View>(
+        itemId: String,
+        @ViewBuilder preview: @escaping () -> Preview
+    ) -> some View {
+        modifier(AnytypeVerticalDragWithPreviewViewModifier(itemId: itemId, preview: preview))
     }
 }
 
@@ -44,6 +110,7 @@ struct AnytypeVerticalDropViewModifier<Data>: ViewModifier where Data: Identifia
     
     @State private var dropState = DropState<Data>()
     @State private var framesStorage = DragAndDropFrames()
+    @State private var pendingCommit = DragAndDropPendingCommit()
     
     func body(content: Content) -> some View {
         content
@@ -54,6 +121,7 @@ struct AnytypeVerticalDropViewModifier<Data>: ViewModifier where Data: Identifia
                     dragState: $state,
                     dropState: $dropState,
                     framesStorage: framesStorage,
+                    pendingCommit: pendingCommit,
                     dropUpdate: dropUpdate,
                     dropFinish: dropFinish
                 )
@@ -61,6 +129,7 @@ struct AnytypeVerticalDropViewModifier<Data>: ViewModifier where Data: Identifia
             .coordinateSpace(name: "anytypeDropSpace")
             .environment(\.anytypeDragState, $state)
             .environment(\.anytypeDragAndDropFrames, framesStorage)
+            .environment(\.anytypeDragAndDropPendingCommit, pendingCommit)
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
@@ -29,7 +29,7 @@ struct MyFavoritesListView: View {
                     // for the cancel preview when the gesture is released near screen edges.
                     MyFavoritesDragPreviewView(
                         row: row,
-                        width: rowWidths[row.id] ?? UIScreen.main.bounds.width - 40
+                        width: rowWidths[row.id] ?? (UIScreen.main.bounds.width - 40)
                     )
                 }
                 .setZeroOpacity(favoritesDndState.dragInitiateId == row.id && favoritesDndState.dragInProgress)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift
@@ -5,6 +5,7 @@ struct MyFavoritesListView: View {
     let model: MyFavoritesListViewModel
 
     @State private var favoritesDndState = DragState()
+    @State private var rowWidths: [String: CGFloat] = [:]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -18,7 +19,19 @@ struct MyFavoritesListView: View {
                     onObjectSelected: model.onObjectSelected
                 )
                 .contentShape(.dragPreview, RoundedRectangle(cornerRadius: 24, style: .continuous))
-                .anytypeVerticalDrag(itemId: row.id)
+                .readFrame { frame in
+                    guard rowWidths[row.id] != frame.width else { return }
+                    rowWidths[row.id] = frame.width
+                }
+                .anytypeVerticalDrag(itemId: row.id) {
+                    // Keep the drag preview detached from the live row subtree. The live row owns
+                    // subscriptions/context menu state, and iOS 26 can crash while rebuilding it
+                    // for the cancel preview when the gesture is released near screen edges.
+                    MyFavoritesDragPreviewView(
+                        row: row,
+                        width: rowWidths[row.id] ?? UIScreen.main.bounds.width - 40
+                    )
+                }
                 .setZeroOpacity(favoritesDndState.dragInitiateId == row.id && favoritesDndState.dragInProgress)
             }
         }
@@ -29,5 +42,27 @@ struct MyFavoritesListView: View {
         } dropFinish: { from, to in
             model.dropFinish(from: from, to: to)
         }
+    }
+}
+
+private struct MyFavoritesDragPreviewView: View {
+    let row: MyFavoritesRowData
+    let width: CGFloat
+
+    var body: some View {
+        HStack(spacing: 12) {
+            IconView(icon: row.details.objectIconImage)
+                .frame(width: 20, height: 20)
+
+            AnytypeText(row.details.pluralTitle, style: .bodySemibold)
+                .foregroundStyle(Color.Text.primary)
+                .lineLimit(1)
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .frame(width: width, height: 48)
+        .background(Color.Background.widget)
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
     }
 }

--- a/docs/plans/20260424-ios-6106-my-favorites-per-row-vm.md
+++ b/docs/plans/20260424-ios-6106-my-favorites-per-row-vm.md
@@ -258,11 +258,17 @@ Align `MyFavorites` architecture with `blockWidgets`: parent VM owns only the st
 
 ### Phase B — DnD commit-on-drag-end hygiene (PR 2)
 
-**Goal**: move the server RPC off `dropExited` to actual drag-end for both MyFavorites and block widgets. Matches user-requested UX ("drop outside = commit last visual state") and eliminates a residual mid-drag server round-trip.
+**Goal**: move the server RPC off `dropExited` to drag-end / accepted drop paths, and give MyFavorites a detached drag preview. This fixes the edge-release crash and preserves "drop outside = commit last visual state" for both MyFavorites and block widgets.
 
 **Branch**: after Phase A merges, cut a new branch (e.g. `ios-6106-dnd-commit-on-drag-end`) off develop. Do NOT stack on unmerged Phase A.
 
 **Working agreement**: every intermediate task inside Phase B must leave the project compiling. No simulator build required between tasks.
+
+**Current implementation notes from device debugging**:
+- Root cause was split across two iOS 26 drag paths: SwiftUI could crash while rebuilding the live MyFavorites row subtree for `previewForCancelling`, and edge drops could call `performDrop` after `dropExited` had cleared `dropState`.
+- MyFavorites now uses an explicit lightweight drag preview detached from the live row subtree. Keep this: the live row owns subscriptions/context-menu state, and iOS 26 can crash while rebuilding it for cancel preview near screen edges.
+- `DragItemProvider.didEnd` can fire for transient providers while the actual drag is still active. Do not reset `DragState` on a no-commit `didEnd` when `dragInProgress == true`; that causes the row to reappear and can switch the preview to the "not allowed" badge.
+- `performDrop` can arrive after `dropExited` has cleared `dropState` while `pendingCommit` still contains the last valid reorder. Treat that as an accepted edge-drop and execute the pending commit; returning `false` is what makes iOS show the "not allowed" badge and snap the row back.
 
 #### Task B1: Introduce `DragAndDropPendingCommit` + commit-on-drag-end plumbing
 
@@ -271,32 +277,45 @@ Align `MyFavorites` architecture with `blockWidgets`: parent VM owns only the st
 - Modify: `Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/View+DragAndDrop.swift`
 - Modify: `Anytype/Sources/PresentationLayer/Common/SwiftUI/DragAndDrop/DragAndDropVerticalDelegate.swift`
 
-- [ ] in `DragAndDropModels.swift`:
+- [x] in `DragAndDropModels.swift`:
   - add `final class DragAndDropPendingCommit { var commit: (() -> Void)? }`
   - add `@Entry var anytypeDragAndDropPendingCommit: DragAndDropPendingCommit = DragAndDropPendingCommit()` on `EnvironmentValues` (mirror `DragAndDropFrames` / `anytypeDragAndDropFrames`)
   - **do not touch** `DragItemProvider.deinit` — the `DispatchQueue.main.async` defer from IOS-6105 stays
-- [ ] in `View+DragAndDrop.swift`:
+- [x] in `View+DragAndDrop.swift`:
   - in `AnytypeVerticalDropViewModifier`: `@State private var pendingCommit = DragAndDropPendingCommit()`; add `.environment(\.anytypeDragAndDropPendingCommit, pendingCommit)` alongside the existing frames env; pass `pendingCommit` into `DragAndDropVerticalDelegate`
   - in `AnytypeVerticalDragViewModifier`: `@Environment(\.anytypeDragAndDropPendingCommit) private var pendingCommit`; inside `.onDrag`, capture by value and wire `provider.didEnd`:
     ```swift
     let pendingCommit = self.pendingCommit
     provider.didEnd = {
-        state.resetState()
         let commit = pendingCommit.commit
         pendingCommit.commit = nil
-        commit?()
+        if let commit {
+            state.resetState()
+            commit()
+        } else if !state.dragInProgress {
+            state.resetState()
+        }
     }
     ```
-- [ ] in `DragAndDropVerticalDelegate.swift`:
+- [x] in `DragAndDropVerticalDelegate.swift`:
   - add `let pendingCommit: DragAndDropPendingCommit` property (sibling of `framesStorage`)
   - in `dropUpdated`, immediately after computing `(fromElement, toElement)`: `pendingCommit.commit = { [dropFinish] in dropFinish(fromElement, toElement) }` (struct values captured by copy; no bindings, no view types)
-  - in `dropExited`: **remove** the `dropFinish(fromElement, toElement)` call; keep `dropState.resetState()`. Do NOT touch `pendingCommit.commit`.
-  - in `performDrop` success path: call `dropFinish(from, to)` as today inside `withAnimation`, then `pendingCommit.commit = nil` before returning. On the guard-else (no elements) path: also set `pendingCommit.commit = nil` defensively.
+  - in `dropExited`: **remove** the `dropFinish(fromElement, toElement)` call; keep `dropState.resetState()`. Keep `dragInProgress` true while a pending commit exists.
+  - in `performDrop` success path: call `dropFinish(from, to)` as today inside `withAnimation`, then `pendingCommit.commit = nil` before returning. On the guard-else (no elements) path, if `pendingCommit.commit` exists, execute it and return `true`; only return `false` when there is no pending commit.
+
+#### Task B2: Add detached MyFavorites drag preview
+
+**Files:**
+- Modify: `Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListView.swift`
+
+- [x] add `MyFavoritesDragPreviewView` as a lightweight preview that renders only icon/title against widget background
+- [x] measure each source row width and use it for the explicit preview to avoid transparent trailing space
+- [x] keep `.contentShape(.dragPreview, ...)`, `.anytypeVerticalDrag(...)`, and `.setZeroOpacity(...)` on the list-level row wrapper
 
 #### Phase B hand-off (end of PR 2)
 
 - [ ] full Xcode build passes
-- [ ] manual DnD verification on real hardware:
+- [x] manual DnD verification on real hardware:
   - MyFavorites: drop inside zone → persists (happy path)
   - MyFavorites: drop outside zone (drag near Bin and release) → persists last in-zone position if one was captured during the drag; nothing persists if the drag never entered the zone; no crash
   - MyFavorites: start drag but release immediately without entering the zone → no commit, no crash
@@ -323,4 +342,4 @@ Align `MyFavorites` architecture with `blockWidgets`: parent VM owns only the st
 - No middleware changes; no backend coordination required.
 
 **Fallback (if crash still reproduces after both phases land)**:
-- Switch `AnytypeVerticalDragViewModifier` to `.onDrag(_:preview:)` with an explicit preview view snapshot. Bypasses the `previewForCancelling` AttributeGraph path entirely. Open as a separate follow-up issue only if needed.
+- The explicit MyFavorites preview is already implemented. If the crash returns, collect a fresh iOS 26 crash stack and check whether it still points at `SwiftUI DragAndDropBridge.previewForCancelling` or has moved to the reorder commit path.


### PR DESCRIPTION
## Summary
- Fix iOS 26 crash and stuck-state on My Favorites drag-and-drop when releasing near screen edges: explicit detached drag preview, commit-on-drag-end via `DragAndDropPendingCommit`, and edge-drop accepted in `performDrop` when `dropExited` already cleared `dropState`.
- Refactor `View+DragAndDrop` shared provider setup into `DragItemProvider.anytypeProvider(...)` so the no-preview and with-preview modifiers no longer duplicate `provider.didEnd` logic; read `\.anytypeDragState` env entry directly as `Binding<DragState>`.

## Test plan
- [ ] My Favorites: drop inside zone → persists
- [ ] My Favorites: drag past Bin and release at edge → persists last in-zone position; no crash
- [ ] My Favorites: start drag and release immediately without entering zone → no commit, no crash
- [ ] Block widgets (`HomeWidgetsView`): reorder via drag still works; quick tap-and-release leaves no stuck drag state