### PR TITLE
IOS-6151 Add Recently Edited section to home screen

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -34,6 +34,7 @@ private struct HomeWidgetsInternalView: View {
             content
                 .animation(.default, value: model.widgetBlocks.count)
                 .animation(.default, value: model.myFavoritesListViewModel.rows.count)
+                .animation(.default, value: model.recentlyEditedListViewModel.rows.count)
 
             if context.showEmbeddedBottomPanel {
                 HomeBottomNavigationPanelView(
@@ -86,6 +87,7 @@ private struct HomeWidgetsInternalView: View {
                 blockWidgets
                 unreadWidget
                 myFavoritesWidget
+                recentlyEditedWidget
                 objectTypeWidgets
                 binWidget
                 AnytypeNavigationSpacer(minHeight: context.showEmbeddedBottomPanel ? 72 : 0)
@@ -149,6 +151,18 @@ private struct HomeWidgetsInternalView: View {
             }
             if model.myFavoritesSectionIsExpanded {
                 MyFavoritesListView(model: model.myFavoritesListViewModel)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var recentlyEditedWidget: some View {
+        if model.recentlyEditedListViewModel.rows.isNotEmpty {
+            HomeWidgetsGroupView(title: Loc.Widgets.Library.RecentlyEdited.name) {
+                model.onTapRecentlyEditedHeader()
+            }
+            if model.recentlyEditedSectionIsExpanded {
+                RecentlyEditedListView(model: model.recentlyEditedListViewModel)
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -13,6 +13,7 @@ final class HomeWidgetsViewModel {
         static let objectTypeSectionId = "HomeObjectTypeSection"
         static let unreadSectionId = "HomeUnreadSection"
         static let myFavoritesSectionId = "HomeMyFavoritesSection"
+        static let recentlyEditedSectionId = "HomeRecentlyEditedSection"
     }
     
     // MARK: - DI
@@ -66,6 +67,8 @@ final class HomeWidgetsViewModel {
     var unreadItems: [UnreadSectionItem] = []
     var myFavoritesSectionIsExpanded: Bool = false
     var myFavoritesListViewModel: MyFavoritesListViewModel
+    var recentlyEditedSectionIsExpanded: Bool = false
+    var recentlyEditedListViewModel: RecentlyEditedListViewModel
     private var supportsMultiChats: Bool = false
 
     var spaceId: String { info.accountSpaceId }
@@ -99,20 +102,28 @@ final class HomeWidgetsViewModel {
                 output?.onObjectSelected(screenData: details.screenData())
             }
         )
+        self.recentlyEditedListViewModel = RecentlyEditedListViewModel(
+            spaceId: info.accountSpaceId,
+            onObjectSelected: { [weak output] details in
+                output?.onObjectSelected(screenData: details.screenData())
+            }
+        )
         self.objectTypeSectionIsExpanded = expandedService.isExpanded(id: Constants.objectTypeSectionId, defaultValue: true)
         self.unreadSectionIsExpanded = expandedService.isExpanded(id: Constants.unreadSectionId, defaultValue: true)
         self.myFavoritesSectionIsExpanded = expandedService.isExpanded(id: Constants.myFavoritesSectionId, defaultValue: true)
+        self.recentlyEditedSectionIsExpanded = expandedService.isExpanded(id: Constants.recentlyEditedSectionId, defaultValue: true)
     }
 
     func startSubscriptions() async {
         async let widgetObjectSub: () = startWidgetObjectTask()
         async let myFavoritesSub: () = startMyFavoritesTask()
+        async let recentlyEditedSub: () = startRecentlyEditedTask()
         async let canEditSub: () = startCanEditSubscription()
         async let objectTypesTask: () = startObjectTypesTask()
         async let spaceViewTask: () = startSpaceViewTask()
         async let unreadItemsTask: () = startUnreadItemsTask()
 
-        _ = await (widgetObjectSub, myFavoritesSub, canEditSub, objectTypesTask, spaceViewTask, unreadItemsTask)
+        _ = await (widgetObjectSub, myFavoritesSub, recentlyEditedSub, canEditSub, objectTypesTask, spaceViewTask, unreadItemsTask)
     }
 
     func onAppear() {
@@ -172,6 +183,13 @@ final class HomeWidgetsViewModel {
         expandedService.setState(id: Constants.myFavoritesSectionId, isExpanded: myFavoritesSectionIsExpanded)
     }
 
+    func onTapRecentlyEditedHeader() {
+        withAnimation {
+            recentlyEditedSectionIsExpanded = !recentlyEditedSectionIsExpanded
+        }
+        expandedService.setState(id: Constants.recentlyEditedSectionId, isExpanded: recentlyEditedSectionIsExpanded)
+    }
+
     // MARK: - Private
     
     private func startWidgetObjectTask() async {
@@ -192,6 +210,10 @@ final class HomeWidgetsViewModel {
 
     private func startMyFavoritesTask() async {
         await myFavoritesListViewModel.startSubscriptions()
+    }
+
+    private func startRecentlyEditedTask() async {
+        await recentlyEditedListViewModel.startSubscriptions()
     }
 
     private func startCanEditSubscription() async {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedListView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedListView.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SwiftUI
+
+struct RecentlyEditedListView: View {
+    let model: RecentlyEditedListViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(model.rows.enumerated()), id: \.element.id) { index, row in
+                RecentlyEditedRowView(
+                    row: row,
+                    showDivider: index != model.rows.count - 1,
+                    onObjectSelected: model.onObjectSelected
+                )
+            }
+        }
+        .background(Color.Background.widget)
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedListViewModel.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Services
+import AnytypeCore
+
+@MainActor
+@Observable
+final class RecentlyEditedListViewModel {
+
+    // MARK: - DI
+
+    @ObservationIgnored
+    let spaceId: String
+    @ObservationIgnored
+    let onObjectSelected: (ObjectDetails) -> Void
+
+    @ObservationIgnored
+    @Injected(\.recentSubscriptionService)
+    private var recentSubscriptionService: any RecentSubscriptionServiceProtocol
+
+    private enum Constants {
+        // Matches the desktop client's recentEdit subscription limit.
+        static let limit = 10
+    }
+
+    // MARK: - Published state
+
+    var rows: [RecentlyEditedRowData] = []
+
+    init(
+        spaceId: String,
+        onObjectSelected: @escaping (ObjectDetails) -> Void
+    ) {
+        self.spaceId = spaceId
+        self.onObjectSelected = onObjectSelected
+    }
+
+    // MARK: - Subscriptions
+
+    func startSubscriptions() async {
+        await recentSubscriptionService.startSubscription(
+            spaceId: spaceId,
+            type: .recentEdit,
+            objectLimit: Constants.limit,
+            update: { [weak self] details in
+                self?.rows = details.map { RecentlyEditedRowData(id: $0.id, details: $0) }
+            }
+        )
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedRowData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedRowData.swift
@@ -1,0 +1,7 @@
+import Foundation
+import Services
+
+struct RecentlyEditedRowData: Identifiable, Equatable {
+    let id: String
+    let details: ObjectDetails
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedRowView.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftUI
+import Services
+
+struct RecentlyEditedRowView: View {
+    let row: RecentlyEditedRowData
+    let showDivider: Bool
+    let onObjectSelected: (ObjectDetails) -> Void
+
+    var body: some View {
+        Button {
+            onObjectSelected(row.details)
+        } label: {
+            HStack(spacing: 12) {
+                IconView(icon: row.details.objectIconImage)
+                    .frame(width: 20, height: 20)
+
+                AnytypeText(row.details.pluralTitle, style: .bodySemibold)
+                    .foregroundStyle(Color.Text.primary)
+                    .lineLimit(1)
+
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .frame(height: 48)
+            .fixTappableArea()
+        }
+        .buttonStyle(.plain)
+        .if(showDivider) {
+            $0.newDivider(leadingPadding: 16, trailingPadding: 16, color: .Widget.divider)
+        }
+        .background(Color.Background.widget)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds always-on "Recently Edited" section between My Favorites and Object Types on the space home screen
- Reuses existing `RecentSubscriptionService` (sort by `lastModifiedDate` DESC, limit 10 to match desktop)
- Mirrors `myFavoritesWidget` shape: `HomeWidgetsGroupView` header + simple list, no drag/drop, no per-row VM

Part of IOS-5711 (master plan: `plans/PLAN_IOS_5711.md`, item #1). Visibility/order management arrive in IOS-6153–6156.