### PR TITLE
IOS-6002 Use 12px trailing padding when comment count is visible

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -114,7 +114,9 @@ private struct HomeBottomNavigationPanelViewInternal: View {
                         .transition(.opacity.combined(with: .scale(scale: 0.5, anchor: .leading)))
                 }
             }
-            .padding(8)
+            .padding(.leading, 8)
+            .padding(.vertical, 8)
+            .padding(.trailing, hasCount ? 12 : 8)
         }
         .glassEffectInteractiveIOS26(in: Capsule())
         .animation(.snappy(duration: 0.35), value: hasCount)


### PR DESCRIPTION
## Summary
- Asymmetric trailing padding on the Discuss capsule: 8px when only the icon is visible, 12px when the comment count is shown so the count text has more breathing room from the capsule edge.