### PR TITLE
IOS-6143 Fix widget/list titles showing type plural name instead of object title

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/Extensions/RelationValuesProtocol+PageCellTitle.swift
+++ b/Anytype/Sources/PresentationLayer/Common/Extensions/RelationValuesProtocol+PageCellTitle.swift
@@ -28,7 +28,11 @@ extension BundledPropertiesValueProvider {
             return Loc.nonExistentObject
         }
 
-        return pluralName.isNotEmpty ? pluralName : title
+        // pluralName is meaningful only on type objects; middleware also denormalizes it onto instance details.
+        if resolvedLayoutValue == .objectType, pluralName.isNotEmpty {
+            return pluralName
+        }
+        return title
     }
 
     var subtitle: String {


### PR DESCRIPTION
## Summary
- Gate `pluralTitle` on `resolvedLayoutValue == .objectType` so only type objects use `pluralName`.
- Middleware denormalizes the type's `pluralName` onto every instance's details; ungated lookup made widgets, set rows, tree, search, link-to, and favorites show e.g. "Regular Entries" for every journal entry instead of the entry's actual title.
- Matches desktop, which gates the same way in `anytype-ts/src/ts/lib/util/object.ts:463` (`isTypeLayout(layout)`).