### PR TITLE
IOS-6155 Render home sections from storage and add Manage sections menu entry

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
@@ -130,6 +130,10 @@ final class HomeWidgetsCoordinatorViewModel: HomeWidgetsModuleOutput, SetObjectC
         qrCodeInviteData = url.identifiable
     }
 
+    func onManageSectionsSelected(spaceId: String) {
+        // TODO: IOS-6154 — present ManageSectionsView once the screen is merged.
+    }
+
     // MARK: - SetObjectCreationCoordinatorOutput
 
     func showEditorScreen(data: ScreenData) {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsModuleOutput.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsModuleOutput.swift
@@ -6,4 +6,5 @@ protocol HomeWidgetsModuleOutput: AnyObject, CommonWidgetModuleOutput {
     func onCreateObjectType()
     func onChangeHome()
     func onHomeObjectSelected(screenData: ScreenData)
+    func onManageSectionsSelected(spaceId: String)
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -62,6 +62,9 @@ private struct HomeWidgetsInternalView: View {
                 },
                 onQrCodeSelected: { url in
                     model.onQrCodeSelected(url: url)
+                },
+                onManageSectionsSelected: {
+                    model.onManageSectionsSelected()
                 }
             )
         }
@@ -84,17 +87,26 @@ private struct HomeWidgetsInternalView: View {
                 SpaceInfoView(spaceId: model.spaceId)
                 InviteMembersStubWidgetView(spaceId: model.spaceId, output: model.output)
                 homeWidget
-                blockWidgets
-                unreadWidget
-                myFavoritesWidget
-                recentlyEditedWidget
-                objectTypeWidgets
-                binWidget
+                ForEach(model.sectionsConfiguration.visibleSections, id: \.self) { section in
+                    manageableSection(section)
+                }
                 AnytypeNavigationSpacer(minHeight: context.showEmbeddedBottomPanel ? 72 : 0)
             }
             .padding(.horizontal, 20)
             .fitIPadToReadableContentGuide()
             .shouldHideChatBadges(model.shouldHideChatBadges)
+        }
+    }
+
+    @ViewBuilder
+    private func manageableSection(_ section: HomeSection) -> some View {
+        switch section {
+        case .pinned: blockWidgets
+        case .unread: unreadWidget
+        case .myFavorites: myFavoritesWidget
+        case .recentlyEdited: recentlyEditedWidget
+        case .objects: objectTypeWidgets
+        case .bin: binWidget
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -48,6 +48,8 @@ final class HomeWidgetsViewModel {
     private var chatDetailsStorage: any ChatDetailsStorageProtocol
     @Injected(\.objectsWithUnreadDiscussionsSubscription) @ObservationIgnored
     private var unreadDiscussionsSubscription: any ObjectsWithUnreadDiscussionsSubscriptionProtocol
+    @Injected(\.homeSectionsStorage) @ObservationIgnored
+    private var homeSectionsStorage: any HomeSectionsStorageProtocol
 
     @ObservationIgnored
     weak var output: (any HomeWidgetsModuleOutput)?
@@ -69,6 +71,7 @@ final class HomeWidgetsViewModel {
     var myFavoritesListViewModel: MyFavoritesListViewModel
     var recentlyEditedSectionIsExpanded: Bool = false
     var recentlyEditedListViewModel: RecentlyEditedListViewModel
+    var sectionsConfiguration: HomeSectionsConfiguration = .default
     private var supportsMultiChats: Bool = false
 
     var spaceId: String { info.accountSpaceId }
@@ -122,8 +125,9 @@ final class HomeWidgetsViewModel {
         async let objectTypesTask: () = startObjectTypesTask()
         async let spaceViewTask: () = startSpaceViewTask()
         async let unreadItemsTask: () = startUnreadItemsTask()
+        async let sectionsConfigurationTask: () = startSectionsConfigurationTask()
 
-        _ = await (widgetObjectSub, myFavoritesSub, recentlyEditedSub, canEditSub, objectTypesTask, spaceViewTask, unreadItemsTask)
+        _ = await (widgetObjectSub, myFavoritesSub, recentlyEditedSub, canEditSub, objectTypesTask, spaceViewTask, unreadItemsTask, sectionsConfigurationTask)
     }
 
     func onAppear() {
@@ -156,6 +160,10 @@ final class HomeWidgetsViewModel {
 
     func onQrCodeSelected(url: URL) {
         output?.onSpaceChatShowQrCodeSelected(url: url)
+    }
+
+    func onManageSectionsSelected() {
+        output?.onManageSectionsSelected(spaceId: info.accountSpaceId)
     }
 
     func onCreateObjectType() {
@@ -214,6 +222,12 @@ final class HomeWidgetsViewModel {
 
     private func startRecentlyEditedTask() async {
         await recentlyEditedListViewModel.startSubscriptions()
+    }
+
+    private func startSectionsConfigurationTask() async {
+        for await configuration in homeSectionsStorage.configurationPublisher(spaceId: info.accountSpaceId).values {
+            sectionsConfiguration = configuration
+        }
     }
 
     private func startCanEditSubscription() async {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderView.swift
@@ -11,13 +11,15 @@ struct WidgetsHeaderView: View {
         context: WidgetScreenContext,
         onSpaceSelected: @escaping () -> Void,
         onMembersSelected: @escaping (String, SettingsSpaceShareRoute) -> Void,
-        onQrCodeSelected: @escaping (URL) -> Void
+        onQrCodeSelected: @escaping (URL) -> Void,
+        onManageSectionsSelected: @escaping () -> Void
     ) {
         _model = State(initialValue: WidgetsHeaderViewModel(
             spaceId: spaceId,
             onSpaceSelected: onSpaceSelected,
             onMembersSelected: onMembersSelected,
-            onQrCodeSelected: onQrCodeSelected
+            onQrCodeSelected: onQrCodeSelected,
+            onManageSectionsSelected: onManageSectionsSelected
         ))
         self.context = context
     }
@@ -72,6 +74,9 @@ private struct WidgetsHeaderMenuContent: View {
         } else if model.isPrivateSpace {
             inviteMembersButton
         }
+
+        Divider()
+        manageSectionsButton
     }
 
     // MARK: - Menu Items
@@ -127,6 +132,14 @@ private struct WidgetsHeaderMenuContent: View {
             model.onCopyInviteLinkTap()
         } label: {
             Label(Loc.copyInviteLink, systemImage: "document.on.document")
+        }
+    }
+
+    private var manageSectionsButton: some View {
+        Button {
+            model.onManageSectionsTap()
+        } label: {
+            Label(Loc.manageSections, systemImage: "list.bullet")
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderViewModel.swift
@@ -28,6 +28,8 @@ final class WidgetsHeaderViewModel {
     private let onMembersSelected: (String, SettingsSpaceShareRoute) -> Void
     @ObservationIgnored
     private let onQrCodeSelected: (URL) -> Void
+    @ObservationIgnored
+    private let onManageSectionsSelected: () -> Void
 
     @ObservationIgnored
     private let accountSpaceId: String
@@ -73,12 +75,14 @@ final class WidgetsHeaderViewModel {
         spaceId: String,
         onSpaceSelected: @escaping () -> Void,
         onMembersSelected: @escaping (String, SettingsSpaceShareRoute) -> Void,
-        onQrCodeSelected: @escaping (URL) -> Void
+        onQrCodeSelected: @escaping (URL) -> Void,
+        onManageSectionsSelected: @escaping () -> Void
     ) {
         self.accountSpaceId = spaceId
         self.onSpaceSelected = onSpaceSelected
         self.onMembersSelected = onMembersSelected
         self.onQrCodeSelected = onQrCodeSelected
+        self.onManageSectionsSelected = onManageSectionsSelected
     }
 
     func startSubscriptions() async {
@@ -161,5 +165,9 @@ final class WidgetsHeaderViewModel {
         guard let inviteLink else { return }
         UIPasteboard.general.string = inviteLink.absoluteString
         toastBarData = ToastBarData(Loc.copiedToClipboard(Loc.link), type: .success)
+    }
+
+    func onManageSectionsTap() {
+        onManageSectionsSelected()
     }
 }


### PR DESCRIPTION
## Summary
- Wire `HomeWidgetsViewModel` to `HomeSectionsStorage` and refactor `HomeWidgetsView` to render manageable sections (`pinned`, `unread`, `myFavorites`, `recentlyEdited`, `objects`, `bin`) from `sectionsConfiguration.visibleSections` order. Default config matches the previous hardcoded order, so no regression on first launch.
- Add a "Manage sections" entry as the last item in the 3-dots menu (`WidgetsHeaderMenuContent`), separated by a `Divider()`. Closure routes through `WidgetsHeaderViewModel` → `HomeWidgetsViewModel` → new `HomeWidgetsModuleOutput.onManageSectionsSelected(spaceId:)`.
- Coordinator implements the new protocol method as an empty stub with a `TODO: IOS-6154` marker; the screen presentation lands when IOS-6154 (ManageSectionsView) is merged.

Note: per direction, this work ships without the `manageHomeSections` feature flag — only the new storage-driven path is maintained.