### PR TITLE
IOS-5980 Make SpaceView.uxType private and drop deprecation

### DIFF
--- a/AnyTypeTests/PresentationLayer/HomeWidgets/ParentObjectUnreadBadgeBuilderTests.swift
+++ b/AnyTypeTests/PresentationLayer/HomeWidgets/ParentObjectUnreadBadgeBuilderTests.swift
@@ -88,7 +88,6 @@ struct ParentObjectUnreadBadgeBuilderTests {
             writersLimit: nil,
             chatId: "",
             spaceOrder: "",
-            uxType: .data,
             spaceType: .regular,
             pushNotificationEncryptionKey: "",
             pushNotificationMode: pushMode,

--- a/AnyTypeTests/PresentationLayer/SpaceHub/SpaceHubSpacesStorageVisibleParentsTests.swift
+++ b/AnyTypeTests/PresentationLayer/SpaceHub/SpaceHubSpacesStorageVisibleParentsTests.swift
@@ -111,7 +111,6 @@ struct SpaceHubSpacesStorageVisibleParentsTests {
             writersLimit: nil,
             chatId: "",
             spaceOrder: "",
-            uxType: spaceType == .oneToOne ? .oneToOne : .data,
             spaceType: spaceType,
             pushNotificationEncryptionKey: "",
             pushNotificationMode: mode,

--- a/AnyTypeTests/PresentationLayer/SpaceHub/SpacePreviewCountersBuilderTests.swift
+++ b/AnyTypeTests/PresentationLayer/SpaceHub/SpacePreviewCountersBuilderTests.swift
@@ -231,7 +231,6 @@ struct SpacePreviewCountersBuilderTests {
             writersLimit: nil,
             chatId: "",
             spaceOrder: "",
-            uxType: spaceType == .oneToOne ? .oneToOne : .data,
             spaceType: spaceType,
             pushNotificationEncryptionKey: "",
             pushNotificationMode: mode,

--- a/AnyTypeTests/ServiceLayer/Badge/BadgeTotalCalculatorTests.swift
+++ b/AnyTypeTests/ServiceLayer/Badge/BadgeTotalCalculatorTests.swift
@@ -86,7 +86,7 @@ struct BadgeTotalCalculatorTests {
         let info = makeDiscussionInfo(messages: 5, subscribedMentions: 1, unsubscribedMentions: 1)
         let total = BadgeTotalCalculator.compute(
             previews: [],
-            spaceViews: [makeSpaceView(spaceId: spaceA, uxType: .oneToOne, spaceType: .oneToOne, pushMode: .mentions)],
+            spaceViews: [makeSpaceView(spaceId: spaceA, spaceType: .oneToOne, pushMode: .mentions)],
             chatDetails: [],
             discussionsBySpace: [spaceA: info]
         )
@@ -248,7 +248,6 @@ struct BadgeTotalCalculatorTests {
     private func makeSpaceView(
         spaceId: String,
         isActive: Bool = true,
-        uxType: SpaceUxType = .data,
         spaceType: SpaceType = .regular,
         pushMode: SpacePushNotificationsMode = .all,
         forceAllIds: [String] = [],
@@ -270,7 +269,6 @@ struct BadgeTotalCalculatorTests {
             writersLimit: nil,
             chatId: "",
             spaceOrder: "",
-            uxType: uxType,
             spaceType: spaceType,
             pushNotificationEncryptionKey: "",
             pushNotificationMode: pushMode,

--- a/Anytype/Sources/PreviewMocks/Mocks/Models/SpaceViewMock.swift
+++ b/Anytype/Sources/PreviewMocks/Mocks/Models/SpaceViewMock.swift
@@ -26,7 +26,6 @@ extension SpaceView {
             writersLimit: nil,
             chatId: Bool.random() ? "123" : "",
             spaceOrder: "",
-            uxType: .data,
             spaceType: .regular,
             pushNotificationEncryptionKey: "",
             pushNotificationMode: .allCases.randomElement()!,

--- a/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
+++ b/Anytype/Sources/ServiceLayer/SpaceStorage/Models/SpaceView.swift
@@ -17,8 +17,10 @@ struct SpaceView: Identifiable, Equatable, Hashable {
     let writersLimit: Int?
     let chatId: String
     let spaceOrder: String
-    @available(*, deprecated, message: "Use spaceType instead")
-    let uxType: SpaceUxType
+    // Legacy proto field. Kept only as a fallback for stream channels —
+    // they have no representation in `SpaceType`. Sole reader: `isLegacyStream`.
+    // Do not introduce new readers; use `spaceType` for all new logic.
+    private let uxType: SpaceUxType
     let spaceType: SpaceType
     let pushNotificationEncryptionKey: String
     let pushNotificationMode: SpacePushNotificationsMode
@@ -27,6 +29,56 @@ struct SpaceView: Identifiable, Equatable, Hashable {
     let forceMentionIds: [String]
     let oneToOneIdentity: String
     let homepage: SpaceHomepage
+
+    init(
+        id: String,
+        name: String,
+        description: String,
+        objectIconImage: Icon,
+        targetSpaceId: String,
+        createdDate: Date?,
+        joinDate: Date?,
+        accountStatus: SpaceStatus?,
+        localStatus: SpaceStatus?,
+        spaceAccessType: SpaceAccessType?,
+        readersLimit: Int?,
+        writersLimit: Int?,
+        chatId: String,
+        spaceOrder: String,
+        spaceType: SpaceType,
+        pushNotificationEncryptionKey: String,
+        pushNotificationMode: SpacePushNotificationsMode,
+        forceAllIds: [String],
+        forceMuteIds: [String],
+        forceMentionIds: [String],
+        oneToOneIdentity: String,
+        homepage: SpaceHomepage,
+        uxType: SpaceUxType = .data
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.objectIconImage = objectIconImage
+        self.targetSpaceId = targetSpaceId
+        self.createdDate = createdDate
+        self.joinDate = joinDate
+        self.accountStatus = accountStatus
+        self.localStatus = localStatus
+        self.spaceAccessType = spaceAccessType
+        self.readersLimit = readersLimit
+        self.writersLimit = writersLimit
+        self.chatId = chatId
+        self.spaceOrder = spaceOrder
+        self.uxType = uxType
+        self.spaceType = spaceType
+        self.pushNotificationEncryptionKey = pushNotificationEncryptionKey
+        self.pushNotificationMode = pushNotificationMode
+        self.forceAllIds = forceAllIds
+        self.forceMuteIds = forceMuteIds
+        self.forceMentionIds = forceMentionIds
+        self.oneToOneIdentity = oneToOneIdentity
+        self.homepage = homepage
+    }
 }
 
 extension SpaceView: DetailsModel {
@@ -119,7 +171,7 @@ extension SpaceView {
         spaceType == .oneToOne
     }
 
-    // Sole reader of the deprecated `uxType` field. Used only to enforce
+    // Sole reader of the legacy `uxType` field. Used only to enforce
     // owner-only-write on legacy stream spaces, which have no representation
     // in the new `SpaceType` enum.
     var isLegacyStream: Bool {


### PR DESCRIPTION
## Summary
- Drop `@available(*, deprecated)` on `SpaceView.uxType`, mark it `private`, and add a doc comment explaining it is retained as a fallback for legacy stream channels — `isLegacyStream` is the sole reader.
- Add an explicit memberwise `init` to `SpaceView` (with `uxType` as a defaulted last parameter) since making the field private would otherwise poison the synthesized memberwise init used by tests and mocks.
- Remove the `uxType:` argument from `SpaceViewMock` and four test fixtures; none were exercising `.stream`, so legacy-stream semantics are unchanged.