### PR TITLE
IOS-6028 Fold object-discussion unread into app-icon badge

### DIFF
--- a/AnyTypeTests/ServiceLayer/Badge/BadgeTotalCalculatorTests.swift
+++ b/AnyTypeTests/ServiceLayer/Badge/BadgeTotalCalculatorTests.swift
@@ -1,0 +1,331 @@
+import Testing
+import Foundation
+@testable import Anytype
+import Services
+import SwiftProtobuf
+
+struct BadgeTotalCalculatorTests {
+
+    private let spaceA = "space-a"
+    private let spaceB = "space-b"
+    private let chat1 = "chat-1"
+    private let chat2 = "chat-2"
+
+    // MARK: - Sanity
+
+    @Test func emptyInputs_totalIsZero() {
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [],
+            chatDetails: [],
+            discussionsBySpace: [:]
+        )
+        #expect(total == 0)
+    }
+
+    // MARK: - Discussion contribution by mode
+
+    @Test func discussion_allMode_addsUnreadMessageCount() {
+        let info = makeDiscussionInfo(messages: 4, subscribedMentions: 1, unsubscribedMentions: 0)
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .all)],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        // unreadMessageCount already includes subscribed mentions; do not double-count.
+        #expect(total == 4)
+    }
+
+    @Test func discussion_allMode_addsUnsubscribedMentionsOnTop() {
+        let info = makeDiscussionInfo(messages: 4, subscribedMentions: 1, unsubscribedMentions: 2)
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .all)],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        #expect(total == 6) // 4 subscribed + 2 unsubscribed mentions
+    }
+
+    @Test func discussion_allMode_unsubscribedMentionOnly() {
+        let info = makeDiscussionInfo(messages: 0, subscribedMentions: 0, unsubscribedMentions: 3)
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .all)],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        #expect(total == 3)
+    }
+
+    @Test func discussion_mentionsMode_addsTotalMentions() {
+        let info = makeDiscussionInfo(messages: 8, subscribedMentions: 2, unsubscribedMentions: 1)
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .mentions)],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        #expect(total == 3) // subscribed mentions (2) + unsubscribed mentions (1)
+    }
+
+    @Test func discussion_nothingMode_skipped() {
+        let info = makeDiscussionInfo(messages: 9, subscribedMentions: 4, unsubscribedMentions: 5)
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .nothing)],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        #expect(total == 0)
+    }
+
+    @Test func discussion_oneToOneSpace_mentionsModeNotApplied() {
+        // 1:1 spaces don't support mentions; .mentions mode contributes 0.
+        let info = makeDiscussionInfo(messages: 5, subscribedMentions: 1, unsubscribedMentions: 1)
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [makeSpaceView(spaceId: spaceA, uxType: .oneToOne, spaceType: .oneToOne, pushMode: .mentions)],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        #expect(total == 0)
+    }
+
+    // MARK: - Chat contribution preserved
+
+    @Test func chat_allMode_addsUnreadCounter() {
+        let preview = makeChatPreview(spaceId: spaceA, chatId: chat1, unread: 3, mentions: 1)
+        let total = BadgeTotalCalculator.compute(
+            previews: [preview],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .all)],
+            chatDetails: [makeChatDetail(id: chat1)],
+            discussionsBySpace: [:]
+        )
+        #expect(total == 3)
+    }
+
+    @Test func chat_mentionsMode_addsMentionCounterOnly() {
+        let preview = makeChatPreview(spaceId: spaceA, chatId: chat1, unread: 5, mentions: 2)
+        let total = BadgeTotalCalculator.compute(
+            previews: [preview],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .mentions)],
+            chatDetails: [makeChatDetail(id: chat1)],
+            discussionsBySpace: [:]
+        )
+        #expect(total == 2)
+    }
+
+    @Test func chat_archivedDetail_skipped() {
+        let preview = makeChatPreview(spaceId: spaceA, chatId: chat1, unread: 7, mentions: 0)
+        let total = BadgeTotalCalculator.compute(
+            previews: [preview],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .all)],
+            chatDetails: [makeChatDetail(id: chat1, isArchived: true)],
+            discussionsBySpace: [:]
+        )
+        #expect(total == 0)
+    }
+
+    @Test func chat_forceMutedChannel_skipped() {
+        // Per-channel override sets one chat to .nothing inside an .all space.
+        let muted = makeChatPreview(spaceId: spaceA, chatId: chat1, unread: 4, mentions: 0)
+        let normal = makeChatPreview(spaceId: spaceA, chatId: chat2, unread: 2, mentions: 0)
+        let space = makeSpaceView(spaceId: spaceA, pushMode: .all, forceMuteIds: [chat1])
+        let total = BadgeTotalCalculator.compute(
+            previews: [muted, normal],
+            spaceViews: [space],
+            chatDetails: [makeChatDetail(id: chat1), makeChatDetail(id: chat2)],
+            discussionsBySpace: [:]
+        )
+        #expect(total == 2)
+    }
+
+    // MARK: - Discussion bypasses chat-level overrides
+
+    @Test func discussion_ignoresForceMuteIds() {
+        // forceMuteIds is keyed by chatId — discussions live on parent objectIds, so the override
+        // does not apply to them. Discussion still contributes to an .all space.
+        let info = makeDiscussionInfo(messages: 5, subscribedMentions: 0, unsubscribedMentions: 0)
+        let space = makeSpaceView(spaceId: spaceA, pushMode: .all, forceMuteIds: [chat1, "any-parent-id"])
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [space],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        #expect(total == 5)
+    }
+
+    // MARK: - Active-space filter
+
+    @Test func discussion_inactiveSpace_skipped() {
+        let info = makeDiscussionInfo(messages: 7, subscribedMentions: 0, unsubscribedMentions: 0)
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [makeSpaceView(spaceId: spaceA, isActive: false, pushMode: .all)],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        #expect(total == 0)
+    }
+
+    @Test func discussion_missingSpaceView_skipped() {
+        let info = makeDiscussionInfo(messages: 7, subscribedMentions: 0, unsubscribedMentions: 0)
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [], // no space view for spaceA
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        #expect(total == 0)
+    }
+
+    // MARK: - Mixed sources
+
+    @Test func mixed_chatPlusDiscussion_inSameSpace_sums() {
+        let preview = makeChatPreview(spaceId: spaceA, chatId: chat1, unread: 4, mentions: 0)
+        let info = makeDiscussionInfo(messages: 3, subscribedMentions: 0, unsubscribedMentions: 1)
+        let total = BadgeTotalCalculator.compute(
+            previews: [preview],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .all)],
+            chatDetails: [makeChatDetail(id: chat1)],
+            discussionsBySpace: [spaceA: info]
+        )
+        #expect(total == 8) // chat 4 + discussion 3 + unsub mention 1
+    }
+
+    @Test func multiSpace_differentModes_sumIndependently() {
+        // spaceA: .all  → discussion msg 5 + unsub mention 1 = 6
+        // spaceB: .mentions → discussion total mentions 2
+        let infoA = makeDiscussionInfo(messages: 5, subscribedMentions: 0, unsubscribedMentions: 1)
+        let infoB = makeDiscussionInfo(messages: 9, subscribedMentions: 1, unsubscribedMentions: 1)
+
+        let total = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [
+                makeSpaceView(spaceId: spaceA, pushMode: .all),
+                makeSpaceView(spaceId: spaceB, pushMode: .mentions)
+            ],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: infoA, spaceB: infoB]
+        )
+        #expect(total == 8) // 6 + 2
+    }
+
+    // MARK: - Mode change
+
+    @Test func modeChange_sameInputs_differentTotals() {
+        let info = makeDiscussionInfo(messages: 5, subscribedMentions: 1, unsubscribedMentions: 2)
+
+        let totalAll = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .all)],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        let totalMentions = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .mentions)],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+        let totalNothing = BadgeTotalCalculator.compute(
+            previews: [],
+            spaceViews: [makeSpaceView(spaceId: spaceA, pushMode: .nothing)],
+            chatDetails: [],
+            discussionsBySpace: [spaceA: info]
+        )
+
+        #expect(totalAll == 7) // 5 + 2
+        #expect(totalMentions == 3) // 1 + 2
+        #expect(totalNothing == 0)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeSpaceView(
+        spaceId: String,
+        isActive: Bool = true,
+        uxType: SpaceUxType = .data,
+        spaceType: SpaceType = .regular,
+        pushMode: SpacePushNotificationsMode = .all,
+        forceAllIds: [String] = [],
+        forceMuteIds: [String] = [],
+        forceMentionIds: [String] = []
+    ) -> SpaceView {
+        SpaceView(
+            id: "view-\(spaceId)",
+            name: "",
+            description: "",
+            objectIconImage: .object(.space(.name(name: "", iconOption: 0, circular: false))),
+            targetSpaceId: spaceId,
+            createdDate: nil,
+            joinDate: nil,
+            accountStatus: .spaceActive,
+            localStatus: isActive ? .ok : .loading,
+            spaceAccessType: nil,
+            readersLimit: nil,
+            writersLimit: nil,
+            chatId: "",
+            spaceOrder: "",
+            uxType: uxType,
+            spaceType: spaceType,
+            pushNotificationEncryptionKey: "",
+            pushNotificationMode: pushMode,
+            forceAllIds: forceAllIds,
+            forceMuteIds: forceMuteIds,
+            forceMentionIds: forceMentionIds,
+            oneToOneIdentity: "",
+            homepage: .empty
+        )
+    }
+
+    private func makeChatPreview(
+        spaceId: String,
+        chatId: String,
+        unread: Int,
+        mentions: Int
+    ) -> ChatMessagePreview {
+        var preview = ChatMessagePreview(spaceId: spaceId, chatId: chatId)
+        var state = ChatState()
+
+        var messagesState = ChatState.UnreadState()
+        messagesState.counter = Int32(unread)
+        state.messages = messagesState
+
+        var mentionsState = ChatState.UnreadState()
+        mentionsState.counter = Int32(mentions)
+        state.mentions = mentionsState
+
+        preview.state = state
+        return preview
+    }
+
+    private func makeChatDetail(id: String, isArchived: Bool = false, isDeleted: Bool = false) -> ObjectDetails {
+        var values: [String: Google_Protobuf_Value] = [:]
+        if isArchived {
+            values[BundledPropertyKey.isArchived.rawValue] = true.protobufValue
+        }
+        if isDeleted {
+            values[BundledPropertyKey.isDeleted.rawValue] = true.protobufValue
+        }
+        return ObjectDetails(id: id, values: values)
+    }
+
+    private func makeDiscussionInfo(
+        messages: Int,
+        subscribedMentions: Int,
+        unsubscribedMentions: Int
+    ) -> SpaceDiscussionsUnreadInfo {
+        SpaceDiscussionsUnreadInfo(
+            unreadMessageCount: messages,
+            mentions: SpaceDiscussionsMentions(
+                subscribedCount: subscribedMentions,
+                unsubscribedCount: unsubscribedMentions
+            ),
+            parents: []
+        )
+    }
+}

--- a/AnyTypeTests/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsAggregatorTests.swift
+++ b/AnyTypeTests/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsAggregatorTests.swift
@@ -29,7 +29,7 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
         let result = ObjectsWithUnreadDiscussionsAggregator.aggregate(items: [parent], myParticipantIds: [me])
 
         #expect(result[spaceA]?.unreadMessageCount == 0)
-        #expect(result[spaceA]?.unreadMentionCount == 2)
+        #expect(result[spaceA]?.mentions.totalCount == 2)
     }
 
     @Test func subscribedParent_contributesMessagesAndMentions() {
@@ -45,7 +45,7 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
         let result = ObjectsWithUnreadDiscussionsAggregator.aggregate(items: [parent, discussion], myParticipantIds: [me])
 
         #expect(result[spaceA]?.unreadMessageCount == 5)
-        #expect(result[spaceA]?.unreadMentionCount == 1)
+        #expect(result[spaceA]?.mentions.totalCount == 1)
     }
 
     @Test func parentWithNoMentionAndNoSubscription_dropped() {
@@ -76,7 +76,7 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
 
         // Mention contributes; message count is dropped because I am not subscribed.
         #expect(result[spaceA]?.unreadMessageCount == 0)
-        #expect(result[spaceA]?.unreadMentionCount == 2)
+        #expect(result[spaceA]?.mentions.totalCount == 2)
     }
 
     @Test func subscribedParentWithZeroCounters_keepsZeroContribution() {
@@ -92,7 +92,7 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
         let result = ObjectsWithUnreadDiscussionsAggregator.aggregate(items: [parent, discussion], myParticipantIds: [me])
 
         #expect(result[spaceA]?.unreadMessageCount == 0)
-        #expect(result[spaceA]?.unreadMentionCount == 0)
+        #expect(result[spaceA]?.mentions.totalCount == 0)
     }
 
     @Test func sumsAcrossParentsInSameSpace() {
@@ -116,7 +116,7 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
         let result = ObjectsWithUnreadDiscussionsAggregator.aggregate(items: [parent1, parent2, d1, d2], myParticipantIds: [me])
 
         #expect(result[spaceA]?.unreadMessageCount == 7)
-        #expect(result[spaceA]?.unreadMentionCount == 3)
+        #expect(result[spaceA]?.mentions.totalCount == 3)
     }
 
     @Test func groupsByDistinctSpaces() {
@@ -141,9 +141,9 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
 
         #expect(result.count == 2)
         #expect(result[spaceA]?.unreadMessageCount == 3)
-        #expect(result[spaceA]?.unreadMentionCount == 0)
+        #expect(result[spaceA]?.mentions.totalCount == 0)
         #expect(result[spaceB]?.unreadMessageCount == 5)
-        #expect(result[spaceB]?.unreadMentionCount == 1)
+        #expect(result[spaceB]?.mentions.totalCount == 1)
     }
 
     @Test func mentionOnlyParent_excludesMessageCountFromUnsubscribed() {
@@ -158,7 +158,7 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
         let result = ObjectsWithUnreadDiscussionsAggregator.aggregate(items: [parent], myParticipantIds: [me])
 
         #expect(result[spaceA]?.unreadMessageCount == 0)
-        #expect(result[spaceA]?.unreadMentionCount == 3)
+        #expect(result[spaceA]?.mentions.totalCount == 3)
     }
 
     @Test func nonParentLayoutsIgnored() {
@@ -261,6 +261,55 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
 
         let ids = Set((result[spaceA]?.parents ?? []).map(\.id))
         #expect(ids == ["p-mention", "p-subscribed"])
+    }
+
+    // MARK: - Mentions split (subscribed vs unsubscribed)
+
+    @Test func mentions_subscribedParent_unsubscribedCountIsZero() {
+        let parent = makeParent(
+            id: "parent-1", spaceId: spaceA, discussionId: discussion1,
+            unreadMessageCount: 5, unreadMentionCount: 1
+        )
+        let discussion = makeDiscussion(id: discussion1, subscribers: [me])
+
+        let result = ObjectsWithUnreadDiscussionsAggregator.aggregate(items: [parent, discussion], myParticipantIds: [me])
+
+        // Subscribed mentions are already inside unreadMessageCount; nothing leaks into the unsubscribed split.
+        #expect(result[spaceA]?.unreadMessageCount == 5)
+        #expect(result[spaceA]?.mentions.totalCount == 1)
+        #expect(result[spaceA]?.mentions.unsubscribedCount == 0)
+    }
+
+    @Test func mentions_unsubscribedParent_totalEqualsUnsubscribed() {
+        let parent = makeParent(
+            id: "parent-1", spaceId: spaceA, discussionId: discussion1,
+            unreadMessageCount: 8, unreadMentionCount: 3
+        )
+
+        let result = ObjectsWithUnreadDiscussionsAggregator.aggregate(items: [parent], myParticipantIds: [me])
+
+        // Unsubscribed parent: messages dropped to 0; mentions land entirely in the unsubscribed bucket.
+        #expect(result[spaceA]?.unreadMessageCount == 0)
+        #expect(result[spaceA]?.mentions.unsubscribedCount == 3)
+        #expect(result[spaceA]?.mentions.totalCount == 3)
+    }
+
+    @Test func mentions_mixedParents_combineSubscribedAndUnsubscribed() {
+        let subscribed = makeParent(
+            id: "p-sub", spaceId: spaceA, discussionId: discussion1,
+            unreadMessageCount: 4, unreadMentionCount: 1
+        )
+        let unsubscribed = makeParent(
+            id: "p-unsub", spaceId: spaceA, discussionId: discussion2,
+            unreadMessageCount: 9, unreadMentionCount: 2
+        )
+        let d1 = makeDiscussion(id: discussion1, subscribers: [me])
+
+        let result = ObjectsWithUnreadDiscussionsAggregator.aggregate(items: [subscribed, unsubscribed, d1], myParticipantIds: [me])
+
+        #expect(result[spaceA]?.unreadMessageCount == 4)
+        #expect(result[spaceA]?.mentions.unsubscribedCount == 2)
+        #expect(result[spaceA]?.mentions.totalCount == 3) // 1 subscribed + 2 unsubscribed
     }
 
     // MARK: - Fixtures

--- a/AnyTypeTests/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsAggregatorTests.swift
+++ b/AnyTypeTests/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsAggregatorTests.swift
@@ -179,11 +179,12 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
     // MARK: - Parents list
 
     @Test func parents_populatedWithIdAndName() {
+        // Mentions are also messages on the middleware side, so any mention-bearing parent has unreadMessageCount > 0.
         let parent = makeParent(
             id: "parent-1",
             spaceId: spaceA,
             discussionId: discussion1,
-            unreadMessageCount: 0,
+            unreadMessageCount: 1,
             unreadMentionCount: 1,
             name: "Doc One"
         )
@@ -224,12 +225,12 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
         )
         let parentNewer = makeParent(
             id: "parent-newer", spaceId: spaceA, discussionId: discussion2,
-            unreadMessageCount: 0, unreadMentionCount: 1,
+            unreadMessageCount: 1, unreadMentionCount: 1,
             name: "Newer"
         )
         let parentNoDate = makeParent(
             id: "parent-no-date", spaceId: spaceA, discussionId: "discussion-3",
-            unreadMessageCount: 0, unreadMentionCount: 1,
+            unreadMessageCount: 1, unreadMentionCount: 1,
             name: "NoDate"
         )
         let d1 = makeDiscussion(id: discussion1, subscribers: [me], lastMessageDate: older)
@@ -247,7 +248,7 @@ struct ObjectsWithUnreadDiscussionsAggregatorTests {
     @Test func parents_includesBothMentionOnlyAndSubscribed() {
         let mentionOnly = makeParent(
             id: "p-mention", spaceId: spaceA, discussionId: discussion1,
-            unreadMessageCount: 0, unreadMentionCount: 2,
+            unreadMessageCount: 2, unreadMentionCount: 2,
             name: "Mention"
         )
         let subscribed = makeParent(

--- a/AnyTypeTests/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsSubscriptionBuilderTests.swift
+++ b/AnyTypeTests/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsSubscriptionBuilderTests.swift
@@ -54,13 +54,10 @@ struct ObjectsWithUnreadDiscussionsSubscriptionBuilderTests {
         #expect(isHiddenFilter?.relationKey == BundledPropertyKey.isHidden.rawValue)
         #expect(isHiddenFilter?.condition == .notEqual)
 
-        let countersFilter = parentBranch?.nestedFilters[4]
-        #expect(countersFilter?.operator == .or)
-        #expect(countersFilter?.nestedFilters.count == 2)
-        #expect(countersFilter?.nestedFilters[0].relationKey == BundledPropertyKey.unreadMessageCount.rawValue)
-        #expect(countersFilter?.nestedFilters[0].condition == .greater)
-        #expect(countersFilter?.nestedFilters[1].relationKey == BundledPropertyKey.unreadMentionCount.rawValue)
-        #expect(countersFilter?.nestedFilters[1].condition == .greater)
+        // Mentions are always also messages, so a single message-count > 0 filter covers both.
+        let messageCountFilter = parentBranch?.nestedFilters[4]
+        #expect(messageCountFilter?.relationKey == BundledPropertyKey.unreadMessageCount.rawValue)
+        #expect(messageCountFilter?.condition == .greater)
     }
 
     @Test func build_discussionBranch_isPlainLayoutFilter() {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpacePreviewCountersBuilder.swift
@@ -74,7 +74,7 @@ enum SpacePreviewCountersBuilder {
         if let discussionUnread {
             counters = contribute(
                 unreadCount: discussionUnread.unreadMessageCount,
-                mentionCount: discussionUnread.unreadMentionCount,
+                mentionCount: discussionUnread.mentions.totalCount,
                 mode: spaceView.pushNotificationMode,
                 spaceView: spaceView,
                 supportsMentions: supportsMentions,

--- a/Anytype/Sources/ServiceLayer/Badge/AppIconBadgeService.swift
+++ b/Anytype/Sources/ServiceLayer/Badge/AppIconBadgeService.swift
@@ -24,29 +24,36 @@ actor AppIconBadgeService: AppIconBadgeServiceProtocol {
     private var chatDetailsStorage: any ChatDetailsStorageProtocol
     @Injected(\.badgeCountStorage)
     private var badgeCountStorage: any BadgeCountStorageProtocol
+    @Injected(\.objectsWithUnreadDiscussionsSubscription)
+    private var objectsWithUnreadDiscussionsSubscription: any ObjectsWithUnreadDiscussionsSubscriptionProtocol
 
     private var updateTask: Task<Void, Never>?
 
     func startUpdating() async {
         updateTask?.cancel()
 
-        // Compute badge immediately from current values
-        let currentPreviews = await chatMessagesPreviewsStorage.previews()
-        let currentSpaceViews = spaceViewsStorage.allSpaceViews
-        let currentChatDetails = await chatDetailsStorage.allChats()
-        await updateBadge(previews: currentPreviews, spaceViews: currentSpaceViews, chatDetails: currentChatDetails)
-
-        // Subscribe to ongoing updates
-        let stream = combineLatest(
+        // The discussion subscription primes its sequence with `[:]` and the chat / space-view streams
+        // also prime, so the first combineLatest tick fires immediately with current values.
+        let baseTriple = combineLatest(
             await chatMessagesPreviewsStorage.previewsSequenceWithEmpty,
             spaceViewsStorage.allSpaceViewsPublisher.values,
             await chatDetailsStorage.allChatsSequence
+        )
+        let stream = combineLatest(
+            baseTriple,
+            await objectsWithUnreadDiscussionsSubscription.unreadBySpaceSequence
         ).throttle(milliseconds: 300)
 
         updateTask = Task {
-            for await (previews, spaceViews, chatDetails) in stream {
+            for await (triple, discussionsBySpace) in stream {
                 guard !Task.isCancelled else { return }
-                await self.updateBadge(previews: previews, spaceViews: spaceViews, chatDetails: chatDetails)
+                let (previews, spaceViews, chatDetails) = triple
+                await self.updateBadge(
+                    previews: previews,
+                    spaceViews: spaceViews,
+                    chatDetails: chatDetails,
+                    discussionsBySpace: discussionsBySpace
+                )
             }
         }
     }
@@ -63,8 +70,10 @@ actor AppIconBadgeService: AppIconBadgeServiceProtocol {
     private func updateBadge(
         previews: [ChatMessagePreview],
         spaceViews: [SpaceView],
-        chatDetails: [ObjectDetails]
+        chatDetails: [ObjectDetails],
+        discussionsBySpace: [String: SpaceDiscussionsUnreadInfo]
     ) async {
+        let spaceViewById = Dictionary(spaceViews.map { ($0.targetSpaceId, $0) }, uniquingKeysWith: { _, last in last })
         var total = 0
 
         for preview in previews {
@@ -73,7 +82,7 @@ actor AppIconBadgeService: AppIconBadgeServiceProtocol {
                 continue
             }
 
-            guard let spaceView = spaceViews.first(where: { $0.targetSpaceId == preview.spaceId }),
+            guard let spaceView = spaceViewById[preview.spaceId],
                   spaceView.isActive else {
                 continue
             }
@@ -92,6 +101,24 @@ actor AppIconBadgeService: AppIconBadgeServiceProtocol {
             }
         }
 
+        for (spaceId, info) in discussionsBySpace {
+            guard let spaceView = spaceViewById[spaceId], spaceView.isActive else { continue }
+
+            switch spaceView.pushNotificationMode {
+            case .all:
+                // Subscribed-parent messages already include their mentions; add unsubscribed-parent
+                // mentions on top so a mention in an object I don't watch still bumps the badge.
+                total += info.unreadMessageCount + info.mentions.unsubscribedCount
+            case .mentions:
+                if spaceView.uxType.supportsMentions {
+                    total += info.mentions.totalCount
+                }
+            case .nothing, .UNRECOGNIZED:
+                break
+            }
+        }
+
+        guard total != badgeCountStorage.badgeCount else { return }
         badgeCountStorage.badgeCount = total
         try? await UNUserNotificationCenter.current().setBadgeCount(total)
     }

--- a/Anytype/Sources/ServiceLayer/Badge/AppIconBadgeService.swift
+++ b/Anytype/Sources/ServiceLayer/Badge/AppIconBadgeService.swift
@@ -73,51 +73,12 @@ actor AppIconBadgeService: AppIconBadgeServiceProtocol {
         chatDetails: [ObjectDetails],
         discussionsBySpace: [String: SpaceDiscussionsUnreadInfo]
     ) async {
-        let spaceViewById = Dictionary(spaceViews.map { ($0.targetSpaceId, $0) }, uniquingKeysWith: { _, last in last })
-        var total = 0
-
-        for preview in previews {
-            guard let chatDetail = chatDetails.first(where: { $0.id == preview.chatId }),
-                  !chatDetail.isArchivedOrDeleted else {
-                continue
-            }
-
-            guard let spaceView = spaceViewById[preview.spaceId],
-                  spaceView.isActive else {
-                continue
-            }
-
-            let mode = spaceView.effectiveNotificationMode(for: preview.chatId)
-
-            switch mode {
-            case .all:
-                total += preview.unreadCounter
-            case .mentions:
-                if spaceView.uxType.supportsMentions {
-                    total += preview.mentionCounter
-                }
-            case .nothing, .UNRECOGNIZED:
-                break
-            }
-        }
-
-        for (spaceId, info) in discussionsBySpace {
-            guard let spaceView = spaceViewById[spaceId], spaceView.isActive else { continue }
-
-            switch spaceView.pushNotificationMode {
-            case .all:
-                // Subscribed-parent messages already include their mentions; add unsubscribed-parent
-                // mentions on top so a mention in an object I don't watch still bumps the badge.
-                total += info.unreadMessageCount + info.mentions.unsubscribedCount
-            case .mentions:
-                if spaceView.uxType.supportsMentions {
-                    total += info.mentions.totalCount
-                }
-            case .nothing, .UNRECOGNIZED:
-                break
-            }
-        }
-
+        let total = BadgeTotalCalculator.compute(
+            previews: previews,
+            spaceViews: spaceViews,
+            chatDetails: chatDetails,
+            discussionsBySpace: discussionsBySpace
+        )
         guard total != badgeCountStorage.badgeCount else { return }
         badgeCountStorage.badgeCount = total
         try? await UNUserNotificationCenter.current().setBadgeCount(total)

--- a/Anytype/Sources/ServiceLayer/Badge/BadgeTotalCalculator.swift
+++ b/Anytype/Sources/ServiceLayer/Badge/BadgeTotalCalculator.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Services
+
+enum BadgeTotalCalculator {
+
+    static func compute(
+        previews: [ChatMessagePreview],
+        spaceViews: [SpaceView],
+        chatDetails: [ObjectDetails],
+        discussionsBySpace: [String: SpaceDiscussionsUnreadInfo]
+    ) -> Int {
+        let spaceViewById = Dictionary(spaceViews.map { ($0.targetSpaceId, $0) }, uniquingKeysWith: { _, last in last })
+        var total = 0
+
+        for preview in previews {
+            guard let chatDetail = chatDetails.first(where: { $0.id == preview.chatId }),
+                  !chatDetail.isArchivedOrDeleted else {
+                continue
+            }
+            guard let spaceView = spaceViewById[preview.spaceId], spaceView.isActive else { continue }
+
+            switch spaceView.effectiveNotificationMode(for: preview.chatId) {
+            case .all:
+                total += preview.unreadCounter
+            case .mentions:
+                if spaceView.uxType.supportsMentions {
+                    total += preview.mentionCounter
+                }
+            case .nothing, .UNRECOGNIZED:
+                break
+            }
+        }
+
+        for (spaceId, info) in discussionsBySpace {
+            guard let spaceView = spaceViewById[spaceId], spaceView.isActive else { continue }
+
+            switch spaceView.pushNotificationMode {
+            case .all:
+                // Subscribed-parent messages already include their mentions; add unsubscribed-parent
+                // mentions on top so a mention in an object I don't watch still bumps the badge.
+                total += info.unreadMessageCount + info.mentions.unsubscribedCount
+            case .mentions:
+                if spaceView.uxType.supportsMentions {
+                    total += info.mentions.totalCount
+                }
+            case .nothing, .UNRECOGNIZED:
+                break
+            }
+        }
+
+        return total
+    }
+}

--- a/Anytype/Sources/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsAggregator.swift
+++ b/Anytype/Sources/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsAggregator.swift
@@ -3,13 +3,19 @@ import Services
 
 enum ObjectsWithUnreadDiscussionsAggregator {
 
+    private struct SpaceCounters {
+        var messages: Int = 0
+        var subscribedMentions: Int = 0
+        var unsubscribedMentions: Int = 0
+    }
+
     static func aggregate(items: [ObjectDetails], myParticipantIds: Set<String>) -> [String: SpaceDiscussionsUnreadInfo] {
         var discussionsById = [String: ObjectDetails]()
         for item in items where item.resolvedLayoutValue == .discussion {
             discussionsById[item.id] = item
         }
 
-        var countsBySpace = [String: (messages: Int, mentions: Int)]()
+        var countsBySpace = [String: SpaceCounters]()
         var parentsBySpace = [String: [DiscussionUnreadParent]]()
 
         for parent in items where parent.isSupportedForDiscussion {
@@ -18,12 +24,15 @@ enum ObjectsWithUnreadDiscussionsAggregator {
             let isSubscribed = discussion?.notificationSubscribers.contains(where: myParticipantIds.contains) ?? false
             guard mentionCount > 0 || isSubscribed else { continue }
 
-            let messageCount = isSubscribed ? (parent.unreadMessageCount ?? 0) : 0
-            let existing = countsBySpace[parent.spaceId] ?? (0, 0)
-            countsBySpace[parent.spaceId] = (
-                existing.messages + messageCount,
-                existing.mentions + mentionCount
-            )
+            var counters = countsBySpace[parent.spaceId] ?? SpaceCounters()
+            if isSubscribed {
+                counters.messages += parent.unreadMessageCount ?? 0
+                counters.subscribedMentions += mentionCount
+            } else {
+                counters.unsubscribedMentions += mentionCount
+            }
+            countsBySpace[parent.spaceId] = counters
+
             parentsBySpace[parent.spaceId, default: []].append(
                 DiscussionUnreadParent(
                     id: parent.id,
@@ -35,13 +44,16 @@ enum ObjectsWithUnreadDiscussionsAggregator {
         }
 
         var result = [String: SpaceDiscussionsUnreadInfo]()
-        for (spaceId, counts) in countsBySpace {
+        for (spaceId, counters) in countsBySpace {
             let parents = (parentsBySpace[spaceId] ?? []).sorted { (lhs: DiscussionUnreadParent, rhs: DiscussionUnreadParent) -> Bool in
                 (lhs.lastMessageDate ?? .distantPast) > (rhs.lastMessageDate ?? .distantPast)
             }
             result[spaceId] = SpaceDiscussionsUnreadInfo(
-                unreadMessageCount: counts.messages,
-                unreadMentionCount: counts.mentions,
+                unreadMessageCount: counters.messages,
+                mentions: SpaceDiscussionsMentions(
+                    subscribedCount: counters.subscribedMentions,
+                    unsubscribedCount: counters.unsubscribedMentions
+                ),
                 parents: parents
             )
         }

--- a/Anytype/Sources/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsSubscriptionBuilder.swift
+++ b/Anytype/Sources/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsSubscriptionBuilder.swift
@@ -15,15 +15,14 @@ final class ObjectsWithUnreadDiscussionsSubscriptionBuilder: ObjectsWithUnreadDi
     var subscriptionId: String { Constants.subId }
 
     func build() -> SubscriptionData {
+        // A mention message is also a regular message, so any parent with unread mentions
+        // also has `unreadMessageCount > 0`. Filtering on the message count alone is sufficient.
         let parentBranch = andFilter([
             SearchHelper.layoutFilter(DetailsLayout.supportedForDiscussion),
             SearchHelper.isArchivedFilter(isArchived: false),
             SearchHelper.isDeletedFilter(isDeleted: false),
             SearchHelper.isHidden(false),
-            orFilter([
-                countGreaterThanZero(relation: .unreadMessageCount),
-                countGreaterThanZero(relation: .unreadMentionCount)
-            ])
+            countGreaterThanZero(relation: .unreadMessageCount)
         ])
         let discussionBranch = SearchHelper.layoutFilter([.discussion])
         let filters: [DataviewFilter] = [

--- a/Anytype/Sources/ServiceLayer/ObjectsUnread/SpaceDiscussionsUnreadInfo.swift
+++ b/Anytype/Sources/ServiceLayer/ObjectsUnread/SpaceDiscussionsUnreadInfo.swift
@@ -1,9 +1,34 @@
 import Foundation
 
 struct SpaceDiscussionsUnreadInfo: Hashable, Sendable {
+    /// Unread messages in parents the user is subscribed to.
+    /// Includes subscribed-parent mentions (a mention is also a message).
     let unreadMessageCount: Int
-    let unreadMentionCount: Int
+
+    /// Mentions across this space's included parents, split by subscription status.
+    let mentions: SpaceDiscussionsMentions
+
+    /// All parents contributing to this space's unread bucket — subscribed OR mention-only-unsubscribed.
+    /// Sorted by lastMessageDate desc.
     let parents: [DiscussionUnreadParent]
+}
+
+struct SpaceDiscussionsMentions: Hashable, Sendable {
+    /// Mentions in subscribed parents (already inside `SpaceDiscussionsUnreadInfo.unreadMessageCount`).
+    /// Private — only used internally to derive `totalCount` and avoid double-counting in `.all` mode.
+    private let subscribedCount: Int
+
+    /// Mentions in parents the user is NOT subscribed to.
+    /// Bumps the badge in `.all` mode (not in `unreadMessageCount`).
+    let unsubscribedCount: Int
+
+    /// Total mentions across all included parents.
+    var totalCount: Int { subscribedCount + unsubscribedCount }
+
+    init(subscribedCount: Int, unsubscribedCount: Int) {
+        self.subscribedCount = subscribedCount
+        self.unsubscribedCount = unsubscribedCount
+    }
 }
 
 struct DiscussionUnreadParent: Hashable, Sendable {


### PR DESCRIPTION
## Summary
- Inject `objectsWithUnreadDiscussionsSubscription` into `AppIconBadgeService` and add a per-space contribution loop alongside the existing chat loop. `.all`-mode spaces add subscribed-parent unread plus mentions in unsubscribed parents (so a mention in an object you don't watch still bumps the badge); `.mentions`-mode spaces add total mentions; `.nothing` is skipped.
- Restructure `SpaceDiscussionsUnreadInfo` to expose `mentions: SpaceDiscussionsMentions` (private `subscribedCount`, public `unsubscribedCount`, computed `totalCount`) so badge math composes cleanly without double-counting subscribed-parent mentions.
- Simplify the cross-space subscription filter to `unreadMessageCount > 0` (mentions are always also messages, so the prior OR-clause was redundant). Pre-build a `[String: SpaceView]` lookup and add a no-op guard so unchanged totals don't trigger redundant `setBadgeCount` calls every 300ms.