### PR TITLE
IOS-6156 Home sections: analytics events

### DIFF
--- a/Anytype/Sources/Analytics/AnalyticsConstants.swift
+++ b/Anytype/Sources/Analytics/AnalyticsConstants.swift
@@ -59,6 +59,7 @@ enum AnalyticsEventsPropertiesKey {
     static let status = "status"
     static let uploadTime = "uploadTime"
     static let totalTime = "totalTime"
+    static let visible = "visible"
 }
 
 enum AnalyticsEventsTypeValues {

--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -633,7 +633,30 @@ extension AnytypeAnalytics {
             ]
         )
     }
-    
+
+    func logScreenManageSections() {
+        logEvent("ScreenManageSections")
+    }
+
+    func logReorderHomeSection(section: HomeSection) {
+        logEvent(
+            "ReorderHomeSection",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.type: section.analyticsId
+            ]
+        )
+    }
+
+    func logChangeHomeSectionVisibility(section: HomeSection, visible: Bool) {
+        logEvent(
+            "ChangeHomeSectionVisibility",
+            withEventProperties: [
+                AnalyticsEventsPropertiesKey.type: section.analyticsId,
+                AnalyticsEventsPropertiesKey.visible: visible
+            ]
+        )
+    }
+
     func logOpenSidebarGroupToggle(source: AnalyticsWidgetSource) {
         logEvent(
             "OpenSidebarGroupToggle",

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/HomeSection.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/HomeSection.swift
@@ -7,6 +7,17 @@ enum HomeSection: String, CaseIterable, Codable, Sendable {
     case recentlyEdited
     case objects
     case bin
+
+    var analyticsId: String {
+        switch self {
+        case .unread: "Unread"
+        case .pinned: "Pinned"
+        case .myFavorites: "MyFavorites"
+        case .recentlyEdited: "RecentlyEdited"
+        case .objects: "Objects"
+        case .bin: "Bin"
+        }
+    }
 }
 
 struct HomeSectionsConfiguration: Codable, Equatable, Sendable {

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsView.swift
@@ -40,6 +40,9 @@ struct ManageSectionsView: View {
             .environment(\.editMode, .constant(.active))
             .navigationTitle(Loc.manageSections)
             .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                AnytypeAnalytics.instance().logScreenManageSections()
+            }
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     if #available(iOS 26.0, *) {

--- a/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/ManageHomeSections/ManageSectionsViewModel.swift
@@ -30,14 +30,22 @@ final class ManageSectionsViewModel {
     }
 
     func onMove(from: IndexSet, to: Int) {
+        let movedSection = from.first.map { rows[$0].section }
         rows.move(fromOffsets: from, toOffset: to)
         persist()
+        if let movedSection {
+            AnytypeAnalytics.instance().logReorderHomeSection(section: movedSection)
+        }
     }
 
     func onToggle(section: HomeSection) {
         guard let index = rows.firstIndex(where: { $0.section == section }) else { return }
         rows[index].visible.toggle()
         persist()
+        AnytypeAnalytics.instance().logChangeHomeSectionVisibility(
+            section: section,
+            visible: rows[index].visible
+        )
     }
 
     private func persist() {


### PR DESCRIPTION
## Summary

- Adds analytics for the Manage Sections flow: `ScreenManageSections` (screen view), `ReorderHomeSection` (with section identifier), `ChangeHomeSectionVisibility` (with section identifier + new state).
- Introduces `HomeSection.analyticsId` returning PascalCase IDs (`Unread` / `Pinned` / `MyFavorites` / `RecentlyEdited` / `Objects` / `Bin`) — mirrors the existing `AnalyticsWidgetSource.analyticsId` convention.
- Empty-state AC met by existing auto-hide guards in `HomeWidgetsView` (RecentlyEdited / MyFavorites sections hide when their row list is empty — same behavior as desktop).