### PR TITLE
IOS-6083 Remove personalFavorites feature toggle

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetSubmoduleView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetSubmoduleView.swift
@@ -7,7 +7,7 @@ struct HomeWidgetSubmoduleView: View {
 
     let widgetInfo: BlockWidgetInfo
     let channelWidgetsObject: any BaseDocumentProtocol
-    let personalWidgetsObject: (any BaseDocumentProtocol)?
+    let personalWidgetsObject: any BaseDocumentProtocol
     let workspaceInfo: AccountInfo
     @Binding var homeState: HomeWidgetsState
     let output: (any CommonWidgetModuleOutput)?

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -33,7 +33,7 @@ private struct HomeWidgetsInternalView: View {
 
             content
                 .animation(.default, value: model.widgetBlocks.count)
-                .animation(.default, value: model.myFavoritesListViewModel?.rows.count)
+                .animation(.default, value: model.myFavoritesListViewModel.rows.count)
 
             if context.showEmbeddedBottomPanel {
                 HomeBottomNavigationPanelView(
@@ -82,36 +82,16 @@ private struct HomeWidgetsInternalView: View {
             VStack(spacing: 0) {
                 SpaceInfoView(spaceId: model.spaceId)
                 InviteMembersStubWidgetView(spaceId: model.spaceId, output: model.output)
-                if FeatureFlags.personalFavorites {
-                    homeWidget
-                    blockWidgets
-                    unreadWidget
-                    myFavoritesWidget
-                } else {
-                    topWidgets
-                    blockWidgets
-                }
+                homeWidget
+                blockWidgets
+                unreadWidget
+                myFavoritesWidget
                 objectTypeWidgets
                 AnytypeNavigationSpacer(minHeight: context.showEmbeddedBottomPanel ? 72 : 0)
             }
             .padding(.horizontal, 20)
             .fitIPadToReadableContentGuide()
             .shouldHideChatBadges(model.shouldHideChatBadges)
-        }
-    }
-
-    @ViewBuilder
-    private var topWidgets: some View {
-        if context == .overlay, let data = model.homeWidgetData {
-            HomeWidgetView(data: data)
-                .id("\(data.objectId)-\(data.canSetHomepage)")
-        } else if model.shouldShowUnreadSection {
-            HomeWidgetsGroupView(title: Loc.unread) {
-                model.onTapUnreadHeader()
-            }
-            if model.unreadSectionIsExpanded {
-                UnreadItemsGroupedView(items: model.unreadItems)
-            }
         }
     }
 
@@ -138,66 +118,36 @@ private struct HomeWidgetsInternalView: View {
 
     @ViewBuilder
     private var blockWidgets: some View {
-        if FeatureFlags.personalFavorites {
-            if model.widgetBlocks.isNotEmpty {
-                VStack(spacing: 12) {
-                    WidgetSwipeTipView()
-                    ForEach(model.widgetBlocks) { widgetInfo in
-                        HomeWidgetSubmoduleView(
-                            widgetInfo: widgetInfo,
-                            channelWidgetsObject: model.channelWidgetsObject,
-                            personalWidgetsObject: model.myFavoritesListViewModel?.personalWidgetsObject,
-                            workspaceInfo: model.info,
-                            homeState: $model.homeState,
-                            output: model.output
-                        )
-                    }
-                }
-                .anytypeVerticalDrop(data: model.widgetBlocks, state: $widgetsDndState) { from, to in
-                    model.widgetsDropUpdate(from: from, to: to)
-                } dropFinish: { from, to in
-                    model.widgetsDropFinish(from: from, to: to)
+        if model.widgetBlocks.isNotEmpty {
+            VStack(spacing: 12) {
+                WidgetSwipeTipView()
+                ForEach(model.widgetBlocks) { widgetInfo in
+                    HomeWidgetSubmoduleView(
+                        widgetInfo: widgetInfo,
+                        channelWidgetsObject: model.channelWidgetsObject,
+                        personalWidgetsObject: model.personalWidgetsObject,
+                        workspaceInfo: model.info,
+                        homeState: $model.homeState,
+                        output: model.output
+                    )
                 }
             }
-        } else {
-            if model.widgetBlocks.isNotEmpty {
-                HomeWidgetsGroupView(title: Loc.pinned) {
-                    model.onTapPinnedHeader()
-                }
-                if model.pinnedSectionIsExpanded {
-                    VStack(spacing: 12) {
-                        WidgetSwipeTipView()
-                        ForEach(model.widgetBlocks) { widgetInfo in
-                            HomeWidgetSubmoduleView(
-                                widgetInfo: widgetInfo,
-                                channelWidgetsObject: model.channelWidgetsObject,
-                                personalWidgetsObject: model.myFavoritesListViewModel?.personalWidgetsObject,
-                                workspaceInfo: model.info,
-                                homeState: $model.homeState,
-                                output: model.output
-                            )
-                        }
-                    }
-                    .anytypeVerticalDrop(data: model.widgetBlocks, state: $widgetsDndState) { from, to in
-                        model.widgetsDropUpdate(from: from, to: to)
-                    } dropFinish: { from, to in
-                        model.widgetsDropFinish(from: from, to: to)
-                    }
-                }
+            .anytypeVerticalDrop(data: model.widgetBlocks, state: $widgetsDndState) { from, to in
+                model.widgetsDropUpdate(from: from, to: to)
+            } dropFinish: { from, to in
+                model.widgetsDropFinish(from: from, to: to)
             }
         }
     }
-    
+
     @ViewBuilder
     private var myFavoritesWidget: some View {
-        if FeatureFlags.personalFavorites,
-           let myFavoritesListViewModel = model.myFavoritesListViewModel,
-           myFavoritesListViewModel.rows.isNotEmpty {
+        if model.myFavoritesListViewModel.rows.isNotEmpty {
             HomeWidgetsGroupView(title: Loc.myFavorites) {
                 model.onTapMyFavoritesHeader()
             }
             if model.myFavoritesSectionIsExpanded {
-                MyFavoritesListView(model: myFavoritesListViewModel)
+                MyFavoritesListView(model: model.myFavoritesListViewModel)
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -10,7 +10,6 @@ import AsyncAlgorithms
 final class HomeWidgetsViewModel {
 
     private enum Constants {
-        static let pinnedSectionId = "HomePinnedSection"
         static let objectTypeSectionId = "HomeObjectTypeSection"
         static let unreadSectionId = "HomeUnreadSection"
         static let myFavoritesSectionId = "HomeMyFavoritesSection"
@@ -20,6 +19,7 @@ final class HomeWidgetsViewModel {
 
     let info: AccountInfo
     let channelWidgetsObject: any BaseDocumentProtocol
+    let personalWidgetsObject: any BaseDocumentProtocol
 
     @Injected(\.blockWidgetService) @ObservationIgnored
     private var blockWidgetService: any BlockWidgetServiceProtocol
@@ -59,14 +59,13 @@ final class HomeWidgetsViewModel {
     var widgetsDataLoaded: Bool = false
     var objectTypesDataLoaded: Bool = false
     var wallpaper: SpaceWallpaperType = .default
-    var pinnedSectionIsExpanded: Bool = false
     var objectTypeSectionIsExpanded: Bool = false
     var canCreateObjectType: Bool = false
     var homeWidgetData: HomepageWidgetViewData?
     var unreadSectionIsExpanded: Bool = false
     var unreadItems: [UnreadSectionItem] = []
     var myFavoritesSectionIsExpanded: Bool = false
-    var myFavoritesListViewModel: MyFavoritesListViewModel?
+    var myFavoritesListViewModel: MyFavoritesListViewModel
     private var supportsMultiChats: Bool = false
 
     var spaceId: String { info.accountSpaceId }
@@ -87,23 +86,19 @@ final class HomeWidgetsViewModel {
         self.output = output
         let channelWidgetsObject = documentService.document(objectId: info.widgetsId, spaceId: info.accountSpaceId)
         self.channelWidgetsObject = channelWidgetsObject
-        if FeatureFlags.personalFavorites {
-            let personalWidgetsObject = documentService.document(
-                objectId: info.personalWidgetsId,
-                spaceId: info.accountSpaceId
-            )
-            self.myFavoritesListViewModel = MyFavoritesListViewModel(
-                spaceId: info.accountSpaceId,
-                personalWidgetsObject: personalWidgetsObject,
-                channelWidgetsObject: channelWidgetsObject,
-                onObjectSelected: { [weak output] details in
-                    output?.onObjectSelected(screenData: details.screenData())
-                }
-            )
-        } else {
-            self.myFavoritesListViewModel = nil
-        }
-        self.pinnedSectionIsExpanded = expandedService.isExpanded(id: Constants.pinnedSectionId, defaultValue: true)
+        let personalWidgetsObject = documentService.document(
+            objectId: info.personalWidgetsId,
+            spaceId: info.accountSpaceId
+        )
+        self.personalWidgetsObject = personalWidgetsObject
+        self.myFavoritesListViewModel = MyFavoritesListViewModel(
+            spaceId: info.accountSpaceId,
+            personalWidgetsObject: personalWidgetsObject,
+            channelWidgetsObject: channelWidgetsObject,
+            onObjectSelected: { [weak output] details in
+                output?.onObjectSelected(screenData: details.screenData())
+            }
+        )
         self.objectTypeSectionIsExpanded = expandedService.isExpanded(id: Constants.objectTypeSectionId, defaultValue: true)
         self.unreadSectionIsExpanded = expandedService.isExpanded(id: Constants.unreadSectionId, defaultValue: true)
         self.myFavoritesSectionIsExpanded = expandedService.isExpanded(id: Constants.myFavoritesSectionId, defaultValue: true)
@@ -156,13 +151,6 @@ final class HomeWidgetsViewModel {
         output?.onCreateObjectType()
     }
     
-    func onTapPinnedHeader() {
-        withAnimation {
-            pinnedSectionIsExpanded = !pinnedSectionIsExpanded
-        }
-        expandedService.setState(id: Constants.pinnedSectionId, isExpanded: pinnedSectionIsExpanded)
-    }
-    
     func onTapObjectTypeHeader() {
         withAnimation {
             objectTypeSectionIsExpanded = !objectTypeSectionIsExpanded
@@ -203,9 +191,6 @@ final class HomeWidgetsViewModel {
     }
 
     private func startMyFavoritesTask() async {
-        // Drives the `MyFavoritesListViewModel.rows` list — only spins up when the feature flag
-        // enabled the sub-viewmodel in `init`.
-        guard let myFavoritesListViewModel else { return }
         await myFavoritesListViewModel.startSubscriptions()
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetActionsMenu/WidgetCommonActionsMenuView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetActionsMenu/WidgetCommonActionsMenuView.swift
@@ -16,7 +16,7 @@ struct WidgetCommonActionsMenuView: View {
     let items: [WidgetMenuItem]
     let widgetBlockId: String
     let channelWidgetsObject: any BaseDocumentProtocol
-    let personalWidgetsObject: (any BaseDocumentProtocol)?
+    let personalWidgetsObject: any BaseDocumentProtocol
     let homeState: HomeWidgetsState
     let output: (any CommonWidgetModuleOutput)?
     let targetObjectId: String?
@@ -27,7 +27,7 @@ struct WidgetCommonActionsMenuView: View {
         items: [WidgetMenuItem],
         widgetBlockId: String,
         channelWidgetsObject: any BaseDocumentProtocol,
-        personalWidgetsObject: (any BaseDocumentProtocol)?,
+        personalWidgetsObject: any BaseDocumentProtocol,
         homeState: HomeWidgetsState,
         output: (any CommonWidgetModuleOutput)?,
         targetObjectId: String?
@@ -95,10 +95,6 @@ struct WidgetCommonActionsMenuView: View {
             Button {
                 guard let targetObjectId else {
                     anytypeAssertionFailure(".favorite menu item emitted without targetObjectId")
-                    return
-                }
-                guard let personalWidgetsObject else {
-                    anytypeAssertionFailure(".favorite menu item emitted without personalWidgetsObject")
                     return
                 }
                 model.provider.onFavoriteTap(

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
@@ -8,9 +8,8 @@ struct WidgetSubmoduleData {
     /// visible to every member of the space.
     let channelWidgetsObject: any BaseDocumentProtocol
     /// Per-user personal widgets document (`info.personalWidgetsId`) — holds the
-    /// current user's favorites. `nil` when the personalFavorites flag is off so
-    /// downstream consumers skip favorite-related UI without a flag check.
-    let personalWidgetsObject: (any BaseDocumentProtocol)?
+    /// current user's favorites.
+    let personalWidgetsObject: any BaseDocumentProtocol
     let homeState: Binding<HomeWidgetsState>
     let spaceInfo: AccountInfo
     let output: (any CommonWidgetModuleOutput)?

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Container/WidgetContainerView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Container/WidgetContainerView.swift
@@ -21,7 +21,7 @@ struct WidgetContainerView<Content: View>: View {
     init(
         widgetBlockId: String,
         channelWidgetsObject: some BaseDocumentProtocol,
-        personalWidgetsObject: (any BaseDocumentProtocol)?,
+        personalWidgetsObject: any BaseDocumentProtocol,
         spaceId: String,
         homeState: Binding<HomeWidgetsState>,
         name: String,

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Container/WidgetContainerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Container/WidgetContainerViewModel.swift
@@ -12,9 +12,8 @@ final class WidgetContainerViewModel {
 
     let widgetBlockId: String
     let channelWidgetsObject: any BaseDocumentProtocol
-    // `nil` when the personalFavorites flag is off.
     @ObservationIgnored
-    let personalWidgetsObject: (any BaseDocumentProtocol)?
+    let personalWidgetsObject: any BaseDocumentProtocol
     @ObservationIgnored
     private let spaceId: String
     // `nil` for library widgets (Pinned / Recent / …).
@@ -37,7 +36,7 @@ final class WidgetContainerViewModel {
     @ObservationIgnored
     private let baseMenuItems: [WidgetMenuItem]
     var menuItems: [WidgetMenuItem] {
-        guard FeatureFlags.personalFavorites, targetObjectId != nil else {
+        guard targetObjectId != nil else {
             return baseMenuItems
         }
         var extras: [WidgetMenuItem] = [.favorite(isFavorited: isFavorited)]
@@ -53,7 +52,7 @@ final class WidgetContainerViewModel {
     private var isFavorited: Bool = false
     private var isPinnedToChannel: Bool = false
     private var canManageChannelPins: Bool {
-        guard FeatureFlags.personalFavorites, targetObjectId != nil else { return false }
+        guard targetObjectId != nil else { return false }
         return participantSpacesStorage
             .participantSpaceView(spaceId: spaceId)?
             .canManageChannelPins ?? false
@@ -65,7 +64,7 @@ final class WidgetContainerViewModel {
     init(
         widgetBlockId: String,
         channelWidgetsObject: some BaseDocumentProtocol,
-        personalWidgetsObject: (any BaseDocumentProtocol)?,
+        personalWidgetsObject: any BaseDocumentProtocol,
         spaceId: String,
         expectedMenuItems: [WidgetMenuItem],
         defaultExpanded: Bool = true,
@@ -93,10 +92,8 @@ final class WidgetContainerViewModel {
         let menuItems = numberOfWidgetLayouts > 1 ? expectedMenuItems : expectedMenuItems.filter { $0 != .changeType }
         if source?.isLibrary ?? false {
             self.baseMenuItems = menuItems.filter { $0 != .remove }
-        } else if FeatureFlags.personalFavorites {
-            self.baseMenuItems = menuItems.filter { $0 != .remove && $0 != .removeSystemWidget }
         } else {
-            self.baseMenuItems = menuItems.filter { $0 != .removeSystemWidget }
+            self.baseMenuItems = menuItems.filter { $0 != .remove && $0 != .removeSystemWidget }
         }
     }
 
@@ -107,7 +104,7 @@ final class WidgetContainerViewModel {
     }
 
     private func startPersonalSubscription() async {
-        guard let personalWidgetsObject, let targetObjectId else { return }
+        guard let targetObjectId else { return }
         for await _ in personalWidgetsObject.syncPublisher.values {
             let next = personalWidgetsObject.containsWidgetFor(objectId: targetObjectId)
             guard isFavorited != next else { continue }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectAction.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectAction.swift
@@ -41,7 +41,7 @@ enum ObjectAction: Hashable, Identifiable {
                 ObjectAction.pin(isPinned: isPinnedToWidgets)
             }
 
-            if canCreateWidget && FeatureFlags.personalFavorites {
+            if canCreateWidget {
                 ObjectAction.favorite(isFavorited: isFavorited)
             }
 
@@ -113,7 +113,7 @@ enum ObjectAction: Hashable, Identifiable {
                 ObjectAction.pin(isPinned: isPinnedToWidgets)
             }
 
-            if canCreateWidget && FeatureFlags.personalFavorites {
+            if canCreateWidget {
                 ObjectAction.favorite(isFavorited: isFavorited)
             }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
@@ -85,7 +85,6 @@ final class ObjectSettingsViewModel {
     // the global info can race app launch with `AccountData.empty`.
     @ObservationIgnored
     private lazy var personalWidgetsObject: (any BaseDocumentProtocol)? = {
-        guard FeatureFlags.personalFavorites else { return nil }
         guard let info = workspaceStorage.spaceInfo(spaceId: spaceId) else {
             anytypeAssertionFailure("info not found for personal widgets")
             return nil
@@ -160,9 +159,7 @@ final class ObjectSettingsViewModel {
 
     private func startParticipantSpaceViewSubscription() async {
         for await participantSpaceView in participantSpacesStorage.participantSpaceViewPublisher(spaceId: spaceId).values {
-            canManageChannelPins = FeatureFlags.personalFavorites
-                ? participantSpaceView.canManageChannelPins
-                : true
+            canManageChannelPins = participantSpaceView.canManageChannelPins
             isSpaceOwner = participantSpaceView.isOwner
             updateActions()
         }

--- a/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
@@ -42,10 +42,6 @@ public extension FeatureFlags {
         value(for: .muteAndHide)
     }
 
-    static var personalFavorites: Bool {
-        value(for: .personalFavorites)
-    }
-
     static var setKanbanView: Bool {
         value(for: .setKanbanView)
     }
@@ -137,7 +133,6 @@ public extension FeatureFlags {
         .channelTypeSwitcher,
         .fixAvatarTapFreeze,
         .muteAndHide,
-        .personalFavorites,
         .setKanbanView,
         .fullInlineSetImpl,
         .dndOnCollectionsAndSets,

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -60,12 +60,6 @@ public extension FeatureDescription {
         defaultValue: true
     )
 
-    static let personalFavorites = FeatureDescription(
-        title: "Personal Favorites - IOS-5864 (requires MW GO-6962)",
-        category: .productFeature(author: "k@anytype.io", targetRelease: "18"),
-        defaultValue: true
-    )
-
     // MARK: - Experemental
     
     static let setKanbanView = FeatureDescription(


### PR DESCRIPTION
## Summary
- Deletes the `personalFavorites` feature toggle (shipped in release 18, default `true`) and removes all flag-off branches.
- Promotes `myFavoritesListViewModel` to a non-optional property on `HomeWidgetsViewModel` and exposes `personalWidgetsObject` directly so views no longer reach into the sub-viewmodel.
- Propagates non-optional `personalWidgetsObject` through the widget chain (`HomeWidgetSubmoduleView`, `WidgetContainerView`/`ViewModel`, `WidgetSubmoduleData`, `WidgetCommonActionsMenuView`); deletes orphaned pinned-section state (`pinnedSectionIsExpanded`, `onTapPinnedHeader`, `topWidgets`).