### PR TITLE
IOS-6158 Extract Unread section into UnreadSectionView/ViewModel

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -17,6 +17,7 @@ struct HomeWidgetsView: View {
 private struct HomeWidgetsInternalView: View {
     @State private var model: HomeWidgetsViewModel
     @State private var pinnedWidgetsCount: Int = 0
+    @State private var shouldHideChatBadges: Bool = false
 
     let context: WidgetScreenContext
     weak var panelOutput: (any HomeBottomNavigationPanelModuleOutput)?
@@ -86,7 +87,7 @@ private struct HomeWidgetsInternalView: View {
             }
             .padding(.horizontal, 20)
             .fitIPadToReadableContentGuide()
-            .shouldHideChatBadges(model.shouldHideChatBadges)
+            .shouldHideChatBadges(shouldHideChatBadges)
         }
     }
 
@@ -101,7 +102,12 @@ private struct HomeWidgetsInternalView: View {
                 output: model.output,
                 onWidgetsCountChange: { pinnedWidgetsCount = $0 }
             )
-        case .unread: unreadWidget
+        case .unread:
+            UnreadSectionView(
+                spaceId: model.spaceId,
+                output: model.output,
+                onShouldHideBadgesChange: { shouldHideChatBadges = $0 }
+            )
         case .myFavorites: myFavoritesWidget
         case .recentlyEdited: recentlyEditedWidget
         case .objects: objectTypeWidgets
@@ -115,18 +121,6 @@ private struct HomeWidgetsInternalView: View {
             HomeWidgetView(data: data)
                 .id("\(data.objectId)-\(data.canSetHomepage)")
                 .padding(.bottom, 8)
-        }
-    }
-
-    @ViewBuilder
-    private var unreadWidget: some View {
-        if model.shouldShowUnreadSection {
-            HomeWidgetsGroupView(title: Loc.unread) {
-                model.onTapUnreadHeader()
-            }
-            if model.unreadSectionIsExpanded {
-                UnreadItemsGroupedView(items: model.unreadItems)
-            }
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -11,7 +11,6 @@ final class HomeWidgetsViewModel {
 
     private enum Constants {
         static let objectTypeSectionId = "HomeObjectTypeSection"
-        static let unreadSectionId = "HomeUnreadSection"
         static let myFavoritesSectionId = "HomeMyFavoritesSection"
         static let recentlyEditedSectionId = "HomeRecentlyEditedSection"
     }
@@ -36,14 +35,8 @@ final class HomeWidgetsViewModel {
     private var objectTypeProvider: any ObjectTypeProviderProtocol
     @Injected(\.expandedService) @ObservationIgnored
     private var expandedService: any ExpandedServiceProtocol
-    @Injected(\.chatMessagesPreviewsStorage) @ObservationIgnored
-    private var chatMessagesPreviewsStorage: any ChatMessagesPreviewsStorageProtocol
     @Injected(\.objectTypesWithObjectsCreatedService) @ObservationIgnored
     private var objectTypesWithObjectsCreatedService: any ObjectTypesWithObjectsCreatedServiceProtocol
-    @Injected(\.chatDetailsStorage) @ObservationIgnored
-    private var chatDetailsStorage: any ChatDetailsStorageProtocol
-    @Injected(\.objectsWithUnreadDiscussionsSubscription) @ObservationIgnored
-    private var unreadDiscussionsSubscription: any ObjectsWithUnreadDiscussionsSubscriptionProtocol
     @Injected(\.homeSectionsStorage) @ObservationIgnored
     private var homeSectionsStorage: any HomeSectionsStorageProtocol
 
@@ -59,24 +52,13 @@ final class HomeWidgetsViewModel {
     var objectTypeSectionIsExpanded: Bool = false
     var canCreateObjectType: Bool = false
     var homeWidgetData: HomepageWidgetViewData?
-    var unreadSectionIsExpanded: Bool = false
-    var unreadItems: [UnreadSectionItem] = []
     var myFavoritesSectionIsExpanded: Bool = false
     var myFavoritesListViewModel: MyFavoritesListViewModel
     var recentlyEditedSectionIsExpanded: Bool = false
     var recentlyEditedListViewModel: RecentlyEditedListViewModel
     var sectionsConfiguration: HomeSectionsConfiguration = .default
-    private var supportsMultiChats: Bool = false
 
     var spaceId: String { info.accountSpaceId }
-
-    var shouldShowUnreadSection: Bool {
-        supportsMultiChats && unreadItems.isNotEmpty
-    }
-
-    var shouldHideChatBadges: Bool {
-        shouldShowUnreadSection && unreadSectionIsExpanded
-    }
 
     init(
         info: AccountInfo,
@@ -106,7 +88,6 @@ final class HomeWidgetsViewModel {
             }
         )
         self.objectTypeSectionIsExpanded = expandedService.isExpanded(id: Constants.objectTypeSectionId, defaultValue: true)
-        self.unreadSectionIsExpanded = expandedService.isExpanded(id: Constants.unreadSectionId, defaultValue: true)
         self.myFavoritesSectionIsExpanded = expandedService.isExpanded(id: Constants.myFavoritesSectionId, defaultValue: true)
         self.recentlyEditedSectionIsExpanded = expandedService.isExpanded(id: Constants.recentlyEditedSectionId, defaultValue: true)
     }
@@ -117,10 +98,9 @@ final class HomeWidgetsViewModel {
         async let canEditSub: () = startCanEditSubscription()
         async let objectTypesTask: () = startObjectTypesTask()
         async let spaceViewTask: () = startSpaceViewTask()
-        async let unreadItemsTask: () = startUnreadItemsTask()
         async let sectionsConfigurationTask: () = startSectionsConfigurationTask()
 
-        _ = await (myFavoritesSub, recentlyEditedSub, canEditSub, objectTypesTask, spaceViewTask, unreadItemsTask, sectionsConfigurationTask)
+        _ = await (myFavoritesSub, recentlyEditedSub, canEditSub, objectTypesTask, spaceViewTask, sectionsConfigurationTask)
     }
 
     func onAppear() {
@@ -152,13 +132,6 @@ final class HomeWidgetsViewModel {
             objectTypeSectionIsExpanded = !objectTypeSectionIsExpanded
         }
         expandedService.setState(id: Constants.objectTypeSectionId, isExpanded: objectTypeSectionIsExpanded)
-    }
-
-    func onTapUnreadHeader() {
-        withAnimation {
-            unreadSectionIsExpanded = !unreadSectionIsExpanded
-        }
-        expandedService.setState(id: Constants.unreadSectionId, isExpanded: unreadSectionIsExpanded)
     }
 
     func onTapMyFavoritesHeader() {
@@ -236,7 +209,6 @@ final class HomeWidgetsViewModel {
 
         for await participantSpaceView in participantSpacesStorage.participantSpaceViewPublisher(spaceId: spaceId).values {
             let spaceView = participantSpaceView.spaceView
-            supportsMultiChats = !spaceView.isOneToOne
 
             // Home widget renders whichever object is set as homepage (Chat / Page / Collection).
             // 1-on-1 channels always home on Chat; `SpaceView.homepage` is unreliable there
@@ -300,58 +272,4 @@ final class HomeWidgetsViewModel {
         }
     }
 
-    private func startUnreadItemsTask() async {
-        let spaceId = spaceId
-        let spaceView = workspaceStorage.spaceView(spaceId: spaceId)
-        guard !(spaceView?.isOneToOne ?? true) else { return }
-
-        let previewsSequence = await chatMessagesPreviewsStorage.previewsSequenceWithEmpty
-        let chatsSequence = await chatDetailsStorage.allChatsSequence
-        let spaceViewSequence = workspaceStorage.spaceViewPublisher(spaceId: spaceId).removeDuplicates().values
-        let unreadDiscussionsSequence = await unreadDiscussionsSubscription.unreadBySpaceSequence
-
-        // combineLatest is max-arity 3 — nest two pairs.
-        let chatTriple = combineLatest(previewsSequence, chatsSequence, spaceViewSequence)
-        for await (triple, unreadBySpace) in combineLatest(chatTriple, unreadDiscussionsSequence) {
-            let (previews, chatDetails, currentSpaceView) = triple
-
-            let chatItems: [UnreadSectionItem] = previews.compactMap { preview in
-                guard preview.spaceId == spaceId else { return nil }
-
-                if FeatureFlags.muteAndHide {
-                    let mode = currentSpaceView.effectiveNotificationMode(for: preview.chatId)
-                    if mode == .nothing {
-                        guard preview.mentionCounter > 0 || preview.hasUnreadReactions else { return nil }
-                    }
-                }
-
-                guard preview.hasCounters else { return nil }
-                guard let chatDetail = chatDetails.first(where: { $0.id == preview.chatId }), !chatDetail.isArchivedOrDeleted else {
-                    return nil
-                }
-                return .chat(
-                    UnreadChatWidgetData(id: preview.chatId, spaceId: spaceId, output: output),
-                    lastMessageDate: preview.lastMessage?.createdAt
-                )
-            }
-
-            let parentSource = FeatureFlags.discussionButton ? (unreadBySpace[spaceId]?.parents ?? []) : []
-            let parentItems: [UnreadSectionItem] = parentSource.compactMap { parent in
-                if FeatureFlags.muteAndHide && currentSpaceView.pushNotificationMode == .nothing {
-                    guard parent.hasUnreadMention else { return nil }
-                }
-                // Aggregator admits any subscribed parent; drop fully-caught-up rows here so the section
-                // never shows a name with no badge. Mirrors the chat path's `hasCounters` guard.
-                guard parent.unreadMessageCount > 0 || parent.hasUnreadMention else { return nil }
-                return .discussionParent(
-                    UnreadDiscussionParentWidgetData(id: parent.id, spaceId: spaceId, output: output),
-                    lastMessageDate: parent.lastMessageDate
-                )
-            }
-
-            let merged = (chatItems + parentItems).sorted { $0.sortDate > $1.sortDate }
-            guard unreadItems != merged else { continue }
-            unreadItems = merged
-        }
-    }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionView.swift
@@ -46,7 +46,7 @@ private struct UnreadSectionViewInternal: View {
         .task {
             await model.startSubscriptions()
         }
-        .onChange(of: model.shouldHideChatBadges, initial: true) { _, newValue in
+        .onChange(of: model.shouldHideChatBadges) { _, newValue in
             onShouldHideBadgesChange(newValue)
         }
         .onDisappear {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionView.swift
@@ -1,0 +1,57 @@
+import Foundation
+import SwiftUI
+import Services
+
+struct UnreadSectionView: View {
+
+    let spaceId: String
+    weak var output: (any CommonWidgetModuleOutput)?
+    let onShouldHideBadgesChange: (Bool) -> Void
+
+    var body: some View {
+        UnreadSectionViewInternal(
+            spaceId: spaceId,
+            output: output,
+            onShouldHideBadgesChange: onShouldHideBadgesChange
+        )
+    }
+}
+
+private struct UnreadSectionViewInternal: View {
+
+    @State private var model: UnreadSectionViewModel
+    let onShouldHideBadgesChange: (Bool) -> Void
+
+    init(
+        spaceId: String,
+        output: (any CommonWidgetModuleOutput)?,
+        onShouldHideBadgesChange: @escaping (Bool) -> Void
+    ) {
+        self.onShouldHideBadgesChange = onShouldHideBadgesChange
+        self._model = State(wrappedValue: UnreadSectionViewModel(spaceId: spaceId, output: output))
+    }
+
+    var body: some View {
+        // Outer always-rendered VStack so .task attaches to a stable view across the empty→non-empty transition.
+        VStack(spacing: 0) {
+            if model.shouldShowUnreadSection {
+                HomeWidgetsGroupView(title: Loc.unread) {
+                    model.onTapUnreadHeader()
+                }
+                if model.unreadSectionIsExpanded {
+                    UnreadItemsGroupedView(items: model.unreadItems)
+                }
+            }
+        }
+        .task {
+            await model.startSubscriptions()
+        }
+        .onChange(of: model.shouldHideChatBadges, initial: true) { _, newValue in
+            onShouldHideBadgesChange(newValue)
+        }
+        .onDisappear {
+            // Section toggled off via Manage Sections — reset so chat badges aren't stuck hidden in sibling sections.
+            onShouldHideBadgesChange(false)
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -1,0 +1,124 @@
+import Foundation
+import SwiftUI
+import Services
+import AnytypeCore
+import AsyncAlgorithms
+
+@MainActor
+@Observable
+final class UnreadSectionViewModel {
+
+    // MARK: - DI
+
+    @ObservationIgnored
+    let spaceId: String
+    @ObservationIgnored
+    weak var output: (any CommonWidgetModuleOutput)?
+
+    @ObservationIgnored
+    @Injected(\.expandedService)
+    private var expandedService: any ExpandedServiceProtocol
+    @ObservationIgnored
+    @Injected(\.chatMessagesPreviewsStorage)
+    private var chatMessagesPreviewsStorage: any ChatMessagesPreviewsStorageProtocol
+    @ObservationIgnored
+    @Injected(\.chatDetailsStorage)
+    private var chatDetailsStorage: any ChatDetailsStorageProtocol
+    @ObservationIgnored
+    @Injected(\.objectsWithUnreadDiscussionsSubscription)
+    private var unreadDiscussionsSubscription: any ObjectsWithUnreadDiscussionsSubscriptionProtocol
+    private let workspaceStorage: any SpaceViewsStorageProtocol = Container.shared.spaceViewsStorage()
+
+    // MARK: - State
+
+    var unreadItems: [UnreadSectionItem] = []
+    var unreadSectionIsExpanded: Bool = false
+    var supportsMultiChats: Bool = false
+
+    var shouldShowUnreadSection: Bool { supportsMultiChats && unreadItems.isNotEmpty }
+    var shouldHideChatBadges: Bool { shouldShowUnreadSection && unreadSectionIsExpanded }
+
+    private static let expandedStorageId = "HomeUnreadSection"
+
+    init(spaceId: String, output: (any CommonWidgetModuleOutput)?) {
+        self.spaceId = spaceId
+        self.output = output
+        self.unreadSectionIsExpanded = expandedService.isExpanded(id: Self.expandedStorageId, defaultValue: true)
+    }
+
+    // MARK: - Subscriptions
+
+    func startSubscriptions() async {
+        async let unreadSub: () = startUnreadItemsTask()
+        async let spaceViewSub: () = startSpaceViewTask()
+        _ = await (unreadSub, spaceViewSub)
+    }
+
+    func onTapUnreadHeader() {
+        withAnimation {
+            unreadSectionIsExpanded.toggle()
+        }
+        expandedService.setState(id: Self.expandedStorageId, isExpanded: unreadSectionIsExpanded)
+    }
+
+    private func startSpaceViewTask() async {
+        for await spaceView in workspaceStorage.spaceViewPublisher(spaceId: spaceId).removeDuplicates().values {
+            supportsMultiChats = !spaceView.isOneToOne
+        }
+    }
+
+    private func startUnreadItemsTask() async {
+        let spaceId = spaceId
+        let spaceView = workspaceStorage.spaceView(spaceId: spaceId)
+        guard !(spaceView?.isOneToOne ?? true) else { return }
+
+        let previewsSequence = await chatMessagesPreviewsStorage.previewsSequenceWithEmpty
+        let chatsSequence = await chatDetailsStorage.allChatsSequence
+        let spaceViewSequence = workspaceStorage.spaceViewPublisher(spaceId: spaceId).removeDuplicates().values
+        let unreadDiscussionsSequence = await unreadDiscussionsSubscription.unreadBySpaceSequence
+
+        // combineLatest is max-arity 3 — nest two pairs.
+        let chatTriple = combineLatest(previewsSequence, chatsSequence, spaceViewSequence)
+        for await (triple, unreadBySpace) in combineLatest(chatTriple, unreadDiscussionsSequence) {
+            let (previews, chatDetails, currentSpaceView) = triple
+
+            let chatItems: [UnreadSectionItem] = previews.compactMap { preview in
+                guard preview.spaceId == spaceId else { return nil }
+
+                if FeatureFlags.muteAndHide {
+                    let mode = currentSpaceView.effectiveNotificationMode(for: preview.chatId)
+                    if mode == .nothing {
+                        guard preview.mentionCounter > 0 || preview.hasUnreadReactions else { return nil }
+                    }
+                }
+
+                guard preview.hasCounters else { return nil }
+                guard let chatDetail = chatDetails.first(where: { $0.id == preview.chatId }), !chatDetail.isArchivedOrDeleted else {
+                    return nil
+                }
+                return .chat(
+                    UnreadChatWidgetData(id: preview.chatId, spaceId: spaceId, output: output),
+                    lastMessageDate: preview.lastMessage?.createdAt
+                )
+            }
+
+            let parentSource = FeatureFlags.discussionButton ? (unreadBySpace[spaceId]?.parents ?? []) : []
+            let parentItems: [UnreadSectionItem] = parentSource.compactMap { parent in
+                if FeatureFlags.muteAndHide && currentSpaceView.pushNotificationMode == .nothing {
+                    guard parent.hasUnreadMention else { return nil }
+                }
+                // Aggregator admits any subscribed parent; drop fully-caught-up rows here so the section
+                // never shows a name with no badge. Mirrors the chat path's `hasCounters` guard.
+                guard parent.unreadMessageCount > 0 || parent.hasUnreadMention else { return nil }
+                return .discussionParent(
+                    UnreadDiscussionParentWidgetData(id: parent.id, spaceId: spaceId, output: output),
+                    lastMessageDate: parent.lastMessageDate
+                )
+            }
+
+            let merged = (chatItems + parentItems).sorted { $0.sortDate > $1.sortDate }
+            guard unreadItems != merged else { continue }
+            unreadItems = merged
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -27,13 +27,15 @@ final class UnreadSectionViewModel {
     @ObservationIgnored
     @Injected(\.objectsWithUnreadDiscussionsSubscription)
     private var unreadDiscussionsSubscription: any ObjectsWithUnreadDiscussionsSubscriptionProtocol
-    private let workspaceStorage: any SpaceViewsStorageProtocol = Container.shared.spaceViewsStorage()
+    @ObservationIgnored
+    @Injected(\.spaceViewsStorage)
+    private var workspaceStorage: any SpaceViewsStorageProtocol
 
     // MARK: - State
 
     var unreadItems: [UnreadSectionItem] = []
     var unreadSectionIsExpanded: Bool = false
-    var supportsMultiChats: Bool = false
+    private var supportsMultiChats: Bool = false
 
     var shouldShowUnreadSection: Bool { supportsMultiChats && unreadItems.isNotEmpty }
     var shouldHideChatBadges: Bool { shouldShowUnreadSection && unreadSectionIsExpanded }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -56,7 +56,7 @@ final class UnreadSectionViewModel {
 
     func onTapUnreadHeader() {
         withAnimation {
-            unreadSectionIsExpanded.toggle()
+            unreadSectionIsExpanded = !unreadSectionIsExpanded
         }
         expandedService.setState(id: Self.expandedStorageId, isExpanded: unreadSectionIsExpanded)
     }


### PR DESCRIPTION
## Summary

- Move the Unread section out of `HomeWidgetsViewModel` into a self-contained `UnreadSectionView` + `UnreadSectionViewModel` pair, mirroring the Pinned shape from #4928. Verbatim move of the 4-sequence `combineLatest` pipeline including `removeDuplicates()`, `guard unreadItems != merged`, and the `FeatureFlags.muteAndHide` / `FeatureFlags.discussionButton` branches.
- The container's `.shouldHideChatBadges(...)` modifier now reads a local `@State` synced from the section VM via `.onChange(of: model.shouldHideChatBadges)`, with `.onDisappear` resetting the flag when the section is hidden through Manage Sections.
- VM uses `@Injected(\.spaceViewsStorage)`, keeps `supportsMultiChats` private, preserves the `"HomeUnreadSection"` UserDefaults key. PR 2 of 4 in the master plan; stacks on #4928.