### PR TITLE
IOS-6118 Always show page/task/collection types without objects

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -231,12 +231,13 @@ final class HomeWidgetsViewModel {
 
         let typesPublisher = objectTypeProvider.objectTypesPublisher(spaceId: spaceId)
         let objectsCreatedPublisher = objectTypesWithObjectsCreatedService.typeIdsWithObjectsCreatedPublisher
+        let alwaysVisibleKeys: Set<ObjectTypeUniqueKey> = [.page, .task, .collection]
 
         let stream = typesPublisher.combineLatest(objectsCreatedPublisher)
             .map { (types, typeIdsWithObjectsCreated) in
                 types
                     .filter { ($0.recommendedLayout.map { allowedLayouts.contains($0) } ?? false) && !$0.isTemplateType }
-                    .filter { typeIdsWithObjectsCreated.contains($0.id) }
+                    .filter { typeIdsWithObjectsCreated.contains($0.id) || alwaysVisibleKeys.contains($0.uniqueKey) }
                     .map { ObjectTypeWidgetInfo(objectTypeId: $0.id, spaceId: spaceId) }
             }
             .removeDuplicates()

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceCreate/SpaceCreateViewModel.swift
@@ -114,7 +114,7 @@ final class SpaceCreateViewModel: LocalObjectIconPickerOutput {
             name: spaceName,
             iconOption: spaceIconOption,
             accessType: accessType,
-            useCase: .none,
+            useCase: .dataSpaceMobile,
             withChat: false,
             uxType: .data
         )


### PR DESCRIPTION
## Summary
- Always show **page**, **task**, and **collection** types in the home types section, even when no objects of those types exist yet (`HomeWidgetsViewModel.startObjectTypesTask`).
- Fix `SpaceCreateViewModel.createChannel` to pass `useCase: .dataSpaceMobile` instead of `.none` for `.data` channels, matching the legacy path in `SpaceCreateData.swift:44`. Without this, the middleware did not seed `ot-task` (and others) into freshly created channels, so the always-show list had nothing to match against.