### PR TITLE
IOS-6122 Refresh My Favorites context menu pin/unpin state

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowContextMenu.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowContextMenu.swift
@@ -15,7 +15,7 @@ struct MyFavoritesRowContextMenu: View {
         }
 
         if model.canManageChannelPins() {
-            let isPinnedToChannel = model.isPinnedToChannel()
+            let isPinnedToChannel = model.isPinnedToChannel
             Button {
                 DispatchQueue.main.asyncAfter(deadline: .now() + menuDismissAnimationDelay) {
                     model.onChannelPinTap()

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowContextMenuViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowContextMenuViewModel.swift
@@ -6,13 +6,9 @@ import AnytypeCore
 @Observable
 final class MyFavoritesRowContextMenuViewModel {
 
-    @ObservationIgnored
     let objectId: String
-    @ObservationIgnored
     let spaceId: String
-    @ObservationIgnored
     let channelWidgetsObject: any BaseDocumentProtocol
-    @ObservationIgnored
     let personalWidgetsObject: any BaseDocumentProtocol
 
     @ObservationIgnored
@@ -23,6 +19,9 @@ final class MyFavoritesRowContextMenuViewModel {
     private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
 
     private(set) var isPinnedToChannel: Bool
+
+    @ObservationIgnored
+    private var isSubscribing = false
 
     init(
         objectId: String,
@@ -58,6 +57,9 @@ final class MyFavoritesRowContextMenuViewModel {
     }
 
     func startChannelSubscription() async {
+        guard !isSubscribing else { return }
+        isSubscribing = true
+        defer { isSubscribing = false }
         for await _ in channelWidgetsObject.syncPublisher.values {
             let next = channelWidgetsObject.containsWidgetFor(objectId: objectId)
             guard isPinnedToChannel != next else { continue }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowContextMenuViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowContextMenuViewModel.swift
@@ -3,17 +3,26 @@ import Services
 import AnytypeCore
 
 @MainActor
+@Observable
 final class MyFavoritesRowContextMenuViewModel {
 
+    @ObservationIgnored
     let objectId: String
+    @ObservationIgnored
     let spaceId: String
+    @ObservationIgnored
     let channelWidgetsObject: any BaseDocumentProtocol
+    @ObservationIgnored
     let personalWidgetsObject: any BaseDocumentProtocol
 
+    @ObservationIgnored
     @Injected(\.widgetActionsViewCommonMenuProvider)
     private var provider: any WidgetActionsViewCommonMenuProviderProtocol
+    @ObservationIgnored
     @Injected(\.participantSpacesStorage)
     private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
+
+    private(set) var isPinnedToChannel: Bool
 
     init(
         objectId: String,
@@ -25,6 +34,7 @@ final class MyFavoritesRowContextMenuViewModel {
         self.spaceId = spaceId
         self.channelWidgetsObject = channelWidgetsObject
         self.personalWidgetsObject = personalWidgetsObject
+        self.isPinnedToChannel = channelWidgetsObject.containsWidgetFor(objectId: objectId)
     }
 
     func onFavoriteTap() {
@@ -47,12 +57,11 @@ final class MyFavoritesRowContextMenuViewModel {
             .canManageChannelPins ?? false
     }
 
-    func isPinnedToChannel() -> Bool {
-        for block in channelWidgetsObject.children where block.isWidget {
-            guard let info = channelWidgetsObject.widgetInfo(block: block),
-                  case let .object(details) = info.source else { continue }
-            if details.id == objectId { return true }
+    func startChannelSubscription() async {
+        for await _ in channelWidgetsObject.syncPublisher.values {
+            let next = channelWidgetsObject.containsWidgetFor(objectId: objectId)
+            guard isPinnedToChannel != next else { continue }
+            isPinnedToChannel = next
         }
-        return false
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesRowViewModel.swift
@@ -89,7 +89,8 @@ final class MyFavoritesRowViewModel {
         async let chatPreviewsSub: () = startChatPreviewsSubscription()
         async let spaceViewSub: () = startSpaceViewSubscription()
         async let unreadDiscussionsSub: () = startUnreadDiscussionsSubscription()
-        _ = await (detailsSub, chatPreviewsSub, spaceViewSub, unreadDiscussionsSub)
+        async let menuSub: () = menuViewModel.startChannelSubscription()
+        _ = await (detailsSub, chatPreviewsSub, spaceViewSub, unreadDiscussionsSub, menuSub)
     }
 
     // MARK: - Private


### PR DESCRIPTION
## Summary

- Made `MyFavoritesRowContextMenuViewModel` `@Observable` with a tracked `isPinnedToChannel`, updated from a `channelWidgetsObject.syncPublisher` loop. Mirrors the established `WidgetContainerViewModel` pattern so SwiftUI invalidates the context menu when the channel pin state flips.
- Started the new subscription from `MyFavoritesRowViewModel.startSubscriptions()` alongside the row's existing structured `async let` group.
- Added a duplicate-subscription guard so reorder-induced re-`.task` runs do not spawn parallel `for await` loops.