### PR TITLE
IOS-6145 Use LazyVStack in SpaceHubList to defer offscreen card rendering

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubList.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/SpaceHubList.swift
@@ -23,7 +23,7 @@ struct SpaceHubList: View {
     
     private var scrollView: some View {
         ScrollView(.vertical) {
-            VStack(spacing: 8) {
+            LazyVStack(spacing: 8) {
                 HomeUpdateSubmoduleView().padding(8)
 
                 ForEach(model.filteredSpaces) {


### PR DESCRIPTION
## Summary
- Replace eager `VStack` with `LazyVStack` in `SpaceHubList` so off-screen space cards do not build their `IconView`, `DashboardWallpaper` blur, or context-menu/drag previews until scrolled into view.
- Targeted at users with many active spaces on memory-tight devices (e.g. iPhone 11 Pro, ~1.9 GB usable RAM) where Sentry shows `WatchdogTermination` with multiple "Low memory" warnings on the Channels screen.
- One-line change; per-card `.id`, drag/drop delegates and context menus are already per-card and remain correct.