### PR TITLE
IOS-6152 Extract Bin into its own widget on home screen

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -87,6 +87,7 @@ private struct HomeWidgetsInternalView: View {
                 unreadWidget
                 myFavoritesWidget
                 objectTypeWidgets
+                binWidget
                 AnytypeNavigationSpacer(minHeight: context.showEmbeddedBottomPanel ? 72 : 0)
             }
             .padding(.horizontal, 20)
@@ -158,15 +159,18 @@ private struct HomeWidgetsInternalView: View {
             model.onTapObjectTypeHeader()
         }, onCreate: nil)
         if model.objectTypeSectionIsExpanded {
-            VStack(spacing: 12) {
-                ObjectTypesUnifiedWidgetView(
-                    typeInfos: model.objectTypeWidgets,
-                    canCreateType: model.canCreateObjectType,
-                    onCreateType: { model.onCreateObjectType() },
-                    output: model.output
-                )
-                BinLinkWidgetView(spaceId: model.spaceId, homeState: $model.homeState, output: model.output)
-            }
+            ObjectTypesUnifiedWidgetView(
+                typeInfos: model.objectTypeWidgets,
+                canCreateType: model.canCreateObjectType,
+                onCreateType: { model.onCreateObjectType() },
+                output: model.output
+            )
         }
+    }
+
+    @ViewBuilder
+    private var binWidget: some View {
+        BinLinkWidgetView(spaceId: model.spaceId, homeState: $model.homeState, output: model.output)
+            .padding(.top, 24)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -170,7 +170,9 @@ private struct HomeWidgetsInternalView: View {
 
     @ViewBuilder
     private var binWidget: some View {
-        BinLinkWidgetView(spaceId: model.spaceId, homeState: $model.homeState, output: model.output)
-            .padding(.top, 24)
+        if model.homeState.isReadWrite {
+            BinLinkWidgetView(spaceId: model.spaceId, homeState: $model.homeState, output: model.output)
+                .padding(.top, 24)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Pulls `BinLinkWidgetView` out of the Objects section's `objectTypeWidgets` `@ViewBuilder` and renders it as a peer sibling section directly below Objects, with 24pt top spacing.
- Structural prep for the Manage Sections system (parent IOS-5711) so Bin can later be toggled and reordered independently.
- Behavior delta: previously Bin was hidden when Object Types was collapsed (it lived inside `if objectTypeSectionIsExpanded`). It now stays visible regardless. Bin still self-gates on `homeState.isReadWrite` (no widget and no 24pt gap on read-only spaces).