### PR TITLE
IOS-6158 Extract Object Types section into ObjectTypesSectionView/ViewModel

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -110,7 +110,12 @@ private struct HomeWidgetsInternalView: View {
             )
         case .myFavorites: myFavoritesWidget
         case .recentlyEdited: recentlyEditedWidget
-        case .objects: objectTypeWidgets
+        case .objects:
+            ObjectTypesSectionView(
+                spaceId: model.spaceId,
+                output: model.output,
+                onCreateObjectType: { model.output?.onCreateObjectType() }
+            )
         case .bin: binWidget
         }
     }
@@ -144,23 +149,6 @@ private struct HomeWidgetsInternalView: View {
             }
             if model.recentlyEditedSectionIsExpanded {
                 RecentlyEditedListView(model: model.recentlyEditedListViewModel)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var objectTypeWidgets: some View {
-        if model.objectTypesDataLoaded {
-            HomeWidgetsGroupView(title: Loc.types, onTap: {
-                model.onTapObjectTypeHeader()
-            }, onCreate: nil)
-            if model.objectTypeSectionIsExpanded {
-                ObjectTypesUnifiedWidgetView(
-                    typeInfos: model.objectTypeWidgets,
-                    canCreateType: model.canCreateObjectType,
-                    onCreateType: { model.onCreateObjectType() },
-                    output: model.output
-                )
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -10,7 +10,6 @@ import AsyncAlgorithms
 final class HomeWidgetsViewModel {
 
     private enum Constants {
-        static let objectTypeSectionId = "HomeObjectTypeSection"
         static let myFavoritesSectionId = "HomeMyFavoritesSection"
         static let recentlyEditedSectionId = "HomeRecentlyEditedSection"
     }
@@ -31,12 +30,8 @@ final class HomeWidgetsViewModel {
     private var accountParticipantStorage: any ParticipantsStorageProtocol
     @Injected(\.participantSpacesStorage) @ObservationIgnored
     private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
-    @Injected(\.objectTypeProvider) @ObservationIgnored
-    private var objectTypeProvider: any ObjectTypeProviderProtocol
     @Injected(\.expandedService) @ObservationIgnored
     private var expandedService: any ExpandedServiceProtocol
-    @Injected(\.objectTypesWithObjectsCreatedService) @ObservationIgnored
-    private var objectTypesWithObjectsCreatedService: any ObjectTypesWithObjectsCreatedServiceProtocol
     @Injected(\.homeSectionsStorage) @ObservationIgnored
     private var homeSectionsStorage: any HomeSectionsStorageProtocol
 
@@ -45,12 +40,8 @@ final class HomeWidgetsViewModel {
     
     // MARK: - State
 
-    var objectTypeWidgets: [ObjectTypeWidgetInfo] = []
     var homeState: HomeWidgetsState = .readonly
-    var objectTypesDataLoaded: Bool = false
     var wallpaper: SpaceWallpaperType = .default
-    var objectTypeSectionIsExpanded: Bool = false
-    var canCreateObjectType: Bool = false
     var homeWidgetData: HomepageWidgetViewData?
     var myFavoritesSectionIsExpanded: Bool = false
     var myFavoritesListViewModel: MyFavoritesListViewModel
@@ -87,7 +78,6 @@ final class HomeWidgetsViewModel {
                 output?.onObjectSelected(screenData: details.screenData())
             }
         )
-        self.objectTypeSectionIsExpanded = expandedService.isExpanded(id: Constants.objectTypeSectionId, defaultValue: true)
         self.myFavoritesSectionIsExpanded = expandedService.isExpanded(id: Constants.myFavoritesSectionId, defaultValue: true)
         self.recentlyEditedSectionIsExpanded = expandedService.isExpanded(id: Constants.recentlyEditedSectionId, defaultValue: true)
     }
@@ -96,11 +86,10 @@ final class HomeWidgetsViewModel {
         async let myFavoritesSub: () = startMyFavoritesTask()
         async let recentlyEditedSub: () = startRecentlyEditedTask()
         async let canEditSub: () = startCanEditSubscription()
-        async let objectTypesTask: () = startObjectTypesTask()
         async let spaceViewTask: () = startSpaceViewTask()
         async let sectionsConfigurationTask: () = startSectionsConfigurationTask()
 
-        _ = await (myFavoritesSub, recentlyEditedSub, canEditSub, objectTypesTask, spaceViewTask, sectionsConfigurationTask)
+        _ = await (myFavoritesSub, recentlyEditedSub, canEditSub, spaceViewTask, sectionsConfigurationTask)
     }
 
     func onAppear() {
@@ -121,17 +110,6 @@ final class HomeWidgetsViewModel {
 
     func onManageSectionsSelected() {
         output?.onManageSectionsSelected()
-    }
-
-    func onCreateObjectType() {
-        output?.onCreateObjectType()
-    }
-    
-    func onTapObjectTypeHeader() {
-        withAnimation {
-            objectTypeSectionIsExpanded = !objectTypeSectionIsExpanded
-        }
-        expandedService.setState(id: Constants.objectTypeSectionId, isExpanded: objectTypeSectionIsExpanded)
     }
 
     func onTapMyFavoritesHeader() {
@@ -167,33 +145,6 @@ final class HomeWidgetsViewModel {
     private func startCanEditSubscription() async {
         for await canEdit in accountParticipantStorage.canEditSequence(spaceId: info.accountSpaceId) {
             homeState = canEdit ? .readwrite : .readonly
-            canCreateObjectType = canEdit
-        }
-    }
-    
-    private func startObjectTypesTask() async {
-        let spaceId = spaceId
-        let spaceType = workspaceStorage.spaceView(spaceId: spaceId)?.spaceType
-        let allowedLayouts = DetailsLayout.widgetTypeLayouts(spaceType: spaceType)
-        await objectTypesWithObjectsCreatedService.startSubscription(spaceId: spaceId, spaceType: spaceType)
-
-        let typesPublisher = objectTypeProvider.objectTypesPublisher(spaceId: spaceId)
-        let objectsCreatedPublisher = objectTypesWithObjectsCreatedService.typeIdsWithObjectsCreatedPublisher
-        let alwaysVisibleKeys: Set<ObjectTypeUniqueKey> = [.page, .task, .collection]
-
-        let stream = typesPublisher.combineLatest(objectsCreatedPublisher)
-            .map { (types, typeIdsWithObjectsCreated) in
-                types
-                    .filter { ($0.recommendedLayout.map { allowedLayouts.contains($0) } ?? false) && !$0.isTemplateType }
-                    .filter { typeIdsWithObjectsCreated.contains($0.id) || alwaysVisibleKeys.contains($0.uniqueKey) }
-                    .map { ObjectTypeWidgetInfo(objectTypeId: $0.id, spaceId: spaceId) }
-            }
-            .removeDuplicates()
-            .values
-
-        for await objectTypes in stream {
-            objectTypesDataLoaded = true
-            objectTypeWidgets = objectTypes
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionView.swift
@@ -21,6 +21,7 @@ private struct ObjectTypesSectionViewInternal: View {
 
     @State private var model: ObjectTypesSectionViewModel
     weak var output: (any CommonWidgetModuleOutput)?
+    let onCreateObjectType: () -> Void
 
     init(
         spaceId: String,
@@ -28,13 +29,8 @@ private struct ObjectTypesSectionViewInternal: View {
         onCreateObjectType: @escaping () -> Void
     ) {
         self.output = output
-        self._model = State(
-            wrappedValue: ObjectTypesSectionViewModel(
-                spaceId: spaceId,
-                output: output,
-                onCreateObjectType: onCreateObjectType
-            )
-        )
+        self.onCreateObjectType = onCreateObjectType
+        self._model = State(wrappedValue: ObjectTypesSectionViewModel(spaceId: spaceId))
     }
 
     var body: some View {
@@ -42,13 +38,13 @@ private struct ObjectTypesSectionViewInternal: View {
         VStack(spacing: 0) {
             if model.objectTypesDataLoaded {
                 HomeWidgetsGroupView(title: Loc.types) {
-                    model.onTapHeader()
+                    model.onTapObjectTypeHeader()
                 }
-                if model.isExpanded {
+                if model.objectTypeSectionIsExpanded {
                     ObjectTypesUnifiedWidgetView(
                         typeInfos: model.objectTypeWidgets,
                         canCreateType: model.canCreateObjectType,
-                        onCreateType: { model.onCreateObjectType() },
+                        onCreateType: onCreateObjectType,
                         output: output
                     )
                 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionView.swift
@@ -1,0 +1,61 @@
+import Foundation
+import SwiftUI
+import Services
+
+struct ObjectTypesSectionView: View {
+
+    let spaceId: String
+    weak var output: (any CommonWidgetModuleOutput)?
+    let onCreateObjectType: () -> Void
+
+    var body: some View {
+        ObjectTypesSectionViewInternal(
+            spaceId: spaceId,
+            output: output,
+            onCreateObjectType: onCreateObjectType
+        )
+    }
+}
+
+private struct ObjectTypesSectionViewInternal: View {
+
+    @State private var model: ObjectTypesSectionViewModel
+    weak var output: (any CommonWidgetModuleOutput)?
+
+    init(
+        spaceId: String,
+        output: (any CommonWidgetModuleOutput)?,
+        onCreateObjectType: @escaping () -> Void
+    ) {
+        self.output = output
+        self._model = State(
+            wrappedValue: ObjectTypesSectionViewModel(
+                spaceId: spaceId,
+                output: output,
+                onCreateObjectType: onCreateObjectType
+            )
+        )
+    }
+
+    var body: some View {
+        // Outer always-rendered VStack so .task attaches across the data-loading transition.
+        VStack(spacing: 0) {
+            if model.objectTypesDataLoaded {
+                HomeWidgetsGroupView(title: Loc.types) {
+                    model.onTapHeader()
+                }
+                if model.isExpanded {
+                    ObjectTypesUnifiedWidgetView(
+                        typeInfos: model.objectTypeWidgets,
+                        canCreateType: model.canCreateObjectType,
+                        onCreateType: { model.onCreateObjectType() },
+                        output: output
+                    )
+                }
+            }
+        }
+        .task {
+            await model.startSubscriptions()
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
@@ -1,0 +1,105 @@
+import Foundation
+import SwiftUI
+import Services
+import AnytypeCore
+
+@MainActor
+@Observable
+final class ObjectTypesSectionViewModel {
+
+    // MARK: - DI
+
+    @ObservationIgnored
+    let spaceId: String
+    @ObservationIgnored
+    weak var output: (any CommonWidgetModuleOutput)?
+    @ObservationIgnored
+    private let onCreateObjectTypeCallback: () -> Void
+
+    @ObservationIgnored
+    @Injected(\.expandedService)
+    private var expandedService: any ExpandedServiceProtocol
+    @ObservationIgnored
+    @Injected(\.objectTypeProvider)
+    private var objectTypeProvider: any ObjectTypeProviderProtocol
+    @ObservationIgnored
+    @Injected(\.objectTypesWithObjectsCreatedService)
+    private var objectTypesWithObjectsCreatedService: any ObjectTypesWithObjectsCreatedServiceProtocol
+    @ObservationIgnored
+    @Injected(\.spaceViewsStorage)
+    private var workspaceStorage: any SpaceViewsStorageProtocol
+    @ObservationIgnored
+    @Injected(\.participantsStorage)
+    private var participantsStorage: any ParticipantsStorageProtocol
+
+    // MARK: - State
+
+    var objectTypeWidgets: [ObjectTypeWidgetInfo] = []
+    var objectTypesDataLoaded: Bool = false
+    var isExpanded: Bool = false
+    var canCreateObjectType: Bool = false
+
+    private static let expandedStorageId = "HomeObjectTypeSection"
+
+    init(
+        spaceId: String,
+        output: (any CommonWidgetModuleOutput)?,
+        onCreateObjectType: @escaping () -> Void
+    ) {
+        self.spaceId = spaceId
+        self.output = output
+        self.onCreateObjectTypeCallback = onCreateObjectType
+        self.isExpanded = expandedService.isExpanded(id: Self.expandedStorageId, defaultValue: true)
+    }
+
+    // MARK: - Subscriptions
+
+    func startSubscriptions() async {
+        async let typesSub: () = startObjectTypesTask()
+        async let canEditSub: () = startCanEditSubscription()
+        _ = await (typesSub, canEditSub)
+    }
+
+    func onTapHeader() {
+        withAnimation {
+            isExpanded = !isExpanded
+        }
+        expandedService.setState(id: Self.expandedStorageId, isExpanded: isExpanded)
+    }
+
+    func onCreateObjectType() {
+        onCreateObjectTypeCallback()
+    }
+
+    private func startObjectTypesTask() async {
+        let spaceId = spaceId
+        let spaceType = workspaceStorage.spaceView(spaceId: spaceId)?.spaceType
+        let allowedLayouts = DetailsLayout.widgetTypeLayouts(spaceType: spaceType)
+        await objectTypesWithObjectsCreatedService.startSubscription(spaceId: spaceId, spaceType: spaceType)
+
+        let typesPublisher = objectTypeProvider.objectTypesPublisher(spaceId: spaceId)
+        let objectsCreatedPublisher = objectTypesWithObjectsCreatedService.typeIdsWithObjectsCreatedPublisher
+        let alwaysVisibleKeys: Set<ObjectTypeUniqueKey> = [.page, .task, .collection]
+
+        let stream = typesPublisher.combineLatest(objectsCreatedPublisher)
+            .map { (types, typeIdsWithObjectsCreated) in
+                types
+                    .filter { ($0.recommendedLayout.map { allowedLayouts.contains($0) } ?? false) && !$0.isTemplateType }
+                    .filter { typeIdsWithObjectsCreated.contains($0.id) || alwaysVisibleKeys.contains($0.uniqueKey) }
+                    .map { ObjectTypeWidgetInfo(objectTypeId: $0.id, spaceId: spaceId) }
+            }
+            .removeDuplicates()
+            .values
+
+        for await objectTypes in stream {
+            objectTypesDataLoaded = true
+            objectTypeWidgets = objectTypes
+        }
+    }
+
+    private func startCanEditSubscription() async {
+        for await canEdit in participantsStorage.canEditSequence(spaceId: spaceId) {
+            canCreateObjectType = canEdit
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
@@ -11,10 +11,6 @@ final class ObjectTypesSectionViewModel {
 
     @ObservationIgnored
     let spaceId: String
-    @ObservationIgnored
-    weak var output: (any CommonWidgetModuleOutput)?
-    @ObservationIgnored
-    private let onCreateObjectTypeCallback: () -> Void
 
     @ObservationIgnored
     @Injected(\.expandedService)
@@ -36,20 +32,14 @@ final class ObjectTypesSectionViewModel {
 
     var objectTypeWidgets: [ObjectTypeWidgetInfo] = []
     var objectTypesDataLoaded: Bool = false
-    var isExpanded: Bool = false
+    var objectTypeSectionIsExpanded: Bool = false
     var canCreateObjectType: Bool = false
 
     private static let expandedStorageId = "HomeObjectTypeSection"
 
-    init(
-        spaceId: String,
-        output: (any CommonWidgetModuleOutput)?,
-        onCreateObjectType: @escaping () -> Void
-    ) {
+    init(spaceId: String) {
         self.spaceId = spaceId
-        self.output = output
-        self.onCreateObjectTypeCallback = onCreateObjectType
-        self.isExpanded = expandedService.isExpanded(id: Self.expandedStorageId, defaultValue: true)
+        self.objectTypeSectionIsExpanded = expandedService.isExpanded(id: Self.expandedStorageId, defaultValue: true)
     }
 
     // MARK: - Subscriptions
@@ -60,15 +50,11 @@ final class ObjectTypesSectionViewModel {
         _ = await (typesSub, canEditSub)
     }
 
-    func onTapHeader() {
+    func onTapObjectTypeHeader() {
         withAnimation {
-            isExpanded = !isExpanded
+            objectTypeSectionIsExpanded = !objectTypeSectionIsExpanded
         }
-        expandedService.setState(id: Self.expandedStorageId, isExpanded: isExpanded)
-    }
-
-    func onCreateObjectType() {
-        onCreateObjectTypeCallback()
+        expandedService.setState(id: Self.expandedStorageId, isExpanded: objectTypeSectionIsExpanded)
     }
 
     private func startObjectTypesTask() async {
@@ -92,7 +78,7 @@ final class ObjectTypesSectionViewModel {
             .values
 
         for await objectTypes in stream {
-            objectTypesDataLoaded = true
+            if !objectTypesDataLoaded { objectTypesDataLoaded = true }
             objectTypeWidgets = objectTypes
         }
     }


### PR DESCRIPTION
## Summary

- Extract Object Types section state out of `HomeWidgetsViewModel` into a self-contained `ObjectTypesSectionView` + `ObjectTypesSectionViewModel`, mirroring the Unread shape from PR #4929.
- Container loses 4 state props, 2 `@Injected` services, 2 callbacks, the `objectTypeSectionId` constant, the `async let objectTypesTask`, and the `canCreateObjectType = canEdit` write inside `startCanEditSubscription` (now `homeState`-only for Bin).
- VM owns its own `participantsStorage.canEditSequence` for `canCreateObjectType`; expand state persisted via `expandedService` under the same `"HomeObjectTypeSection"` key.

Stacked on top of #4929.