### PR TITLE
IOS-6154 Manage Sections screen

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorView.swift
@@ -87,6 +87,9 @@ private struct HomeWidgetsCoordinatorInternalView: View {
             .anytypeSheet(item: $model.qrCodeInviteData) {
                 QrCodeView(title: Loc.joinSpace, data: $0.value.absoluteString, analyticsType: .inviteSpace, route: .inviteLink)
             }
+            .sheet(isPresented: $model.showManageSections) {
+                ManageSectionsView(spaceId: model.spaceInfo.accountSpaceId)
+            }
             .sheet(isPresented: $model.showHomeChangePicker) {
                 HomepageSettingsPickerView(
                     spaceId: model.spaceInfo.accountSpaceId,

--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorViewModel.swift
@@ -20,6 +20,7 @@ final class HomeWidgetsCoordinatorViewModel: HomeWidgetsModuleOutput, SetObjectC
     var qrCodeInviteData: URLIdentifiable?
     var showHomeChangePicker = false
     var showHomepagePicker = false
+    var showManageSections = false
     var shouldDismissOverlay = false
 
     @Injected(\.legacySetObjectCreationCoordinator) @ObservationIgnored
@@ -130,8 +131,8 @@ final class HomeWidgetsCoordinatorViewModel: HomeWidgetsModuleOutput, SetObjectC
         qrCodeInviteData = url.identifiable
     }
 
-    func onManageSectionsSelected(spaceId: String) {
-        // TODO: IOS-6154 — present ManageSectionsView once the screen is merged.
+    func onManageSectionsSelected() {
+        showManageSections = true
     }
 
     // MARK: - SetObjectCreationCoordinatorOutput

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsModuleOutput.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsModuleOutput.swift
@@ -6,5 +6,5 @@ protocol HomeWidgetsModuleOutput: AnyObject, CommonWidgetModuleOutput {
     func onCreateObjectType()
     func onChangeHome()
     func onHomeObjectSelected(screenData: ScreenData)
-    func onManageSectionsSelected(spaceId: String)
+    func onManageSectionsSelected()
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -163,7 +163,7 @@ final class HomeWidgetsViewModel {
     }
 
     func onManageSectionsSelected() {
-        output?.onManageSectionsSelected(spaceId: info.accountSpaceId)
+        output?.onManageSectionsSelected()
     }
 
     func onCreateObjectType() {

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/HomeSection+Manage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/HomeSection+Manage.swift
@@ -1,11 +1,10 @@
 import Foundation
 
 extension HomeSection {
+    static let lockedSections: [HomeSection] = [.pinned, .unread]
+
     var isLocked: Bool {
-        switch self {
-        case .pinned, .unread: return true
-        case .myFavorites, .recentlyEdited, .objects, .bin: return false
-        }
+        Self.lockedSections.contains(self)
     }
 
     var localizedTitle: String {

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/HomeSection+Manage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/HomeSection+Manage.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension HomeSection {
+    var isLocked: Bool {
+        switch self {
+        case .pinned, .unread: return true
+        case .myFavorites, .recentlyEdited, .objects, .bin: return false
+        }
+    }
+
+    var localizedTitle: String {
+        switch self {
+        case .pinned:         return Loc.homeAndPinned
+        case .unread:         return Loc.unread
+        case .myFavorites:    return Loc.myFavorites
+        case .recentlyEdited: return Loc.recentlyEdited
+        case .objects:        return Loc.objects
+        case .bin:            return Loc.bin
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionRowView.swift
@@ -25,7 +25,9 @@ struct ManageSectionRowView: View {
         .contentShape(Rectangle())
         .onTapGesture {
             guard !isLocked else { return }
-            onToggle()
+            withAnimation {
+                onToggle()
+            }
         }
         .newDivider(leadingPadding: 16, trailingPadding: 16)
     }

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionRowView.swift
@@ -2,17 +2,19 @@ import SwiftUI
 import DesignKit
 
 struct ManageSectionRowView: View {
-    let row: ManageSectionsViewModel.Row
+    let title: String
+    let isLocked: Bool
+    let visible: Bool
     let onToggle: () -> Void
 
     var body: some View {
         HStack(spacing: 12) {
-            if row.isLocked {
+            if isLocked {
                 Color.clear.frame(width: 24, height: 24)
             } else {
-                AnytypeCircleCheckbox(checked: row.visible)
+                AnytypeCircleCheckbox(checked: visible)
             }
-            AnytypeText(row.title, style: .uxBodyRegular)
+            AnytypeText(title, style: .uxBodyRegular)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .foregroundStyle(Color.Text.primary)
@@ -22,7 +24,7 @@ struct ManageSectionRowView: View {
         .padding(.horizontal, 16)
         .contentShape(Rectangle())
         .onTapGesture {
-            guard !row.isLocked else { return }
+            guard !isLocked else { return }
             onToggle()
         }
         .newDivider(leadingPadding: 16, trailingPadding: 16)

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionRowView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import DesignKit
+
+struct ManageSectionRowView: View {
+    let row: ManageSectionsViewModel.Row
+    let onToggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            if row.isLocked {
+                Color.clear.frame(width: 24, height: 24)
+            } else {
+                AnytypeCircleCheckbox(checked: row.visible)
+            }
+            AnytypeText(row.title, style: .uxBodyRegular)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .foregroundStyle(Color.Text.primary)
+            Spacer(minLength: 0)
+        }
+        .frame(height: 52)
+        .padding(.horizontal, 16)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard !row.isLocked else { return }
+            onToggle()
+        }
+        .newDivider(leadingPadding: 16, trailingPadding: 16)
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct ManageSectionsView: View {
+    @State private var model: ManageSectionsViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    init(spaceId: String) {
+        _model = State(wrappedValue: ManageSectionsViewModel(spaceId: spaceId))
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(model.rows) { row in
+                    ManageSectionRowView(row: row) {
+                        model.onToggle(section: row.section)
+                    }
+                    .moveDisabled(row.isLocked)
+                    .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                    .listRowSeparator(.hidden)
+                }
+                .onMove { from, to in
+                    model.onMove(from: from, to: to)
+                }
+            }
+            .listStyle(.plain)
+            .environment(\.editMode, .constant(.active))
+            .navigationTitle(Loc.manageSections)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    if #available(iOS 26.0, *) {
+                        Button(role: .confirm) { dismiss() }
+                    } else {
+                        Button(Loc.done) { dismiss() }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsView.swift
@@ -11,11 +11,24 @@ struct ManageSectionsView: View {
     var body: some View {
         NavigationStack {
             List {
+                ForEach(model.lockedSections, id: \.self) { section in
+                    ManageSectionRowView(
+                        title: section.localizedTitle,
+                        isLocked: true,
+                        visible: true,
+                        onToggle: {}
+                    )
+                    .moveDisabled(true)
+                    .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                    .listRowSeparator(.hidden)
+                }
                 ForEach(model.rows) { row in
-                    ManageSectionRowView(row: row) {
-                        model.onToggle(section: row.section)
-                    }
-                    .moveDisabled(row.isLocked)
+                    ManageSectionRowView(
+                        title: row.section.localizedTitle,
+                        isLocked: false,
+                        visible: row.visible,
+                        onToggle: { model.onToggle(section: row.section) }
+                    )
                     .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
                     .listRowSeparator(.hidden)
                 }

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsViewModel.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SwiftUI
+import AnytypeCore
+
+@MainActor
+@Observable
+final class ManageSectionsViewModel {
+
+    struct Row: Identifiable {
+        let section: HomeSection
+        var visible: Bool
+        var id: HomeSection { section }
+        var isLocked: Bool { section.isLocked }
+        var title: String { section.localizedTitle }
+    }
+
+    private let spaceId: String
+
+    @ObservationIgnored
+    @Injected(\.homeSectionsStorage)
+    private var storage: any HomeSectionsStorageProtocol
+
+    var rows: [Row] = []
+
+    init(spaceId: String) {
+        self.spaceId = spaceId
+        let config = storage.configuration(spaceId: spaceId)
+        let visibleSections = config.visibleSections
+        let hiddenSections = HomeSection.allCases.filter { !visibleSections.contains($0) }
+        let visibleRows = visibleSections.map { Row(section: $0, visible: true) }
+        let hiddenRows = hiddenSections.map { Row(section: $0, visible: false) }
+        self.rows = visibleRows + hiddenRows
+        enforceLockedTop()
+    }
+
+    func onMove(from: IndexSet, to: Int) {
+        rows.move(fromOffsets: from, toOffset: to)
+        enforceLockedTop()
+        persist()
+    }
+
+    func onToggle(section: HomeSection) {
+        guard let index = rows.firstIndex(where: { $0.section == section }) else { return }
+        guard !rows[index].isLocked else { return }
+        rows[index].visible.toggle()
+        persist()
+    }
+
+    private func enforceLockedTop() {
+        if let pinnedIndex = rows.firstIndex(where: { $0.section == .pinned }), pinnedIndex != 0 {
+            let row = rows.remove(at: pinnedIndex)
+            rows.insert(row, at: 0)
+        }
+        if let unreadIndex = rows.firstIndex(where: { $0.section == .unread }) {
+            let pinnedExists = rows.contains(where: { $0.section == .pinned })
+            let target = pinnedExists ? 1 : 0
+            if unreadIndex != target {
+                let row = rows.remove(at: unreadIndex)
+                rows.insert(row, at: target)
+            }
+        }
+    }
+
+    private func persist() {
+        let visibleSections = rows.filter(\.visible).map(\.section)
+        storage.setConfiguration(
+            HomeSectionsConfiguration(visibleSections: visibleSections),
+            spaceId: spaceId
+        )
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsViewModel.swift
@@ -10,8 +10,6 @@ final class ManageSectionsViewModel {
         let section: HomeSection
         var visible: Bool
         var id: HomeSection { section }
-        var isLocked: Bool { section.isLocked }
-        var title: String { section.localizedTitle }
     }
 
     private let spaceId: String
@@ -20,51 +18,32 @@ final class ManageSectionsViewModel {
     @Injected(\.homeSectionsStorage)
     private var storage: any HomeSectionsStorageProtocol
 
+    let lockedSections: [HomeSection] = HomeSection.lockedSections
     var rows: [Row] = []
 
     init(spaceId: String) {
         self.spaceId = spaceId
         let config = storage.configuration(spaceId: spaceId)
-        let visibleSections = config.visibleSections
-        let hiddenSections = HomeSection.allCases.filter { !visibleSections.contains($0) }
-        let visibleRows = visibleSections.map { Row(section: $0, visible: true) }
-        let hiddenRows = hiddenSections.map { Row(section: $0, visible: false) }
-        self.rows = visibleRows + hiddenRows
-        enforceLockedTop()
+        let visible = config.visibleSections.filter { !$0.isLocked }
+        let hidden = HomeSection.allCases.filter { !$0.isLocked && !visible.contains($0) }
+        self.rows = (visible + hidden).map { Row(section: $0, visible: visible.contains($0)) }
     }
 
     func onMove(from: IndexSet, to: Int) {
         rows.move(fromOffsets: from, toOffset: to)
-        enforceLockedTop()
         persist()
     }
 
     func onToggle(section: HomeSection) {
         guard let index = rows.firstIndex(where: { $0.section == section }) else { return }
-        guard !rows[index].isLocked else { return }
         rows[index].visible.toggle()
         persist()
     }
 
-    private func enforceLockedTop() {
-        if let pinnedIndex = rows.firstIndex(where: { $0.section == .pinned }), pinnedIndex != 0 {
-            let row = rows.remove(at: pinnedIndex)
-            rows.insert(row, at: 0)
-        }
-        if let unreadIndex = rows.firstIndex(where: { $0.section == .unread }) {
-            let pinnedExists = rows.contains(where: { $0.section == .pinned })
-            let target = pinnedExists ? 1 : 0
-            if unreadIndex != target {
-                let row = rows.remove(at: unreadIndex)
-                rows.insert(row, at: target)
-            }
-        }
-    }
-
     private func persist() {
-        let visibleSections = rows.filter(\.visible).map(\.section)
+        let visible = HomeSection.lockedSections + rows.filter(\.visible).map(\.section)
         storage.setConfiguration(
-            HomeSectionsConfiguration(visibleSections: visibleSections),
+            HomeSectionsConfiguration(visibleSections: visible),
             spaceId: spaceId
         )
     }

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -383,6 +383,7 @@ public enum Loc {
   public static let highlight = Loc.tr("UI", "Highlight", fallback: "Highlight")
   public static let history = Loc.tr("UI", "History", fallback: "History")
   public static let home = Loc.tr("UI", "Home", fallback: "Home")
+  public static let homeAndPinned = Loc.tr("UI", "Home and Pinned", fallback: "Home and Pinned")
   public static let icon = Loc.tr("UI", "Icon", fallback: "Icon")
   public static func image(_ p1: Int) -> String {
     return Loc.tr("UI", "Image", p1, fallback: "Plural format key: Image")

--- a/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
@@ -49493,6 +49493,17 @@
         }
       }
     },
+    "Home and Pinned" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home and Pinned"
+          }
+        }
+      }
+    },
     "Home.Snackbar.Library" : {
       "comment" : "MARK: - Home",
       "extractionState" : "manual",


### PR DESCRIPTION
## Summary
- Adds the Manage Sections modal: drag-reorder + show/hide for the 4 toggleable home sections (My Favorites, Recently Edited, Objects, Bin); Pinned and Unread sit locked at the top.
- Wires the existing 3-dots menu entry from IOS-6155 to present the screen.
- iOS 26 uses `Button(role: .confirm)` for the Done action (system Liquid Glass circle); iOS 18 falls back to plain "Done".