### PR TITLE
IOS-6144 Fix NSInternalInconsistencyException during cell dequeue

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewSwitcher.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewSwitcher.swift
@@ -115,7 +115,10 @@ final class AccessoryViewSwitcher: AccessoryViewSwitcherProtocol {
                 reloadInputViews()
             }
         } else {
-            reloadInputViews()
+            // Defer: this can be reached from a UITextView delegate during cell dequeue; flushing layout there crashes on iOS 26.
+            DispatchQueue.main.async {
+                reloadInputViews()
+            }
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView.swift
@@ -123,8 +123,11 @@ final class TextBlockContentView: UIView, BlockContentView, DynamicHeightView, F
         }
         
         if let position = configuration.initialBlockFocusPosition {
-            textView.textView.setFocus(position)
-        }        
+            // Defer: applyNewConfiguration runs during cell dequeue; synchronous becomeFirstResponder triggers delegate side effects that crash on iOS 26.
+            DispatchQueue.main.async { [weak self] in
+                self?.textView.textView.setFocus(position)
+            }
+        }
     }
     
     private func updateAllConstraint(configuration: TextBlockContentConfiguration) {


### PR DESCRIPTION
## Summary
- Fix fatal `NSInternalInconsistencyException` ("Expected dequeued view to be returned to the collection view…") originating in `AccessoryViewSwitcher.changeAccessoryView`. Reproduced on iOS 26.x in 0.46.0+19 (4 Sentry reports).
- Root cause: a `UITextView` delegate (`textViewDidBeginEditing` / `textViewDidEndEditing`) fires synchronously while a cell is mid-dequeue, reaches `changeAccessoryView`, and calls `textView.window?.layoutIfNeeded()` — flushing layout before the cell returns to the collection view, which iOS 26 treats as fatal.
- Two-layer fix:
  - `AccessoryViewSwitcher`: defer the no-animation `reloadInputViews()` (and the `layoutIfNeeded()` it calls) to the next runloop tick. This is the choke point — covers all four observed crash variants.
  - `TextBlockContentView`: defer the synchronous `setFocus(initialBlockFocusPosition)` so we don't kick off `becomeFirstResponder` while the cell is still being dequeued. Matches the existing `focusPublisher` path which already uses `.receiveOnMain()`.