### PR TITLE
IOS-6159 Filter object types and other-user edits from Recently Edited

### DIFF
--- a/Anytype/Sources/ServiceLayer/Subscriptions/RecentSubscriptionService.swift
+++ b/Anytype/Sources/ServiceLayer/Subscriptions/RecentSubscriptionService.swift
@@ -51,7 +51,7 @@ final class RecentSubscriptionService: RecentSubscriptionServiceProtocol {
             SearchHelper.templateScheme(include: false)
             makeDateFilter(type: type, spaceId: spaceId)
             if type == .recentEdit {
-                SearchHelper.excludedRecomendedLayoutFilter([.participant])
+                SearchHelper.excludedRecommendedLayoutFilter([.participant])
                 if let participantId = currentParticipantId(spaceId: spaceId) {
                     SearchHelper.lastModifiedByFilter(participantId)
                 }

--- a/Anytype/Sources/ServiceLayer/Subscriptions/RecentSubscriptionService.swift
+++ b/Anytype/Sources/ServiceLayer/Subscriptions/RecentSubscriptionService.swift
@@ -25,6 +25,8 @@ final class RecentSubscriptionService: RecentSubscriptionServiceProtocol {
     private var workspaceStorage: any SpaceViewsStorageProtocol
     @Injected(\.subscriptionStorageProvider)
     private var subscriptionStorageProvider: any SubscriptionStorageProviderProtocol
+    @Injected(\.participantsStorage)
+    private var participantsStorage: any ParticipantsStorageProtocol
     private lazy var subscriptionStorage: any SubscriptionStorageProtocol = {
         subscriptionStorageProvider.createSubscriptionStorage(subId: subscriptionId)
     }()
@@ -45,9 +47,15 @@ final class RecentSubscriptionService: RecentSubscriptionServiceProtocol {
         let spaceType = workspaceStorage.spaceView(spaceId: spaceId)?.spaceType
         let filters: [DataviewFilter] = .builder {
             SearchHelper.notHiddenFilters()
-            SearchHelper.layoutFilter(DetailsLayout.visibleLayouts(spaceType: spaceType))
+            SearchHelper.layoutFilter(DetailsLayout.visibleLayoutsWithFiles(spaceType: spaceType))
             SearchHelper.templateScheme(include: false)
             makeDateFilter(type: type, spaceId: spaceId)
+            if type == .recentEdit {
+                SearchHelper.excludedRecomendedLayoutFilter([.participant])
+                if let participantId = currentParticipantId(spaceId: spaceId) {
+                    SearchHelper.lastModifiedByFilter(participantId)
+                }
+            }
         }
         
         let keys: [BundledPropertyKey] = .builder {
@@ -100,9 +108,13 @@ final class RecentSubscriptionService: RecentSubscriptionServiceProtocol {
         case .recentEdit:
             guard let spaceView = workspaceStorage.spaceView(spaceId: spaceId),
                   let createdDate = spaceView.createdDate else { return nil }
-            return SearchHelper.lastModifiedDateFrom(createdDate.addingTimeInterval(3))
+            return SearchHelper.lastModifiedDateFrom(createdDate.addingTimeInterval(10))
         case .recentOpen:
             return SearchHelper.lastOpenedDateNotNilFilter()
         }
+    }
+
+    private func currentParticipantId(spaceId: String) -> String? {
+        participantsStorage.participants.first { $0.spaceId == spaceId }?.id
     }
 }

--- a/Modules/Services/Sources/Services/SearchService/SearchHelper.swift
+++ b/Modules/Services/Sources/Services/SearchService/SearchHelper.swift
@@ -192,7 +192,7 @@ public class SearchHelper {
         return filter
     }
 
-    public static func excludedRecomendedLayoutFilter(_ layouts: [DetailsLayout]) -> DataviewFilter {
+    public static func excludedRecommendedLayoutFilter(_ layouts: [DetailsLayout]) -> DataviewFilter {
         var filter = DataviewFilter()
         filter.condition = .notIn
         filter.value = layouts.map(\.rawValue).protobufValue

--- a/Modules/Services/Sources/Services/SearchService/SearchHelper.swift
+++ b/Modules/Services/Sources/Services/SearchService/SearchHelper.swift
@@ -192,6 +192,14 @@ public class SearchHelper {
         return filter
     }
 
+    public static func excludedRecomendedLayoutFilter(_ layouts: [DetailsLayout]) -> DataviewFilter {
+        var filter = DataviewFilter()
+        filter.condition = .notIn
+        filter.value = layouts.map(\.rawValue).protobufValue
+        filter.relationKey = BundledPropertyKey.recommendedLayout.rawValue
+        return filter
+    }
+
     // MARK: - Relation Filters
 
     public static func relationKey(_ relationKey: String) -> DataviewFilter {
@@ -233,6 +241,16 @@ public class SearchHelper {
         filter.condition = .greaterOrEqual
         filter.value = date.timeIntervalSince1970.protobufValue
         filter.relationKey = BundledPropertyKey.lastModifiedDate.rawValue
+        filter.format = .date
+        filter.includeTime = true
+        return filter
+    }
+
+    public static func lastModifiedByFilter(_ participantId: String) -> DataviewFilter {
+        var filter = DataviewFilter()
+        filter.condition = .equal
+        filter.value = participantId.protobufValue
+        filter.relationKey = BundledPropertyKey.lastModifiedBy.rawValue
         return filter
     }
 


### PR DESCRIPTION
## Summary
- Excludes the Space Member object type from the Recently Edited home widget via `recommendedLayout NotIn [.participant]`, mirroring desktop's `recentEditMe` filter.
- Restricts results to items the current user last modified (`lastModifiedBy == currentParticipantId`) and bumps the post-creation buffer from `+3s` to `+10s` to match desktop's window for excluding bundled types.
- Fixes the date filter sent to middleware: `lastModifiedDateFrom` now sets `format = .date` and `includeTime = true` so the comparison is honored (without these the filter was silently ignored, letting auto-created types through).