### PR TITLE
IOS-6153 Add home sections model, per-space storage, and localization

### DIFF
--- a/AnyTypeTests/Services/HomeSectionsStorageTests.swift
+++ b/AnyTypeTests/Services/HomeSectionsStorageTests.swift
@@ -6,16 +6,15 @@ import Combine
 @Suite(.serialized)
 final class HomeSectionsStorageTests {
 
-    private static let userDefaultsKey = "homeSectionsConfigurations"
     private let sut: HomeSectionsStorage
 
     init() {
-        UserDefaults.standard.removeObject(forKey: Self.userDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: HomeSectionsStorage.userDefaultsKey)
         self.sut = HomeSectionsStorage()
     }
 
     deinit {
-        UserDefaults.standard.removeObject(forKey: Self.userDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: HomeSectionsStorage.userDefaultsKey)
     }
 
     @Test func returnsDefaultWhenNoRecordExists() {

--- a/AnyTypeTests/Services/HomeSectionsStorageTests.swift
+++ b/AnyTypeTests/Services/HomeSectionsStorageTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+import Combine
+@testable import Anytype
+
+@Suite(.serialized)
+final class HomeSectionsStorageTests {
+
+    private static let userDefaultsKey = "homeSectionsConfigurations"
+    private let sut: HomeSectionsStorage
+
+    init() {
+        UserDefaults.standard.removeObject(forKey: Self.userDefaultsKey)
+        self.sut = HomeSectionsStorage()
+    }
+
+    deinit {
+        UserDefaults.standard.removeObject(forKey: Self.userDefaultsKey)
+    }
+
+    @Test func returnsDefaultWhenNoRecordExists() {
+        #expect(sut.configuration(spaceId: "space-1") == .default)
+    }
+
+    @Test func setAndGetRoundTrip() {
+        let custom = HomeSectionsConfiguration(visibleSections: [.unread, .objects])
+        sut.setConfiguration(custom, spaceId: "space-1")
+
+        #expect(sut.configuration(spaceId: "space-1") == custom)
+    }
+
+    @Test func isolationBetweenSpaces() {
+        let custom = HomeSectionsConfiguration(visibleSections: [.bin])
+        sut.setConfiguration(custom, spaceId: "space-A")
+
+        #expect(sut.configuration(spaceId: "space-A") == custom)
+        #expect(sut.configuration(spaceId: "space-B") == .default)
+    }
+
+    @Test func publisherEmitsCurrentValueOnSubscribe() {
+        var received: [HomeSectionsConfiguration] = []
+        let cancellable = sut.configurationPublisher(spaceId: "space-1")
+            .sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        #expect(received == [.default])
+    }
+
+    @Test func publisherEmitsOnUpdate() {
+        var received: [HomeSectionsConfiguration] = []
+        let cancellable = sut.configurationPublisher(spaceId: "space-1")
+            .sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        let custom = HomeSectionsConfiguration(visibleSections: [.bin])
+        sut.setConfiguration(custom, spaceId: "space-1")
+
+        #expect(received == [.default, custom])
+    }
+
+    @Test func publisherIgnoresUnrelatedSpaceUpdates() {
+        var received: [HomeSectionsConfiguration] = []
+        let cancellable = sut.configurationPublisher(spaceId: "space-1")
+            .sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        let other = HomeSectionsConfiguration(visibleSections: [.bin])
+        sut.setConfiguration(other, spaceId: "space-2")
+
+        #expect(received == [.default])
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/HomeSection.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/HomeSection.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum HomeSection: String, CaseIterable, Codable, Sendable {
+    case unread
+    case pinned
+    case myFavorites
+    case recentlyEdited
+    case objects
+    case bin
+}
+
+struct HomeSectionsConfiguration: Codable, Equatable, Sendable {
+    /// Visible sections in render order. Sections not listed are hidden.
+    let visibleSections: [HomeSection]
+
+    static let `default` = HomeSectionsConfiguration(
+        visibleSections: [.pinned, .unread, .myFavorites, .recentlyEdited, .objects, .bin]
+    )
+}

--- a/Anytype/Sources/ServiceLayer/HomeSections/HomeSectionsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/HomeSections/HomeSectionsStorage.swift
@@ -10,8 +10,10 @@ protocol HomeSectionsStorageProtocol: Sendable {
 
 final class HomeSectionsStorage: HomeSectionsStorageProtocol, Sendable {
 
+    static let userDefaultsKey = "homeSectionsConfigurations"
+
     private let storage = UserDefaultStorage<[String: HomeSectionsConfiguration]>(
-        key: "homeSectionsConfigurations",
+        key: Self.userDefaultsKey,
         defaultValue: [:]
     )
     private let subject: CurrentValueSubject<[String: HomeSectionsConfiguration], Never>

--- a/Anytype/Sources/ServiceLayer/HomeSections/HomeSectionsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/HomeSections/HomeSectionsStorage.swift
@@ -13,7 +13,7 @@ final class HomeSectionsStorage: HomeSectionsStorageProtocol, Sendable {
     static let userDefaultsKey = "homeSectionsConfigurations"
 
     private let storage = UserDefaultStorage<[String: HomeSectionsConfiguration]>(
-        key: Self.userDefaultsKey,
+        key: HomeSectionsStorage.userDefaultsKey,
         defaultValue: [:]
     )
     private let subject: CurrentValueSubject<[String: HomeSectionsConfiguration], Never>

--- a/Anytype/Sources/ServiceLayer/HomeSections/HomeSectionsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/HomeSections/HomeSectionsStorage.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Combine
+import AnytypeCore
+
+protocol HomeSectionsStorageProtocol: Sendable {
+    func configuration(spaceId: String) -> HomeSectionsConfiguration
+    func setConfiguration(_ configuration: HomeSectionsConfiguration, spaceId: String)
+    func configurationPublisher(spaceId: String) -> AnyPublisher<HomeSectionsConfiguration, Never>
+}
+
+final class HomeSectionsStorage: HomeSectionsStorageProtocol, Sendable {
+
+    private let storage = UserDefaultStorage<[String: HomeSectionsConfiguration]>(
+        key: "homeSectionsConfigurations",
+        defaultValue: [:]
+    )
+    private let subject: CurrentValueSubject<[String: HomeSectionsConfiguration], Never>
+
+    init() {
+        self.subject = CurrentValueSubject(storage.value)
+    }
+
+    func configuration(spaceId: String) -> HomeSectionsConfiguration {
+        storage.value[spaceId] ?? .default
+    }
+
+    func setConfiguration(_ configuration: HomeSectionsConfiguration, spaceId: String) {
+        storage.value[spaceId] = configuration
+        subject.send(storage.value)
+    }
+
+    func configurationPublisher(spaceId: String) -> AnyPublisher<HomeSectionsConfiguration, Never> {
+        subject
+            .map { $0[spaceId] ?? .default }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+}

--- a/Anytype/Sources/ServiceLayer/ServicesDI.swift
+++ b/Anytype/Sources/ServiceLayer/ServicesDI.swift
@@ -192,6 +192,10 @@ extension Container {
         self { ExpandedService() }.shared
     }
 
+    var homeSectionsStorage: Factory<any HomeSectionsStorageProtocol> {
+        self { HomeSectionsStorage() }.shared
+    }
+
     var channelOnboardingStorage: Factory<any ChannelOnboardingStorageProtocol> {
         self { ChannelOnboardingStorage() }.shared
     }

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -421,6 +421,7 @@ public enum Loc {
   public static let logOut = Loc.tr("UI", "Log out", fallback: "Log Out")
   public static let logoutAndClearData = Loc.tr("UI", "Logout and clear data", fallback: "Logout and clear data")
   public static let managePayment = Loc.tr("UI", "Manage payment", fallback: "Manage payment")
+  public static let manageSections = Loc.tr("UI", "Manage sections", fallback: "Manage sections")
   public static let media = Loc.tr("UI", "Media", fallback: "Media")
   public static func membersPlural(_ p1: Int) -> String {
     return Loc.tr("UI", "membersPlural", p1, fallback: "Plural format key: membersPlural")
@@ -546,6 +547,7 @@ public enum Loc {
   public static let qrCode = Loc.tr("UI", "QR Code", fallback: "QR Code")
   public static let random = Loc.tr("UI", "Random", fallback: "Random")
   public static let recent = Loc.tr("UI", "Recent", fallback: "Recent")
+  public static let recentlyEdited = Loc.tr("UI", "Recently edited", fallback: "Recently edited")
   public static let red = Loc.tr("UI", "Red", fallback: "Red")
   public static let redBackground = Loc.tr("UI", "Red background", fallback: "Red background")
   public static let redo = Loc.tr("UI", "Redo", fallback: "Redo")

--- a/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
@@ -57780,6 +57780,17 @@
         }
       }
     },
+    "Manage sections" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manage sections"
+          }
+        }
+      }
+    },
     "Media" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -76880,6 +76891,17 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "最近存取"
+          }
+        }
+      }
+    },
+    "Recently edited" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recently edited"
           }
         }
       }


### PR DESCRIPTION
## Summary

- Adds `HomeSection` enum (`unread`, `pinned`, `myFavorites`, `recentlyEdited`, `objects`, `bin`) and `HomeSectionsConfiguration` model with default order `[pinned, unread, myFavorites, recentlyEdited, objects, bin]`.
- Adds `HomeSectionsStorage` — per-spaceId UserDefaults-backed storage with a Combine publisher, registered via DI. Mirrors the `TypesPinStorage` / `ExpandedService` sibling pattern.
- Adds `Loc.manageSections` and `Loc.recentlyEdited`. Six Swift Testing tests covering default lookup, round-trip, per-space isolation, and publisher behavior.

Foundation only — no UI is wired in; that comes in IOS-6155. No feature flag and no mock added (deliberate; mock will land with IOS-6154 when there's a screen VM to test against).