### PR TITLE
IOS-6158 Extract Pinned section into PinnedSectionView/ViewModel

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetSubmoduleView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetSubmoduleView.swift
@@ -20,64 +20,66 @@ struct HomeWidgetSubmoduleView: View {
             viewForAnytypeWidgetId(anytypeWidgetId)
         }
     }
-    
+
     @ViewBuilder
     private func viewForAnytypeWidgetId(_ anytypeWidgetId: AnytypeWidgetId) -> some View {
         switch (anytypeWidgetId, widgetInfo.fixedLayout) {
         case (.pinned, .tree):
-            PinnedTreeWidgetsubmoduleView(data: widgetData)
+            PinnedTreeWidgetsubmoduleView(data: widgetData(prefetchedDetails: nil))
         case (.pinned, .list):
-            PinnedListWidgetSubmoduleView(data: widgetData)
+            PinnedListWidgetSubmoduleView(data: widgetData(prefetchedDetails: nil))
         case (.pinned, .compactList):
-            PinnedCompactListWidgetSubmoduleView(data: widgetData)
+            PinnedCompactListWidgetSubmoduleView(data: widgetData(prefetchedDetails: nil))
         case (.recent, .tree):
-            RecentEditTreeWidgetSubmoduleView(data: widgetData)
+            RecentEditTreeWidgetSubmoduleView(data: widgetData(prefetchedDetails: nil))
         case (.recent, .list):
-            RecentEditListWidgetSubmoduleView(data: widgetData)
+            RecentEditListWidgetSubmoduleView(data: widgetData(prefetchedDetails: nil))
         case (.recent, .compactList):
-            RecentEditCompactListWidgetSubmoduleView(data: widgetData)
+            RecentEditCompactListWidgetSubmoduleView(data: widgetData(prefetchedDetails: nil))
         case (.recentOpen, .tree):
-            RecentOpenTreeWidgetSubmoduleView(data: widgetData)
+            RecentOpenTreeWidgetSubmoduleView(data: widgetData(prefetchedDetails: nil))
         case (.recentOpen, .list):
-            RecentOpenListWidgetSubmoduleView(data: widgetData)
+            RecentOpenListWidgetSubmoduleView(data: widgetData(prefetchedDetails: nil))
         case (.recentOpen, .compactList):
-            RecentOpenCompactListWidgetSubmoduleView(data: widgetData)
+            RecentOpenCompactListWidgetSubmoduleView(data: widgetData(prefetchedDetails: nil))
         case _:
             EmptyView()
         }
     }
-        
+
     @ViewBuilder
     private func viewForObject(_ objectDetails: ObjectDetails) -> some View {
         if objectDetails.isNotDeletedAndArchived {
+            let data = widgetData(prefetchedDetails: objectDetails)
             switch (widgetInfo.fixedLayout, objectDetails.editorViewType) {
             case (.link, .page), (.link, .list), (.link, .type):
-                LinkWidgetView(data: widgetData)
+                LinkWidgetView(data: data)
             case (.tree, .page):
-                ObjectTreeWidgetSubmoduleView(data: widgetData)
+                ObjectTreeWidgetSubmoduleView(data: data)
             case (.view, .list), (.view, .type):
-                SetObjectViewWidgetSubmoduleView(data: widgetData)
+                SetObjectViewWidgetSubmoduleView(data: data)
             case (.list, .list), (.list, .type):
-                SetObjectListWidgetSubmoduleView(data: widgetData)
+                SetObjectListWidgetSubmoduleView(data: data)
             case (.compactList, .list), (.compactList, .type):
-                SetObjectCompactListWidgetSubmoduleView(data: widgetData)
+                SetObjectCompactListWidgetSubmoduleView(data: data)
             default:
                 // Fallback
-                LinkWidgetView(data: widgetData)
+                LinkWidgetView(data: data)
             }
         } else {
             EmptyView()
         }
     }
-    
-    private var widgetData: WidgetSubmoduleData {
+
+    private func widgetData(prefetchedDetails: ObjectDetails?) -> WidgetSubmoduleData {
         WidgetSubmoduleData(
             widgetBlockId: widgetInfo.id,
             channelWidgetsObject: channelWidgetsObject,
             personalWidgetsObject: personalWidgetsObject,
             homeState: $homeState,
             spaceInfo: workspaceInfo,
-            output: output
+            output: output,
+            prefetchedDetails: prefetchedDetails
         )
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -16,7 +16,6 @@ struct HomeWidgetsView: View {
 
 private struct HomeWidgetsInternalView: View {
     @State private var model: HomeWidgetsViewModel
-    @State var widgetsDndState = DragState()
 
     let context: WidgetScreenContext
     weak var panelOutput: (any HomeBottomNavigationPanelModuleOutput)?
@@ -32,7 +31,6 @@ private struct HomeWidgetsInternalView: View {
             HomeWallpaperView(spaceId: model.spaceId)
 
             content
-                .animation(.default, value: model.widgetBlocks.count)
                 .animation(.default, value: model.myFavoritesListViewModel.rows.count)
                 .animation(.default, value: model.recentlyEditedListViewModel.rows.count)
 
@@ -75,7 +73,7 @@ private struct HomeWidgetsInternalView: View {
     
     private var content: some View {
         ZStack {
-            if model.widgetsDataLoaded && model.objectTypesDataLoaded {
+            if model.objectTypesDataLoaded {
                 widgets
             }
         }
@@ -101,7 +99,13 @@ private struct HomeWidgetsInternalView: View {
     @ViewBuilder
     private func manageableSection(_ section: HomeSection) -> some View {
         switch section {
-        case .pinned: blockWidgets
+        case .pinned:
+            PinnedSectionView(
+                info: model.info,
+                channelWidgetsObject: model.channelWidgetsObject,
+                personalWidgetsObject: model.personalWidgetsObject,
+                output: model.output
+            )
         case .unread: unreadWidget
         case .myFavorites: myFavoritesWidget
         case .recentlyEdited: recentlyEditedWidget
@@ -127,30 +131,6 @@ private struct HomeWidgetsInternalView: View {
             }
             if model.unreadSectionIsExpanded {
                 UnreadItemsGroupedView(items: model.unreadItems)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var blockWidgets: some View {
-        if model.widgetBlocks.isNotEmpty {
-            VStack(spacing: 12) {
-                WidgetSwipeTipView()
-                ForEach(model.widgetBlocks) { widgetInfo in
-                    HomeWidgetSubmoduleView(
-                        widgetInfo: widgetInfo,
-                        channelWidgetsObject: model.channelWidgetsObject,
-                        personalWidgetsObject: model.personalWidgetsObject,
-                        workspaceInfo: model.info,
-                        homeState: $model.homeState,
-                        output: model.output
-                    )
-                }
-            }
-            .anytypeVerticalDrop(data: model.widgetBlocks, state: $widgetsDndState) { from, to in
-                model.widgetsDropUpdate(from: from, to: to)
-            } dropFinish: { from, to in
-                model.widgetsDropFinish(from: from, to: to)
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -72,11 +72,7 @@ private struct HomeWidgetsInternalView: View {
     }
     
     private var content: some View {
-        ZStack {
-            if model.objectTypesDataLoaded {
-                widgets
-            }
-        }
+        widgets
     }
     
     private var widgets: some View {
@@ -161,16 +157,18 @@ private struct HomeWidgetsInternalView: View {
 
     @ViewBuilder
     private var objectTypeWidgets: some View {
-        HomeWidgetsGroupView(title: Loc.types, onTap: {
-            model.onTapObjectTypeHeader()
-        }, onCreate: nil)
-        if model.objectTypeSectionIsExpanded {
-            ObjectTypesUnifiedWidgetView(
-                typeInfos: model.objectTypeWidgets,
-                canCreateType: model.canCreateObjectType,
-                onCreateType: { model.onCreateObjectType() },
-                output: model.output
-            )
+        if model.objectTypesDataLoaded {
+            HomeWidgetsGroupView(title: Loc.types, onTap: {
+                model.onTapObjectTypeHeader()
+            }, onCreate: nil)
+            if model.objectTypeSectionIsExpanded {
+                ObjectTypesUnifiedWidgetView(
+                    typeInfos: model.objectTypeWidgets,
+                    canCreateType: model.canCreateObjectType,
+                    onCreateType: { model.onCreateObjectType() },
+                    output: model.output
+                )
+            }
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -16,6 +16,7 @@ struct HomeWidgetsView: View {
 
 private struct HomeWidgetsInternalView: View {
     @State private var model: HomeWidgetsViewModel
+    @State private var pinnedWidgetsCount: Int = 0
 
     let context: WidgetScreenContext
     weak var panelOutput: (any HomeBottomNavigationPanelModuleOutput)?
@@ -31,6 +32,7 @@ private struct HomeWidgetsInternalView: View {
             HomeWallpaperView(spaceId: model.spaceId)
 
             content
+                .animation(.default, value: pinnedWidgetsCount)
                 .animation(.default, value: model.myFavoritesListViewModel.rows.count)
                 .animation(.default, value: model.recentlyEditedListViewModel.rows.count)
 
@@ -100,7 +102,8 @@ private struct HomeWidgetsInternalView: View {
                 info: model.info,
                 channelWidgetsObject: model.channelWidgetsObject,
                 personalWidgetsObject: model.personalWidgetsObject,
-                output: model.output
+                output: model.output,
+                onWidgetsCountChange: { pinnedWidgetsCount = $0 }
             )
         case .unread: unreadWidget
         case .myFavorites: myFavoritesWidget

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -31,7 +31,7 @@ private struct HomeWidgetsInternalView: View {
         ZStack(alignment: .bottom) {
             HomeWallpaperView(spaceId: model.spaceId)
 
-            content
+            widgets
                 .animation(.default, value: pinnedWidgetsCount)
                 .animation(.default, value: model.myFavoritesListViewModel.rows.count)
                 .animation(.default, value: model.recentlyEditedListViewModel.rows.count)
@@ -71,10 +71,6 @@ private struct HomeWidgetsInternalView: View {
         .navigationBarHidden(true)
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .homeBottomPanelHidden(context.showEmbeddedBottomPanel)
-    }
-    
-    private var content: some View {
-        widgets
     }
     
     private var widgets: some View {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -24,8 +24,6 @@ final class HomeWidgetsViewModel {
 
     @Injected(\.blockWidgetService) @ObservationIgnored
     private var blockWidgetService: any BlockWidgetServiceProtocol
-    @Injected(\.objectActionsService) @ObservationIgnored
-    private var objectActionService: any ObjectActionsServiceProtocol
     private let documentService: any OpenedDocumentsProviderProtocol = Container.shared.openedDocumentProvider()
     private let workspaceStorage: any SpaceViewsStorageProtocol = Container.shared.spaceViewsStorage()
     @Injected(\.documentsProvider) @ObservationIgnored
@@ -34,8 +32,6 @@ final class HomeWidgetsViewModel {
     private var accountParticipantStorage: any ParticipantsStorageProtocol
     @Injected(\.participantSpacesStorage) @ObservationIgnored
     private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
-    @Injected(\.homeWidgetsRecentStateManager) @ObservationIgnored
-    private var recentStateManager: any HomeWidgetsRecentStateManagerProtocol
     @Injected(\.objectTypeProvider) @ObservationIgnored
     private var objectTypeProvider: any ObjectTypeProviderProtocol
     @Injected(\.expandedService) @ObservationIgnored
@@ -55,11 +51,9 @@ final class HomeWidgetsViewModel {
     weak var output: (any HomeWidgetsModuleOutput)?
     
     // MARK: - State
-    
-    var widgetBlocks: [BlockWidgetInfo] = []
+
     var objectTypeWidgets: [ObjectTypeWidgetInfo] = []
     var homeState: HomeWidgetsState = .readonly
-    var widgetsDataLoaded: Bool = false
     var objectTypesDataLoaded: Bool = false
     var wallpaper: SpaceWallpaperType = .default
     var objectTypeSectionIsExpanded: Bool = false
@@ -118,7 +112,6 @@ final class HomeWidgetsViewModel {
     }
 
     func startSubscriptions() async {
-        async let widgetObjectSub: () = startWidgetObjectTask()
         async let myFavoritesSub: () = startMyFavoritesTask()
         async let recentlyEditedSub: () = startRecentlyEditedTask()
         async let canEditSub: () = startCanEditSubscription()
@@ -127,29 +120,13 @@ final class HomeWidgetsViewModel {
         async let unreadItemsTask: () = startUnreadItemsTask()
         async let sectionsConfigurationTask: () = startSectionsConfigurationTask()
 
-        _ = await (widgetObjectSub, myFavoritesSub, recentlyEditedSub, canEditSub, objectTypesTask, spaceViewTask, unreadItemsTask, sectionsConfigurationTask)
+        _ = await (myFavoritesSub, recentlyEditedSub, canEditSub, objectTypesTask, spaceViewTask, unreadItemsTask, sectionsConfigurationTask)
     }
 
     func onAppear() {
         AnytypeAnalytics.instance().logScreenWidget()
     }
 
-    func widgetsDropUpdate(from: DropDataElement<BlockWidgetInfo>, to: DropDataElement<BlockWidgetInfo>) {
-        widgetBlocks.move(fromOffsets: IndexSet(integer: from.index), toOffset: to.index)
-    }
-    
-    func widgetsDropFinish(from: DropDataElement<BlockWidgetInfo>, to: DropDataElement<BlockWidgetInfo>) {
-        AnytypeAnalytics.instance().logReorderWidget(source: from.data.source.analyticsSource)
-        Task {
-            try? await objectActionService.move(
-                dashboadId: channelWidgetsObject.objectId,
-                blockId: from.data.id,
-                dropPositionblockId: to.data.id,
-                position: to.index > from.index ? .bottom : .top
-            )
-        }
-    }
-    
     func onSpaceSelected() {
         output?.onSpaceSelected()
     }
@@ -199,22 +176,6 @@ final class HomeWidgetsViewModel {
     }
 
     // MARK: - Private
-    
-    private func startWidgetObjectTask() async {
-        for await _ in channelWidgetsObject.syncPublisher.values {
-            widgetsDataLoaded = true
-
-            let blocks = channelWidgetsObject.children.filter(\.isWidget)
-            recentStateManager.setupRecentStateIfNeeded(blocks: blocks, widgetObject: channelWidgetsObject)
-
-            let newWidgetBlocks = blocks
-                .compactMap { channelWidgetsObject.widgetInfo(block: $0) }
-
-            guard widgetBlocks != newWidgetBlocks else { continue }
-
-            widgetBlocks = newWidgetBlocks
-        }
-    }
 
     private func startMyFavoritesTask() async {
         await myFavoritesListViewModel.startSubscriptions()

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
@@ -13,4 +13,8 @@ struct WidgetSubmoduleData {
     let homeState: Binding<HomeWidgetsState>
     let spaceInfo: AccountInfo
     let output: (any CommonWidgetModuleOutput)?
+    /// Already-resolved details for `.object`-source widgets, lifted from
+    /// `BlockWidgetInfo` at dispatch time. Lets row VMs pre-seed name/icon
+    /// synchronously instead of rendering empty until their own publisher ticks.
+    let prefetchedDetails: ObjectDetails?
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
@@ -13,8 +13,6 @@ struct WidgetSubmoduleData {
     let homeState: Binding<HomeWidgetsState>
     let spaceInfo: AccountInfo
     let output: (any CommonWidgetModuleOutput)?
-    /// Already-resolved details for `.object`-source widgets, lifted from
-    /// `BlockWidgetInfo` at dispatch time. Lets row VMs pre-seed name/icon
-    /// synchronously instead of rendering empty until their own publisher ticks.
+    /// Pre-seeded object details for `.object`-source widgets, enabling synchronous first-render without an empty frame.
     let prefetchedDetails: ObjectDetails?
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Link/LinkWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Link/LinkWidgetViewModel.swift
@@ -52,6 +52,13 @@ final class LinkWidgetViewModel {
         self.widgetBlockId = data.widgetBlockId
         self.widgetObject = data.channelWidgetsObject
         self.output = data.output
+        // Pre-seed name/icon synchronously when the parent already resolved details for an
+        // `.object`-source widget. Avoids a frame of empty-row before the per-row publisher ticks.
+        if let details = data.prefetchedDetails {
+            self.linkedObjectDetails = details
+            self.name = details.pluralTitle
+            self.icon = details.objectIconImage
+        }
     }
     
     func onHeaderTap() {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Link/LinkWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Link/LinkWidgetViewModel.swift
@@ -52,8 +52,7 @@ final class LinkWidgetViewModel {
         self.widgetBlockId = data.widgetBlockId
         self.widgetObject = data.channelWidgetsObject
         self.output = data.output
-        // Pre-seed name/icon synchronously when the parent already resolved details for an
-        // `.object`-source widget. Avoids a frame of empty-row before the per-row publisher ticks.
+        // Avoid a frame of empty row before `widgetTargetDetailsPublisher` first ticks.
         if let details = data.prefetchedDetails {
             self.linkedObjectDetails = details
             self.name = details.pluralTitle

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
@@ -8,13 +8,15 @@ struct PinnedSectionView: View {
     let channelWidgetsObject: any BaseDocumentProtocol
     let personalWidgetsObject: any BaseDocumentProtocol
     weak var output: (any HomeWidgetsModuleOutput)?
+    let onWidgetsCountChange: (Int) -> Void
 
     var body: some View {
         PinnedSectionViewInternal(
             info: info,
             channelWidgetsObject: channelWidgetsObject,
             personalWidgetsObject: personalWidgetsObject,
-            output: output
+            output: output,
+            onWidgetsCountChange: onWidgetsCountChange
         )
     }
 }
@@ -32,7 +34,8 @@ private struct PinnedSectionViewInternal: View {
         info: AccountInfo,
         channelWidgetsObject: any BaseDocumentProtocol,
         personalWidgetsObject: any BaseDocumentProtocol,
-        output: (any HomeWidgetsModuleOutput)?
+        output: (any HomeWidgetsModuleOutput)?,
+        onWidgetsCountChange: @escaping (Int) -> Void
     ) {
         self.info = info
         self.personalWidgetsObject = personalWidgetsObject
@@ -40,7 +43,8 @@ private struct PinnedSectionViewInternal: View {
         self._model = State(
             wrappedValue: PinnedSectionViewModel(
                 spaceId: info.accountSpaceId,
-                channelWidgetsObject: channelWidgetsObject
+                channelWidgetsObject: channelWidgetsObject,
+                onWidgetsCountChange: onWidgetsCountChange
             )
         )
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
@@ -7,7 +7,7 @@ struct PinnedSectionView: View {
     let info: AccountInfo
     let channelWidgetsObject: any BaseDocumentProtocol
     let personalWidgetsObject: any BaseDocumentProtocol
-    weak var output: (any HomeWidgetsModuleOutput)?
+    weak var output: (any CommonWidgetModuleOutput)?
     let onWidgetsCountChange: (Int) -> Void
 
     var body: some View {
@@ -28,13 +28,13 @@ private struct PinnedSectionViewInternal: View {
 
     let info: AccountInfo
     let personalWidgetsObject: any BaseDocumentProtocol
-    weak var output: (any HomeWidgetsModuleOutput)?
+    weak var output: (any CommonWidgetModuleOutput)?
 
     init(
         info: AccountInfo,
         channelWidgetsObject: any BaseDocumentProtocol,
         personalWidgetsObject: any BaseDocumentProtocol,
-        output: (any HomeWidgetsModuleOutput)?,
+        output: (any CommonWidgetModuleOutput)?,
         onWidgetsCountChange: @escaping (Int) -> Void
     ) {
         self.info = info

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
@@ -1,0 +1,73 @@
+import Foundation
+import SwiftUI
+import Services
+
+struct PinnedSectionView: View {
+
+    let info: AccountInfo
+    let channelWidgetsObject: any BaseDocumentProtocol
+    let personalWidgetsObject: any BaseDocumentProtocol
+    weak var output: (any HomeWidgetsModuleOutput)?
+
+    var body: some View {
+        PinnedSectionViewInternal(
+            info: info,
+            channelWidgetsObject: channelWidgetsObject,
+            personalWidgetsObject: personalWidgetsObject,
+            output: output
+        )
+    }
+}
+
+private struct PinnedSectionViewInternal: View {
+
+    @State private var model: PinnedSectionViewModel
+    @State private var dndState = DragState()
+
+    init(
+        info: AccountInfo,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        personalWidgetsObject: any BaseDocumentProtocol,
+        output: (any HomeWidgetsModuleOutput)?
+    ) {
+        self._model = State(
+            wrappedValue: PinnedSectionViewModel(
+                info: info,
+                channelWidgetsObject: channelWidgetsObject,
+                personalWidgetsObject: personalWidgetsObject,
+                output: output
+            )
+        )
+    }
+
+    var body: some View {
+        content
+            .task {
+                await model.startSubscriptions()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if model.widgetBlocks.isNotEmpty {
+            VStack(spacing: 12) {
+                WidgetSwipeTipView()
+                ForEach(model.widgetBlocks) { widgetInfo in
+                    HomeWidgetSubmoduleView(
+                        widgetInfo: widgetInfo,
+                        channelWidgetsObject: model.channelWidgetsObject,
+                        personalWidgetsObject: model.personalWidgetsObject,
+                        workspaceInfo: model.info,
+                        homeState: $model.homeState,
+                        output: model.output
+                    )
+                }
+            }
+            .anytypeVerticalDrop(data: model.widgetBlocks, state: $dndState) { from, to in
+                model.widgetsDropUpdate(from: from, to: to)
+            } dropFinish: { from, to in
+                model.widgetsDropFinish(from: from, to: to)
+            }
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
@@ -66,7 +66,6 @@ private struct PinnedSectionViewInternal: View {
         } dropFinish: { from, to in
             model.widgetsDropFinish(from: from, to: to)
         }
-        .animation(.default, value: model.widgetBlocks.count)
         .task {
             await model.startSubscriptions()
         }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
@@ -24,18 +24,23 @@ private struct PinnedSectionViewInternal: View {
     @State private var model: PinnedSectionViewModel
     @State private var dndState = DragState()
 
+    let info: AccountInfo
+    let personalWidgetsObject: any BaseDocumentProtocol
+    weak var output: (any HomeWidgetsModuleOutput)?
+
     init(
         info: AccountInfo,
         channelWidgetsObject: any BaseDocumentProtocol,
         personalWidgetsObject: any BaseDocumentProtocol,
         output: (any HomeWidgetsModuleOutput)?
     ) {
+        self.info = info
+        self.personalWidgetsObject = personalWidgetsObject
+        self.output = output
         self._model = State(
             wrappedValue: PinnedSectionViewModel(
-                info: info,
-                channelWidgetsObject: channelWidgetsObject,
-                personalWidgetsObject: personalWidgetsObject,
-                output: output
+                spaceId: info.accountSpaceId,
+                channelWidgetsObject: channelWidgetsObject
             )
         )
     }
@@ -56,10 +61,10 @@ private struct PinnedSectionViewInternal: View {
                     HomeWidgetSubmoduleView(
                         widgetInfo: widgetInfo,
                         channelWidgetsObject: model.channelWidgetsObject,
-                        personalWidgetsObject: model.personalWidgetsObject,
-                        workspaceInfo: model.info,
+                        personalWidgetsObject: personalWidgetsObject,
+                        workspaceInfo: info,
                         homeState: $model.homeState,
-                        output: model.output
+                        output: output
                     )
                 }
             }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
@@ -46,16 +46,8 @@ private struct PinnedSectionViewInternal: View {
     }
 
     var body: some View {
-        content
-            .task {
-                await model.startSubscriptions()
-            }
-    }
-
-    @ViewBuilder
-    private var content: some View {
-        if model.widgetBlocks.isNotEmpty {
-            VStack(spacing: 12) {
+        VStack(spacing: 12) {
+            if model.widgetBlocks.isNotEmpty {
                 WidgetSwipeTipView()
                 ForEach(model.widgetBlocks) { widgetInfo in
                     HomeWidgetSubmoduleView(
@@ -68,11 +60,15 @@ private struct PinnedSectionViewInternal: View {
                     )
                 }
             }
-            .anytypeVerticalDrop(data: model.widgetBlocks, state: $dndState) { from, to in
-                model.widgetsDropUpdate(from: from, to: to)
-            } dropFinish: { from, to in
-                model.widgetsDropFinish(from: from, to: to)
-            }
+        }
+        .anytypeVerticalDrop(data: model.widgetBlocks, state: $dndState) { from, to in
+            model.widgetsDropUpdate(from: from, to: to)
+        } dropFinish: { from, to in
+            model.widgetsDropFinish(from: from, to: to)
+        }
+        .animation(.default, value: model.widgetBlocks.count)
+        .task {
+            await model.startSubscriptions()
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Services
+import AnytypeCore
+
+@MainActor
+@Observable
+final class PinnedSectionViewModel {
+
+    // MARK: - DI
+
+    @ObservationIgnored
+    let info: AccountInfo
+    @ObservationIgnored
+    let channelWidgetsObject: any BaseDocumentProtocol
+    @ObservationIgnored
+    let personalWidgetsObject: any BaseDocumentProtocol
+
+    @ObservationIgnored
+    weak var output: (any HomeWidgetsModuleOutput)?
+
+    @ObservationIgnored
+    @Injected(\.objectActionsService)
+    private var objectActionService: any ObjectActionsServiceProtocol
+    @ObservationIgnored
+    @Injected(\.homeWidgetsRecentStateManager)
+    private var recentStateManager: any HomeWidgetsRecentStateManagerProtocol
+    @ObservationIgnored
+    @Injected(\.participantsStorage)
+    private var participantsStorage: any ParticipantsStorageProtocol
+
+    // MARK: - State
+
+    var widgetBlocks: [BlockWidgetInfo] = []
+    var widgetsDataLoaded: Bool = false
+    var homeState: HomeWidgetsState = .readonly
+
+    init(
+        info: AccountInfo,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        personalWidgetsObject: any BaseDocumentProtocol,
+        output: (any HomeWidgetsModuleOutput)?
+    ) {
+        self.info = info
+        self.channelWidgetsObject = channelWidgetsObject
+        self.personalWidgetsObject = personalWidgetsObject
+        self.output = output
+    }
+
+    // MARK: - Subscriptions
+
+    func startSubscriptions() async {
+        async let widgetObjectSub: () = startWidgetObjectTask()
+        async let canEditSub: () = startCanEditSubscription()
+        _ = await (widgetObjectSub, canEditSub)
+    }
+
+    private func startWidgetObjectTask() async {
+        for await _ in channelWidgetsObject.syncPublisher.values {
+            widgetsDataLoaded = true
+
+            let blocks = channelWidgetsObject.children.filter(\.isWidget)
+            recentStateManager.setupRecentStateIfNeeded(blocks: blocks, widgetObject: channelWidgetsObject)
+
+            let newWidgetBlocks = blocks
+                .compactMap { channelWidgetsObject.widgetInfo(block: $0) }
+
+            guard widgetBlocks != newWidgetBlocks else { continue }
+
+            widgetBlocks = newWidgetBlocks
+        }
+    }
+
+    private func startCanEditSubscription() async {
+        for await canEdit in participantsStorage.canEditSequence(spaceId: info.accountSpaceId) {
+            homeState = canEdit ? .readwrite : .readonly
+        }
+    }
+
+    // MARK: - Drag-and-drop
+
+    func widgetsDropUpdate(from: DropDataElement<BlockWidgetInfo>, to: DropDataElement<BlockWidgetInfo>) {
+        widgetBlocks.move(fromOffsets: IndexSet(integer: from.index), toOffset: to.index)
+    }
+
+    func widgetsDropFinish(from: DropDataElement<BlockWidgetInfo>, to: DropDataElement<BlockWidgetInfo>) {
+        AnytypeAnalytics.instance().logReorderWidget(source: from.data.source.analyticsSource)
+        Task {
+            try? await objectActionService.move(
+                dashboadId: channelWidgetsObject.objectId,
+                blockId: from.data.id,
+                dropPositionblockId: to.data.id,
+                position: to.index > from.index ? .bottom : .top
+            )
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
@@ -63,8 +63,11 @@ final class PinnedSectionViewModel {
             // Update container's count AND Pinned's blocks atomically within the same
             // animation transaction so the parent VStack reflow animates in lockstep
             // with the section's own appearance.
+            let countChanged = widgetBlocks.count != newWidgetBlocks.count
             withAnimation(.default) {
-                onWidgetsCountChange?(newWidgetBlocks.count)
+                if countChanged {
+                    onWidgetsCountChange?(newWidgetBlocks.count)
+                }
                 widgetBlocks = newWidgetBlocks
             }
         }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
@@ -9,14 +9,9 @@ final class PinnedSectionViewModel {
     // MARK: - DI
 
     @ObservationIgnored
-    let info: AccountInfo
+    let spaceId: String
     @ObservationIgnored
     let channelWidgetsObject: any BaseDocumentProtocol
-    @ObservationIgnored
-    let personalWidgetsObject: any BaseDocumentProtocol
-
-    @ObservationIgnored
-    weak var output: (any HomeWidgetsModuleOutput)?
 
     @ObservationIgnored
     @Injected(\.objectActionsService)
@@ -31,19 +26,14 @@ final class PinnedSectionViewModel {
     // MARK: - State
 
     var widgetBlocks: [BlockWidgetInfo] = []
-    var widgetsDataLoaded: Bool = false
     var homeState: HomeWidgetsState = .readonly
 
     init(
-        info: AccountInfo,
-        channelWidgetsObject: any BaseDocumentProtocol,
-        personalWidgetsObject: any BaseDocumentProtocol,
-        output: (any HomeWidgetsModuleOutput)?
+        spaceId: String,
+        channelWidgetsObject: any BaseDocumentProtocol
     ) {
-        self.info = info
+        self.spaceId = spaceId
         self.channelWidgetsObject = channelWidgetsObject
-        self.personalWidgetsObject = personalWidgetsObject
-        self.output = output
     }
 
     // MARK: - Subscriptions
@@ -56,8 +46,6 @@ final class PinnedSectionViewModel {
 
     private func startWidgetObjectTask() async {
         for await _ in channelWidgetsObject.syncPublisher.values {
-            widgetsDataLoaded = true
-
             let blocks = channelWidgetsObject.children.filter(\.isWidget)
             recentStateManager.setupRecentStateIfNeeded(blocks: blocks, widgetObject: channelWidgetsObject)
 
@@ -71,7 +59,7 @@ final class PinnedSectionViewModel {
     }
 
     private func startCanEditSubscription() async {
-        for await canEdit in participantsStorage.canEditSequence(spaceId: info.accountSpaceId) {
+        for await canEdit in participantsStorage.canEditSequence(spaceId: spaceId) {
             homeState = canEdit ? .readwrite : .readonly
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
@@ -60,9 +60,7 @@ final class PinnedSectionViewModel {
 
             guard widgetBlocks != newWidgetBlocks else { continue }
 
-            // Update container's count AND Pinned's blocks atomically within the same
-            // animation transaction so the parent VStack reflow animates in lockstep
-            // with the section's own appearance.
+            // Animate count change and block update in the same transaction so parent VStack reflows in lockstep.
             let countChanged = widgetBlocks.count != newWidgetBlocks.count
             withAnimation(.default) {
                 if countChanged {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Services
 import AnytypeCore
 
@@ -54,7 +55,9 @@ final class PinnedSectionViewModel {
 
             guard widgetBlocks != newWidgetBlocks else { continue }
 
-            widgetBlocks = newWidgetBlocks
+            withAnimation(.default) {
+                widgetBlocks = newWidgetBlocks
+            }
         }
     }
 
@@ -67,7 +70,9 @@ final class PinnedSectionViewModel {
     // MARK: - Drag-and-drop
 
     func widgetsDropUpdate(from: DropDataElement<BlockWidgetInfo>, to: DropDataElement<BlockWidgetInfo>) {
-        widgetBlocks.move(fromOffsets: IndexSet(integer: from.index), toOffset: to.index)
+        withAnimation(.default) {
+            widgetBlocks.move(fromOffsets: IndexSet(integer: from.index), toOffset: to.index)
+        }
     }
 
     func widgetsDropFinish(from: DropDataElement<BlockWidgetInfo>, to: DropDataElement<BlockWidgetInfo>) {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
@@ -29,12 +29,17 @@ final class PinnedSectionViewModel {
     var widgetBlocks: [BlockWidgetInfo] = []
     var homeState: HomeWidgetsState = .readonly
 
+    @ObservationIgnored
+    private let onWidgetsCountChange: ((Int) -> Void)?
+
     init(
         spaceId: String,
-        channelWidgetsObject: any BaseDocumentProtocol
+        channelWidgetsObject: any BaseDocumentProtocol,
+        onWidgetsCountChange: ((Int) -> Void)? = nil
     ) {
         self.spaceId = spaceId
         self.channelWidgetsObject = channelWidgetsObject
+        self.onWidgetsCountChange = onWidgetsCountChange
     }
 
     // MARK: - Subscriptions
@@ -55,7 +60,11 @@ final class PinnedSectionViewModel {
 
             guard widgetBlocks != newWidgetBlocks else { continue }
 
+            // Update container's count AND Pinned's blocks atomically within the same
+            // animation transaction so the parent VStack reflow animates in lockstep
+            // with the section's own appearance.
             withAnimation(.default) {
+                onWidgetsCountChange?(newWidgetBlocks.count)
                 widgetBlocks = newWidgetBlocks
             }
         }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/ObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/ObjectWidgetInternalViewModel.swift
@@ -41,6 +41,14 @@ final class ObjectWidgetInternalViewModel: ObservableObject, WidgetInternalViewM
         self.widgetBlockId = data.widgetBlockId
         self.widgetObject = data.channelWidgetsObject
         self.output = data.output
+        // Pre-seed name/icon synchronously when the parent already resolved details for an
+        // `.object`-source widget. Avoids a frame of empty-row before the per-row publisher ticks.
+        if let details = data.prefetchedDetails {
+            self.linkedObjectDetails = details
+            self.name = details.title
+            self.icon = details.objectIconImage
+            self.allowCreateObject = details.permissions(participantCanEdit: true).canEditBlocks
+        }
     }
     
     func startHeaderSubscription() {}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/ObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/ObjectWidgetInternalViewModel.swift
@@ -41,8 +41,7 @@ final class ObjectWidgetInternalViewModel: ObservableObject, WidgetInternalViewM
         self.widgetBlockId = data.widgetBlockId
         self.widgetObject = data.channelWidgetsObject
         self.output = data.output
-        // Pre-seed name/icon synchronously when the parent already resolved details for an
-        // `.object`-source widget. Avoids a frame of empty-row before the per-row publisher ticks.
+        // Avoid a frame of empty row before `widgetTargetDetailsPublisher` first ticks.
         if let details = data.prefetchedDetails {
             self.linkedObjectDetails = details
             self.name = details.title

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
@@ -73,8 +73,7 @@ final class SetObjectWidgetInternalViewModel {
         let storageProvider = Container.shared.subscriptionStorageProvider.resolve()
         self.subscriptionStorage = storageProvider.createSubscriptionStorage(subId: subscriptionId)
 
-        // Pre-seed name/icon synchronously when the parent already resolved details for an
-        // `.object`-source widget. Avoids a frame of empty-row before the per-row publisher ticks.
+        // Avoid a frame of empty row before `targetDetailsPublisher` first ticks.
         if let details = data.prefetchedDetails {
             self.name = details.pluralTitle
             self.icon = details.objectIconImage

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
@@ -69,9 +69,16 @@ final class SetObjectWidgetInternalViewModel {
         self.style = style
         self.widgetObject = data.channelWidgetsObject
         self.output = data.output
-        
+
         let storageProvider = Container.shared.subscriptionStorageProvider.resolve()
         self.subscriptionStorage = storageProvider.createSubscriptionStorage(subId: subscriptionId)
+
+        // Pre-seed name/icon synchronously when the parent already resolved details for an
+        // `.object`-source widget. Avoids a frame of empty-row before the per-row publisher ticks.
+        if let details = data.prefetchedDetails {
+            self.name = details.pluralTitle
+            self.icon = details.objectIconImage
+        }
     }
     
     func startSubscriptions() async {


### PR DESCRIPTION
## Summary

- Extracts the locked-at-top **Pinned** section (channel widgets row + drag-and-drop reorder) out of `HomeWidgetsViewModel` into self-contained `PinnedSectionView` + `PinnedSectionViewModel`. Container shrinks by ~40 lines.
- Pre-seeds `LinkWidgetViewModel`, `ObjectWidgetInternalViewModel`, `SetObjectWidgetInternalViewModel` with `prefetchedDetails` from `BlockWidgetInfo` so widget rows render with title/icon synchronously instead of going through an empty-frame on first appearance.
- Restores section-appearance animation by routing Pinned's count change through a callback inside `withAnimation { ... }` so the parent VStack reflow animates in lockstep with the section growing.

PR 1 of 4 from `plans/PLAN_IOS_6158.md`. PRs 2–4 (Unread, Object Types, cleanup) follow.