### PR TITLE
IOS-6112 Show discussion button only on layouts that support discussions

### DIFF
--- a/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
+++ b/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
@@ -135,6 +135,8 @@ extension BundledPropertiesValueProvider {
     
     var isSupportedForOpening: Bool { resolvedLayoutValue.isSupportedForOpening }
 
+    var isSupportedForDiscussion: Bool { resolvedLayoutValue.isSupportedForDiscussion }
+
     @available(*, deprecated, message: "Use spaceType overload instead")
     func isVisibleLayout(spaceUxType: SpaceUxType?) -> Bool {
         DetailsLayout.visibleLayouts(spaceUxType: spaceUxType).contains(resolvedLayoutValue)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelViewModel.swift
@@ -246,10 +246,12 @@ final class HomeBottomNavigationPanelViewModel {
             return
         }
         let document = documentsProvider.document(objectId: objectId, spaceId: editorData.spaceId)
-        let discussionId = document.details?.discussionId
+        let details = document.details
+        let discussionId = details?.discussionId
         let hasDiscussion = discussionId?.isNotEmpty == true
-        showDiscussButton = FeatureFlags.discussionButton && (canCreateObject || hasDiscussion)
-        discussButtonHasUnread = showDiscussButton && (document.details?.unreadMessageCount ?? 0) > 0
+        let layoutSupportsDiscussion = details?.isSupportedForDiscussion ?? false
+        showDiscussButton = FeatureFlags.discussionButton && layoutSupportsDiscussion && (canCreateObject || hasDiscussion)
+        discussButtonHasUnread = showDiscussButton && (details?.unreadMessageCount ?? 0) > 0
 
         guard hasDiscussion, let discussionId else {
             clearDiscussionObservation()

--- a/Modules/Services/Sources/Models/Extensions/DetailsLayoutExtension.swift
+++ b/Modules/Services/Sources/Models/Extensions/DetailsLayoutExtension.swift
@@ -18,6 +18,7 @@ public extension DetailsLayout {
     fileprivate static let widgetTypeLayoutsBase = listLayouts + editorLayouts + [.bookmark] + fileAndMediaLayouts
 
     private static let supportedForOpening: [DetailsLayout] = visibleLayoutsWithFilesBase + [.objectType, .participant] + chatLayouts
+    // Kept separate from `editorLayouts` so the discussion whitelist can grow (e.g. files) without touching call sites.
     private static let supportedForDiscussion: [DetailsLayout] = editorLayouts
 
     private static let supportedForCreationInSetsBase: [DetailsLayout] = editorLayouts + [.bookmark] + listLayouts

--- a/Modules/Services/Sources/Models/Extensions/DetailsLayoutExtension.swift
+++ b/Modules/Services/Sources/Models/Extensions/DetailsLayoutExtension.swift
@@ -18,6 +18,7 @@ public extension DetailsLayout {
     fileprivate static let widgetTypeLayoutsBase = listLayouts + editorLayouts + [.bookmark] + fileAndMediaLayouts
 
     private static let supportedForOpening: [DetailsLayout] = visibleLayoutsWithFilesBase + [.objectType, .participant] + chatLayouts
+    private static let supportedForDiscussion: [DetailsLayout] = editorLayouts
 
     private static let supportedForCreationInSetsBase: [DetailsLayout] = editorLayouts + [.bookmark] + listLayouts
     private static let layoutsWithIcon: [DetailsLayout] = listLayouts + fileAndMediaLayouts + [.basic, .profile, .objectType]
@@ -106,6 +107,7 @@ public extension DetailsLayout {
     var isFile: Bool { Self.fileLayouts.contains(self) }
     var isFileOrMedia: Bool { Self.fileAndMediaLayouts.contains(self) }
     var isSupportedForOpening: Bool { Self.supportedForOpening.contains(self) }
+    var isSupportedForDiscussion: Bool { Self.supportedForDiscussion.contains(self) }
     var haveIcon: Bool { Self.layoutsWithIcon.contains(self) }
     var haveCover: Bool { Self.layoutsWithCover.contains(self) }
 


### PR DESCRIPTION
## Summary
- Hide the bottom-panel discussion button on Sets, Collections, Object Types, and other non-editor layouts; the search button takes its place via the existing fallback in `HomeBottomNavigationPanelView`.
- Add `DetailsLayout.supportedForDiscussion` + `isSupportedForDiscussion` (and an `ObjectDetails` proxy), mirroring the `supportedForOpening` / `isSupportedForOpening` pair, so the whitelist has a single source of truth and can grow (e.g. files) without touching call sites.
- `HomeBottomNavigationPanelViewModel.updateState()` now gates `showDiscussButton` on the new predicate; unread/count cascading is unchanged.