### PR TITLE
IOS-6124 Fix My Favorites first-reorder row loss

### DIFF
--- a/Anytype/Sources/ServiceLayer/ChannelPins/ChannelPinsService.swift
+++ b/Anytype/Sources/ServiceLayer/ChannelPins/ChannelPinsService.swift
@@ -28,11 +28,12 @@ final class ChannelPinsService: ChannelPinsServiceProtocol {
         layout: BlockWidget.Layout,
         limit: Int
     ) async throws {
+        let position: WidgetPosition = channelWidgetsObject.children.first.map { .above(widgetId: $0.id) } ?? .end
         try await blockWidgetService.toggleWidgetBlock(
             contextId: channelWidgetsObject.objectId,
             targetObjectId: objectId,
             existingWidgetBlockId: channelWidgetsObject.widgetBlockIdFor(targetObjectId: objectId),
-            firstChildBlockId: channelWidgetsObject.children.first?.id,
+            position: position,
             layout: layout,
             limit: limit
         )

--- a/Anytype/Sources/ServiceLayer/PersonalFavorites/PersonalFavoritesService.swift
+++ b/Anytype/Sources/ServiceLayer/PersonalFavorites/PersonalFavoritesService.swift
@@ -4,7 +4,7 @@ import AnytypeCore
 
 protocol PersonalFavoritesServiceProtocol: AnyObject, Sendable {
     // Caller must pass an already-open `personalWidgetsObject`; synchronous reads
-    // of `children` / `widgetBlockIdFor(...)` would otherwise duplicate on toggle.
+    // of `widgetBlockIdFor(...)` would otherwise duplicate on toggle.
     func toggle(objectId: String, personalWidgetsObject: any BaseDocumentProtocol) async throws
 }
 
@@ -13,11 +13,16 @@ final class PersonalFavoritesService: PersonalFavoritesServiceProtocol {
     private let blockWidgetService: any BlockWidgetServiceProtocol = Container.shared.blockWidgetService()
 
     func toggle(objectId: String, personalWidgetsObject: any BaseDocumentProtocol) async throws {
+        // `.innerFirst` mirrors desktop (`anyproto/anytype-ts#2161`) — wrappers must land at
+        // the doc root, not nested inside `header`. With `.above(children.first?.id)` the
+        // wrapper ended up under `header` and a later `BlockListMoveToExistingObject` reorder
+        // misparented it back to root, triggering a consistency pass that deleted the other
+        // favorite (IOS-6124).
         try await blockWidgetService.toggleWidgetBlock(
             contextId: personalWidgetsObject.objectId,
             targetObjectId: objectId,
             existingWidgetBlockId: personalWidgetsObject.widgetBlockIdFor(targetObjectId: objectId),
-            firstChildBlockId: personalWidgetsObject.children.first?.id,
+            position: .innerFirst,
             layout: .link,
             limit: 0
         )

--- a/Modules/Services/Sources/Models/WidgetPosition.swift
+++ b/Modules/Services/Sources/Models/WidgetPosition.swift
@@ -5,19 +5,22 @@ public enum WidgetPosition:  Equatable, Hashable, Sendable {
     case end
     case above(widgetId: String)
     case below(widgetId: String)
+    // First child of the context (used for personal-favorites where wrappers must
+    // land at the doc root, not nested inside the `header` block).
+    case innerFirst
 }
 
 extension WidgetPosition {
-    
+
     var targetId: String {
         switch self {
-        case .end:
+        case .end, .innerFirst:
             return ""
         case .above(let widgetId), .below(let widgetId):
             return widgetId
         }
     }
-    
+
     var middlePosition: Anytype_Model_Block.Position {
         switch self {
         case .end:
@@ -26,6 +29,8 @@ extension WidgetPosition {
             return .top
         case .below:
             return .bottom
+        case .innerFirst:
+            return .innerFirst
         }
     }
 }

--- a/Modules/Services/Sources/Services/BlockWidget/BlockWidgetService.swift
+++ b/Modules/Services/Sources/Services/BlockWidget/BlockWidgetService.swift
@@ -9,15 +9,17 @@ public protocol BlockWidgetServiceProtocol: Sendable {
     func setViewId(contextId: String, widgetBlockId: String, viewId: String) async throws
     /// Toggle a widget-block entry inside `contextId` for the given `targetObjectId`.
     /// If an existing widget block references the target, it is removed; otherwise a
-    /// new widget block is inserted via `.above(firstChildId)` with `.end` fallback.
-    /// Shared between channel-pin (IOS-5864 `WidgetActionsViewCommonMenuProvider`) and
-    /// personal-favorite (`PersonalFavoritesService`) toggle flows — they differ only
-    /// in `contextId`, `layout`, and `limit`.
+    /// new widget block is inserted at `position`. Shared between channel-pin
+    /// (IOS-5864 `WidgetActionsViewCommonMenuProvider`) and personal-favorite
+    /// (`PersonalFavoritesService`) toggle flows — they differ in `contextId`, `layout`,
+    /// `limit`, and the create-time `position` (channel pins use `.above(firstChild) ?? .end`,
+    /// personal favorites use `.innerFirst` so wrappers land at the doc root and not nested
+    /// inside `header`, see IOS-6124).
     func toggleWidgetBlock(
         contextId: String,
         targetObjectId: String,
         existingWidgetBlockId: String?,
-        firstChildBlockId: String?,
+        position: WidgetPosition,
         layout: BlockWidget.Layout,
         limit: Int
     ) async throws
@@ -71,14 +73,13 @@ final class BlockWidgetService: BlockWidgetServiceProtocol {
         contextId: String,
         targetObjectId: String,
         existingWidgetBlockId: String?,
-        firstChildBlockId: String?,
+        position: WidgetPosition,
         layout: BlockWidget.Layout,
         limit: Int
     ) async throws {
         if let existingWidgetBlockId {
             try await removeWidgetBlock(contextId: contextId, widgetBlockId: existingWidgetBlockId)
         } else {
-            let position: WidgetPosition = firstChildBlockId.map { .above(widgetId: $0) } ?? .end
             try await createWidgetBlock(
                 contextId: contextId,
                 sourceId: targetObjectId,


### PR DESCRIPTION
## Summary

- Personal-favorite widget wrappers now land at the personal-widgets doc root via `WidgetPosition.innerFirst` (matching desktop `anyproto/anytype-ts#2161`). They were ending up nested inside `header` because `.above(children.first?.id)` resolved `children.first` to the `title` block; a subsequent `BlockListMoveToExistingObject` reorder then misparented the wrapper back to root and triggered a consistency pass that **deleted** the other favorite — the visible "second favorite disappears on first reorder" bug.
- `BlockWidgetService.toggleWidgetBlock` now takes an explicit `position: WidgetPosition` instead of deriving one from `firstChildBlockId`. `ChannelPinsService` computes its own `.above(firstChild) ?? .end` locally; `PersonalFavoritesService` passes `.innerFirst`.
- New `WidgetPosition.innerFirst` case (proto `Anytype_Model_Block.Position.innerFirst`, empty `targetId`).