### PR TITLE
IOS-6158 Refactor HomeWidgets god-object into per-section View+VM pairs

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -17,6 +17,8 @@ struct HomeWidgetsView: View {
 private struct HomeWidgetsInternalView: View {
     @State private var model: HomeWidgetsViewModel
     @State private var pinnedWidgetsCount: Int = 0
+    @State private var myFavoritesRowsCount: Int = 0
+    @State private var recentlyEditedRowsCount: Int = 0
     @State private var shouldHideChatBadges: Bool = false
 
     let context: WidgetScreenContext
@@ -34,8 +36,8 @@ private struct HomeWidgetsInternalView: View {
 
             widgets
                 .animation(.default, value: pinnedWidgetsCount)
-                .animation(.default, value: model.myFavoritesListViewModel.rows.count)
-                .animation(.default, value: model.recentlyEditedListViewModel.rows.count)
+                .animation(.default, value: myFavoritesRowsCount)
+                .animation(.default, value: recentlyEditedRowsCount)
 
             if context.showEmbeddedBottomPanel {
                 HomeBottomNavigationPanelView(
@@ -80,7 +82,7 @@ private struct HomeWidgetsInternalView: View {
                 SpaceInfoView(spaceId: model.spaceId)
                 InviteMembersStubWidgetView(spaceId: model.spaceId, output: model.output)
                 homeWidget
-                ForEach(model.sectionsConfiguration.visibleSections, id: \.self) { section in
+                ForEach(model.visibleSections, id: \.self) { section in
                     manageableSection(section)
                 }
                 AnytypeNavigationSpacer(minHeight: context.showEmbeddedBottomPanel ? 72 : 0)
@@ -108,15 +110,29 @@ private struct HomeWidgetsInternalView: View {
                 output: model.output,
                 onShouldHideBadgesChange: { shouldHideChatBadges = $0 }
             )
-        case .myFavorites: myFavoritesWidget
-        case .recentlyEdited: recentlyEditedWidget
+        case .myFavorites:
+            MyFavoritesSectionView(
+                spaceId: model.spaceId,
+                personalWidgetsObject: model.personalWidgetsObject,
+                channelWidgetsObject: model.channelWidgetsObject,
+                output: model.output,
+                onRowsCountChange: { myFavoritesRowsCount = $0 }
+            )
+        case .recentlyEdited:
+            RecentlyEditedSectionView(
+                spaceId: model.spaceId,
+                output: model.output,
+                onRowsCountChange: { recentlyEditedRowsCount = $0 }
+            )
         case .objects:
             ObjectTypesSectionView(
                 spaceId: model.spaceId,
                 output: model.output,
                 onCreateObjectType: { model.output?.onCreateObjectType() }
             )
-        case .bin: binWidget
+        case .bin:
+            BinLinkWidgetView(spaceId: model.spaceId, output: model.output)
+                .padding(.top, 24)
         }
     }
 
@@ -126,38 +142,6 @@ private struct HomeWidgetsInternalView: View {
             HomeWidgetView(data: data)
                 .id("\(data.objectId)-\(data.canSetHomepage)")
                 .padding(.bottom, 8)
-        }
-    }
-
-    @ViewBuilder
-    private var myFavoritesWidget: some View {
-        if model.myFavoritesListViewModel.rows.isNotEmpty {
-            HomeWidgetsGroupView(title: Loc.myFavorites) {
-                model.onTapMyFavoritesHeader()
-            }
-            if model.myFavoritesSectionIsExpanded {
-                MyFavoritesListView(model: model.myFavoritesListViewModel)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var recentlyEditedWidget: some View {
-        if model.recentlyEditedListViewModel.rows.isNotEmpty {
-            HomeWidgetsGroupView(title: Loc.Widgets.Library.RecentlyEdited.name) {
-                model.onTapRecentlyEditedHeader()
-            }
-            if model.recentlyEditedSectionIsExpanded {
-                RecentlyEditedListView(model: model.recentlyEditedListViewModel)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var binWidget: some View {
-        if model.homeState.isReadWrite {
-            BinLinkWidgetView(spaceId: model.spaceId, homeState: $model.homeState, output: model.output)
-                .padding(.top, 24)
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -3,53 +3,49 @@ import AnytypeCore
 import Services
 import Combine
 import SwiftUI
-import AsyncAlgorithms
 
 @MainActor
 @Observable
 final class HomeWidgetsViewModel {
 
-    private enum Constants {
-        static let myFavoritesSectionId = "HomeMyFavoritesSection"
-        static let recentlyEditedSectionId = "HomeRecentlyEditedSection"
-    }
-    
     // MARK: - DI
 
     let info: AccountInfo
     let channelWidgetsObject: any BaseDocumentProtocol
     let personalWidgetsObject: any BaseDocumentProtocol
 
-    @Injected(\.blockWidgetService) @ObservationIgnored
-    private var blockWidgetService: any BlockWidgetServiceProtocol
     private let documentService: any OpenedDocumentsProviderProtocol = Container.shared.openedDocumentProvider()
-    private let workspaceStorage: any SpaceViewsStorageProtocol = Container.shared.spaceViewsStorage()
     @Injected(\.documentsProvider) @ObservationIgnored
     private var documentsProvider: any DocumentsProviderProtocol
-    @Injected(\.participantsStorage) @ObservationIgnored
-    private var accountParticipantStorage: any ParticipantsStorageProtocol
     @Injected(\.participantSpacesStorage) @ObservationIgnored
     private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
-    @Injected(\.expandedService) @ObservationIgnored
-    private var expandedService: any ExpandedServiceProtocol
     @Injected(\.homeSectionsStorage) @ObservationIgnored
     private var homeSectionsStorage: any HomeSectionsStorageProtocol
+    @Injected(\.participantsStorage) @ObservationIgnored
+    private var accountParticipantStorage: any ParticipantsStorageProtocol
 
     @ObservationIgnored
     weak var output: (any HomeWidgetsModuleOutput)?
-    
+
     // MARK: - State
 
-    var homeState: HomeWidgetsState = .readonly
-    var wallpaper: SpaceWallpaperType = .default
     var homeWidgetData: HomepageWidgetViewData?
-    var myFavoritesSectionIsExpanded: Bool = false
-    var myFavoritesListViewModel: MyFavoritesListViewModel
-    var recentlyEditedSectionIsExpanded: Bool = false
-    var recentlyEditedListViewModel: RecentlyEditedListViewModel
     var sectionsConfiguration: HomeSectionsConfiguration = .default
 
+    // Default true so editors (common case) see Bin on the first frame; readonly users
+    // briefly see Bin until the canEdit subscription fires.
+    private var canEdit: Bool = true
+
     var spaceId: String { info.accountSpaceId }
+
+    // Bin is the only section whose visibility is gated by canEdit; filtering here keeps
+    // the Bin VM from instantiating for readonly users (PR 4 invariant: hidden sections
+    // do not start subscriptions).
+    var visibleSections: [HomeSection] {
+        canEdit
+            ? sectionsConfiguration.visibleSections
+            : sectionsConfiguration.visibleSections.filter { $0 != .bin }
+    }
 
     init(
         info: AccountInfo,
@@ -57,39 +53,19 @@ final class HomeWidgetsViewModel {
     ) {
         self.info = info
         self.output = output
-        let channelWidgetsObject = documentService.document(objectId: info.widgetsId, spaceId: info.accountSpaceId)
-        self.channelWidgetsObject = channelWidgetsObject
-        let personalWidgetsObject = documentService.document(
+        self.channelWidgetsObject = documentService.document(objectId: info.widgetsId, spaceId: info.accountSpaceId)
+        self.personalWidgetsObject = documentService.document(
             objectId: info.personalWidgetsId,
             spaceId: info.accountSpaceId
         )
-        self.personalWidgetsObject = personalWidgetsObject
-        self.myFavoritesListViewModel = MyFavoritesListViewModel(
-            spaceId: info.accountSpaceId,
-            personalWidgetsObject: personalWidgetsObject,
-            channelWidgetsObject: channelWidgetsObject,
-            onObjectSelected: { [weak output] details in
-                output?.onObjectSelected(screenData: details.screenData())
-            }
-        )
-        self.recentlyEditedListViewModel = RecentlyEditedListViewModel(
-            spaceId: info.accountSpaceId,
-            onObjectSelected: { [weak output] details in
-                output?.onObjectSelected(screenData: details.screenData())
-            }
-        )
-        self.myFavoritesSectionIsExpanded = expandedService.isExpanded(id: Constants.myFavoritesSectionId, defaultValue: true)
-        self.recentlyEditedSectionIsExpanded = expandedService.isExpanded(id: Constants.recentlyEditedSectionId, defaultValue: true)
     }
 
     func startSubscriptions() async {
-        async let myFavoritesSub: () = startMyFavoritesTask()
-        async let recentlyEditedSub: () = startRecentlyEditedTask()
-        async let canEditSub: () = startCanEditSubscription()
         async let spaceViewTask: () = startSpaceViewTask()
         async let sectionsConfigurationTask: () = startSectionsConfigurationTask()
+        async let canEditTask: () = startCanEditSubscription()
 
-        _ = await (myFavoritesSub, recentlyEditedSub, canEditSub, spaceViewTask, sectionsConfigurationTask)
+        _ = await (spaceViewTask, sectionsConfigurationTask, canEditTask)
     }
 
     func onAppear() {
@@ -112,29 +88,7 @@ final class HomeWidgetsViewModel {
         output?.onManageSectionsSelected()
     }
 
-    func onTapMyFavoritesHeader() {
-        withAnimation {
-            myFavoritesSectionIsExpanded = !myFavoritesSectionIsExpanded
-        }
-        expandedService.setState(id: Constants.myFavoritesSectionId, isExpanded: myFavoritesSectionIsExpanded)
-    }
-
-    func onTapRecentlyEditedHeader() {
-        withAnimation {
-            recentlyEditedSectionIsExpanded = !recentlyEditedSectionIsExpanded
-        }
-        expandedService.setState(id: Constants.recentlyEditedSectionId, isExpanded: recentlyEditedSectionIsExpanded)
-    }
-
     // MARK: - Private
-
-    private func startMyFavoritesTask() async {
-        await myFavoritesListViewModel.startSubscriptions()
-    }
-
-    private func startRecentlyEditedTask() async {
-        await recentlyEditedListViewModel.startSubscriptions()
-    }
 
     private func startSectionsConfigurationTask() async {
         for await configuration in homeSectionsStorage.configurationPublisher(spaceId: info.accountSpaceId).values {
@@ -144,7 +98,7 @@ final class HomeWidgetsViewModel {
 
     private func startCanEditSubscription() async {
         for await canEdit in accountParticipantStorage.canEditSequence(spaceId: info.accountSpaceId) {
-            homeState = canEdit ? .readwrite : .readonly
+            self.canEdit = canEdit
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -39,8 +39,7 @@ final class HomeWidgetsViewModel {
     var spaceId: String { info.accountSpaceId }
 
     // Bin is the only section whose visibility is gated by canEdit; filtering here keeps
-    // the Bin VM from instantiating for readonly users (PR 4 invariant: hidden sections
-    // do not start subscriptions).
+    // the Bin VM from instantiating for readonly users once `canEdit` resolves.
     var visibleSections: [HomeSection] {
         canEdit
             ? sectionsConfiguration.visibleSections

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -32,14 +32,13 @@ final class HomeWidgetsViewModel {
     var homeWidgetData: HomepageWidgetViewData?
     var sectionsConfiguration: HomeSectionsConfiguration = .default
 
-    // Default true so editors (common case) see Bin on the first frame; readonly users
-    // briefly see Bin until the canEdit subscription fires.
-    private var canEdit: Bool = true
+    // Default false so readonly users never see (and can never tap) the Bin's empty-bin
+    // action before `canEdit` resolves. Editors briefly see no Bin section until then —
+    // matches pre-refactor `homeState = .readonly` default and `PinnedSectionViewModel`.
+    private var canEdit: Bool = false
 
     var spaceId: String { info.accountSpaceId }
 
-    // Bin is the only section whose visibility is gated by canEdit; filtering here keeps
-    // the Bin VM from instantiating for readonly users once `canEdit` resolves.
     var visibleSections: [HomeSection] {
         canEdit
             ? sectionsConfiguration.visibleSections

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/HomeSection.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/HomeSection.swift
@@ -42,3 +42,15 @@ struct HomeSectionsConfiguration: Codable, Equatable, Sendable {
         visibleSections: [.pinned, .unread, .myFavorites, .recentlyEdited, .objects, .bin]
     )
 }
+
+extension ExpandedServiceProtocol {
+    func isExpanded(section: HomeSection, defaultValue: Bool) -> Bool {
+        guard let id = section.expandedStorageId else { return defaultValue }
+        return isExpanded(id: id, defaultValue: defaultValue)
+    }
+
+    func setState(section: HomeSection, isExpanded: Bool) {
+        guard let id = section.expandedStorageId else { return }
+        setState(id: id, isExpanded: isExpanded)
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/HomeSection.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/HomeSection.swift
@@ -18,6 +18,20 @@ enum HomeSection: String, CaseIterable, Codable, Sendable {
         case .bin: "Bin"
         }
     }
+
+    // UserDefaults key for the section's expand/collapse state. `nil` for sections
+    // without a persistent expand state (Pinned and Bin). String values must stay
+    // stable so existing user state survives.
+    var expandedStorageId: String? {
+        switch self {
+        case .unread:         "HomeUnreadSection"
+        case .pinned:          nil
+        case .myFavorites:    "HomeMyFavoritesSection"
+        case .recentlyEdited: "HomeRecentlyEditedSection"
+        case .objects:        "HomeObjectTypeSection"
+        case .bin:             nil
+        }
+    }
 }
 
 struct HomeSectionsConfiguration: Codable, Equatable, Sendable {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/BinLink/BinLinkWidgetView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/BinLink/BinLinkWidgetView.swift
@@ -2,13 +2,12 @@ import Foundation
 import SwiftUI
 
 struct BinLinkWidgetView: View {
-    
+
     let spaceId: String
-    @Binding var homeState: HomeWidgetsState
     weak var output: (any CommonWidgetModuleOutput)?
 
     var body: some View {
-        BinLinkWidgetViewInternal(spaceId: spaceId, homeState: $homeState, output: output)
+        BinLinkWidgetViewInternal(spaceId: spaceId, output: output)
             .id(spaceId)
     }
 }
@@ -16,28 +15,22 @@ struct BinLinkWidgetView: View {
 private struct BinLinkWidgetViewInternal: View {
 
     @State private var model: BinLinkWidgetViewModel
-    @Binding var homeState: HomeWidgetsState
 
     init(
         spaceId: String,
-        homeState: Binding<HomeWidgetsState>,
         output: (any CommonWidgetModuleOutput)?
     ) {
-        self._homeState = homeState
         self._model = State(initialValue: BinLinkWidgetViewModel(spaceId: spaceId, output: output))
     }
-    
+
     var body: some View {
-        if homeState.isReadWrite {
-            content
-        }
-    }
-    
-    var content: some View {
+        // Bin is only ever rendered when the user is readwrite — readonly is filtered out
+        // upstream by HomeWidgetsViewModel.visibleSections — so the homeState binding
+        // passed into LinkWidgetViewContainer is a constant.
         LinkWidgetViewContainer(
             isExpanded: .constant(false),
             dragId: nil,
-            homeState: $homeState,
+            homeState: .constant(.readwrite),
             allowContent: false,
             header: {
                 LinkWidgetDefaultHeader(title: Loc.bin, icon: .asset(.X24.bin), onTap: {
@@ -54,7 +47,7 @@ private struct BinLinkWidgetViewInternal: View {
         }
         .snackbar(toastBarData: $model.toastData)
     }
-    
+
     private var menuItems: some View {
         AsyncButton(Loc.Widgets.Actions.emptyBin, role: .destructive) {
             try await model.onEmptyBinTap()

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/BinLink/BinLinkWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/BinLink/BinLinkWidgetViewModel.swift
@@ -21,17 +21,17 @@ final class BinLinkWidgetViewModel {
 
     var toastData: ToastBarData?
     var binAlertData: BinConfirmationAlertData? = nil
-    
+
     init(spaceId: String, output: (any CommonWidgetModuleOutput)?) {
         self.spaceId = spaceId
         self.output = output
     }
-    
+
     func onHeaderTap() {
         AnytypeAnalytics.instance().logClickWidgetTitle(source: .bin, createType: .manual)
         output?.onObjectSelected(screenData: .editor(.bin(spaceId: spaceId)))
     }
-    
+
     func onEmptyBinTap() async throws {
         let binIds = try await searchService.searchArchiveObjectIds(spaceId: spaceId)
         guard binIds.isNotEmpty else {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListViewModel.swift
@@ -74,7 +74,7 @@ final class MyFavoritesListViewModel {
             let newIds = newRows.map(\.id)
             guard sourceIds != newIds else { continue }
             // Animate count change and rows update in the same transaction so the parent
-            // VStack reflow inherits the animation context (lesson #2 of the master plan).
+            // VStack reflow inherits the animation context.
             let countChanged = rows.count != newRows.count
             withAnimation(.default) {
                 if countChanged { onRowsCountChange?(newRows.count) }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesListViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Services
 import AnytypeCore
 
@@ -14,6 +15,8 @@ final class MyFavoritesListViewModel {
     let channelWidgetsObject: any BaseDocumentProtocol
     @ObservationIgnored
     let onObjectSelected: (ObjectDetails) -> Void
+    @ObservationIgnored
+    private let onRowsCountChange: ((Int) -> Void)?
 
     @ObservationIgnored
     let spaceId: String
@@ -35,12 +38,14 @@ final class MyFavoritesListViewModel {
         spaceId: String,
         personalWidgetsObject: any BaseDocumentProtocol,
         channelWidgetsObject: any BaseDocumentProtocol,
-        onObjectSelected: @escaping (ObjectDetails) -> Void
+        onObjectSelected: @escaping (ObjectDetails) -> Void,
+        onRowsCountChange: ((Int) -> Void)? = nil
     ) {
         self.spaceId = spaceId
         self.personalWidgetsObject = personalWidgetsObject
         self.channelWidgetsObject = channelWidgetsObject
         self.onObjectSelected = onObjectSelected
+        self.onRowsCountChange = onRowsCountChange
     }
 
     // MARK: - Subscriptions
@@ -68,8 +73,14 @@ final class MyFavoritesListViewModel {
             //   `widgetTargetDetailsPublisher`, so the parent doesn't need to rebuild for those.
             let newIds = newRows.map(\.id)
             guard sourceIds != newIds else { continue }
-            sourceIds = newIds
-            rows = newRows
+            // Animate count change and rows update in the same transaction so the parent
+            // VStack reflow inherits the animation context (lesson #2 of the master plan).
+            let countChanged = rows.count != newRows.count
+            withAnimation(.default) {
+                if countChanged { onRowsCountChange?(newRows.count) }
+                sourceIds = newIds
+                rows = newRows
+            }
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesSectionView.swift
@@ -1,0 +1,62 @@
+import Foundation
+import SwiftUI
+import Services
+
+struct MyFavoritesSectionView: View {
+
+    let spaceId: String
+    let personalWidgetsObject: any BaseDocumentProtocol
+    let channelWidgetsObject: any BaseDocumentProtocol
+    weak var output: (any CommonWidgetModuleOutput)?
+    let onRowsCountChange: (Int) -> Void
+
+    var body: some View {
+        MyFavoritesSectionViewInternal(
+            spaceId: spaceId,
+            personalWidgetsObject: personalWidgetsObject,
+            channelWidgetsObject: channelWidgetsObject,
+            output: output,
+            onRowsCountChange: onRowsCountChange
+        )
+    }
+}
+
+private struct MyFavoritesSectionViewInternal: View {
+
+    @State private var model: MyFavoritesSectionViewModel
+
+    init(
+        spaceId: String,
+        personalWidgetsObject: any BaseDocumentProtocol,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        output: (any CommonWidgetModuleOutput)?,
+        onRowsCountChange: @escaping (Int) -> Void
+    ) {
+        self._model = State(
+            wrappedValue: MyFavoritesSectionViewModel(
+                spaceId: spaceId,
+                personalWidgetsObject: personalWidgetsObject,
+                channelWidgetsObject: channelWidgetsObject,
+                output: output,
+                onRowsCountChange: onRowsCountChange
+            )
+        )
+    }
+
+    var body: some View {
+        // Outer always-rendered VStack so .task attaches to a stable view across the empty→non-empty transition.
+        VStack(spacing: 0) {
+            if model.listModel.rows.isNotEmpty {
+                HomeWidgetsGroupView(title: Loc.myFavorites) {
+                    model.onTapHeader()
+                }
+                if model.isExpanded {
+                    MyFavoritesListView(model: model.listModel)
+                }
+            }
+        }
+        .task {
+            await model.startSubscriptions()
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesSectionViewModel.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SwiftUI
+import Services
+
+@MainActor
+@Observable
+final class MyFavoritesSectionViewModel {
+
+    @ObservationIgnored
+    let listModel: MyFavoritesListViewModel
+
+    @ObservationIgnored
+    @Injected(\.expandedService)
+    private var expandedService: any ExpandedServiceProtocol
+
+    var isExpanded: Bool
+
+    init(
+        spaceId: String,
+        personalWidgetsObject: any BaseDocumentProtocol,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        output: (any CommonWidgetModuleOutput)?,
+        onRowsCountChange: @escaping (Int) -> Void
+    ) {
+        self.listModel = MyFavoritesListViewModel(
+            spaceId: spaceId,
+            personalWidgetsObject: personalWidgetsObject,
+            channelWidgetsObject: channelWidgetsObject,
+            onObjectSelected: { [weak output] details in
+                output?.onObjectSelected(screenData: details.screenData())
+            },
+            onRowsCountChange: onRowsCountChange
+        )
+        // Default to true so users without persisted state see the section open.
+        self.isExpanded = HomeSection.myFavorites.expandedStorageId
+            .map { expandedService.isExpanded(id: $0, defaultValue: true) } ?? true
+    }
+
+    func startSubscriptions() async {
+        await listModel.startSubscriptions()
+    }
+
+    func onTapHeader() {
+        withAnimation { isExpanded.toggle() }
+        if let id = HomeSection.myFavorites.expandedStorageId {
+            expandedService.setState(id: id, isExpanded: isExpanded)
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/MyFavorites/MyFavoritesSectionViewModel.swift
@@ -13,7 +13,7 @@ final class MyFavoritesSectionViewModel {
     @Injected(\.expandedService)
     private var expandedService: any ExpandedServiceProtocol
 
-    var isExpanded: Bool
+    var isExpanded: Bool = true
 
     init(
         spaceId: String,
@@ -32,8 +32,7 @@ final class MyFavoritesSectionViewModel {
             onRowsCountChange: onRowsCountChange
         )
         // Default to true so users without persisted state see the section open.
-        self.isExpanded = HomeSection.myFavorites.expandedStorageId
-            .map { expandedService.isExpanded(id: $0, defaultValue: true) } ?? true
+        self.isExpanded = expandedService.isExpanded(section: .myFavorites, defaultValue: true)
     }
 
     func startSubscriptions() async {
@@ -42,8 +41,6 @@ final class MyFavoritesSectionViewModel {
 
     func onTapHeader() {
         withAnimation { isExpanded.toggle() }
-        if let id = HomeSection.myFavorites.expandedStorageId {
-            expandedService.setState(id: id, isExpanded: isExpanded)
-        }
+        expandedService.setState(section: .myFavorites, isExpanded: isExpanded)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
@@ -35,11 +35,10 @@ final class ObjectTypesSectionViewModel {
     var objectTypeSectionIsExpanded: Bool = false
     var canCreateObjectType: Bool = false
 
-    private static let expandedStorageId = "HomeObjectTypeSection"
-
     init(spaceId: String) {
         self.spaceId = spaceId
-        self.objectTypeSectionIsExpanded = expandedService.isExpanded(id: Self.expandedStorageId, defaultValue: true)
+        self.objectTypeSectionIsExpanded = HomeSection.objects.expandedStorageId
+            .map { expandedService.isExpanded(id: $0, defaultValue: true) } ?? true
     }
 
     // MARK: - Subscriptions
@@ -54,7 +53,9 @@ final class ObjectTypesSectionViewModel {
         withAnimation {
             objectTypeSectionIsExpanded = !objectTypeSectionIsExpanded
         }
-        expandedService.setState(id: Self.expandedStorageId, isExpanded: objectTypeSectionIsExpanded)
+        if let id = HomeSection.objects.expandedStorageId {
+            expandedService.setState(id: id, isExpanded: objectTypeSectionIsExpanded)
+        }
     }
 
     private func startObjectTypesTask() async {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
@@ -37,8 +37,7 @@ final class ObjectTypesSectionViewModel {
 
     init(spaceId: String) {
         self.spaceId = spaceId
-        self.objectTypeSectionIsExpanded = HomeSection.objects.expandedStorageId
-            .map { expandedService.isExpanded(id: $0, defaultValue: true) } ?? true
+        self.objectTypeSectionIsExpanded = expandedService.isExpanded(section: .objects, defaultValue: true)
     }
 
     // MARK: - Subscriptions
@@ -53,9 +52,7 @@ final class ObjectTypesSectionViewModel {
         withAnimation {
             objectTypeSectionIsExpanded = !objectTypeSectionIsExpanded
         }
-        if let id = HomeSection.objects.expandedStorageId {
-            expandedService.setState(id: id, isExpanded: objectTypeSectionIsExpanded)
-        }
+        expandedService.setState(section: .objects, isExpanded: objectTypeSectionIsExpanded)
     }
 
     private func startObjectTypesTask() async {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedListViewModel.swift
@@ -49,6 +49,8 @@ final class RecentlyEditedListViewModel {
             update: { [weak self] details in
                 guard let self else { return }
                 let newRows = details.map { RecentlyEditedRowData(id: $0.id, details: $0) }
+                // Animate count change and rows update in the same transaction so the parent
+                // VStack reflow inherits the animation context.
                 let countChanged = self.rows.count != newRows.count
                 withAnimation(.default) {
                     if countChanged { self.onRowsCountChange?(newRows.count) }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedListViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Services
 import AnytypeCore
 
@@ -12,6 +13,8 @@ final class RecentlyEditedListViewModel {
     let spaceId: String
     @ObservationIgnored
     let onObjectSelected: (ObjectDetails) -> Void
+    @ObservationIgnored
+    private let onRowsCountChange: ((Int) -> Void)?
 
     @ObservationIgnored
     @Injected(\.recentSubscriptionService)
@@ -28,10 +31,12 @@ final class RecentlyEditedListViewModel {
 
     init(
         spaceId: String,
-        onObjectSelected: @escaping (ObjectDetails) -> Void
+        onObjectSelected: @escaping (ObjectDetails) -> Void,
+        onRowsCountChange: ((Int) -> Void)? = nil
     ) {
         self.spaceId = spaceId
         self.onObjectSelected = onObjectSelected
+        self.onRowsCountChange = onRowsCountChange
     }
 
     // MARK: - Subscriptions
@@ -42,7 +47,13 @@ final class RecentlyEditedListViewModel {
             type: .recentEdit,
             objectLimit: Constants.limit,
             update: { [weak self] details in
-                self?.rows = details.map { RecentlyEditedRowData(id: $0.id, details: $0) }
+                guard let self else { return }
+                let newRows = details.map { RecentlyEditedRowData(id: $0.id, details: $0) }
+                let countChanged = self.rows.count != newRows.count
+                withAnimation(.default) {
+                    if countChanged { self.onRowsCountChange?(newRows.count) }
+                    self.rows = newRows
+                }
             }
         )
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedSectionView.swift
@@ -1,0 +1,54 @@
+import Foundation
+import SwiftUI
+import Services
+
+struct RecentlyEditedSectionView: View {
+
+    let spaceId: String
+    weak var output: (any CommonWidgetModuleOutput)?
+    let onRowsCountChange: (Int) -> Void
+
+    var body: some View {
+        RecentlyEditedSectionViewInternal(
+            spaceId: spaceId,
+            output: output,
+            onRowsCountChange: onRowsCountChange
+        )
+    }
+}
+
+private struct RecentlyEditedSectionViewInternal: View {
+
+    @State private var model: RecentlyEditedSectionViewModel
+
+    init(
+        spaceId: String,
+        output: (any CommonWidgetModuleOutput)?,
+        onRowsCountChange: @escaping (Int) -> Void
+    ) {
+        self._model = State(
+            wrappedValue: RecentlyEditedSectionViewModel(
+                spaceId: spaceId,
+                output: output,
+                onRowsCountChange: onRowsCountChange
+            )
+        )
+    }
+
+    var body: some View {
+        // Outer always-rendered VStack so .task attaches to a stable view across the empty→non-empty transition.
+        VStack(spacing: 0) {
+            if model.listModel.rows.isNotEmpty {
+                HomeWidgetsGroupView(title: Loc.Widgets.Library.RecentlyEdited.name) {
+                    model.onTapHeader()
+                }
+                if model.isExpanded {
+                    RecentlyEditedListView(model: model.listModel)
+                }
+            }
+        }
+        .task {
+            await model.startSubscriptions()
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedSectionViewModel.swift
@@ -13,7 +13,7 @@ final class RecentlyEditedSectionViewModel {
     @Injected(\.expandedService)
     private var expandedService: any ExpandedServiceProtocol
 
-    var isExpanded: Bool
+    var isExpanded: Bool = true
 
     init(
         spaceId: String,
@@ -28,8 +28,7 @@ final class RecentlyEditedSectionViewModel {
             onRowsCountChange: onRowsCountChange
         )
         // Default to true so users without persisted state see the section open.
-        self.isExpanded = HomeSection.recentlyEdited.expandedStorageId
-            .map { expandedService.isExpanded(id: $0, defaultValue: true) } ?? true
+        self.isExpanded = expandedService.isExpanded(section: .recentlyEdited, defaultValue: true)
     }
 
     func startSubscriptions() async {
@@ -38,8 +37,6 @@ final class RecentlyEditedSectionViewModel {
 
     func onTapHeader() {
         withAnimation { isExpanded.toggle() }
-        if let id = HomeSection.recentlyEdited.expandedStorageId {
-            expandedService.setState(id: id, isExpanded: isExpanded)
-        }
+        expandedService.setState(section: .recentlyEdited, isExpanded: isExpanded)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/RecentlyEdited/RecentlyEditedSectionViewModel.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftUI
+import Services
+
+@MainActor
+@Observable
+final class RecentlyEditedSectionViewModel {
+
+    @ObservationIgnored
+    let listModel: RecentlyEditedListViewModel
+
+    @ObservationIgnored
+    @Injected(\.expandedService)
+    private var expandedService: any ExpandedServiceProtocol
+
+    var isExpanded: Bool
+
+    init(
+        spaceId: String,
+        output: (any CommonWidgetModuleOutput)?,
+        onRowsCountChange: @escaping (Int) -> Void
+    ) {
+        self.listModel = RecentlyEditedListViewModel(
+            spaceId: spaceId,
+            onObjectSelected: { [weak output] details in
+                output?.onObjectSelected(screenData: details.screenData())
+            },
+            onRowsCountChange: onRowsCountChange
+        )
+        // Default to true so users without persisted state see the section open.
+        self.isExpanded = HomeSection.recentlyEdited.expandedStorageId
+            .map { expandedService.isExpanded(id: $0, defaultValue: true) } ?? true
+    }
+
+    func startSubscriptions() async {
+        await listModel.startSubscriptions()
+    }
+
+    func onTapHeader() {
+        withAnimation { isExpanded.toggle() }
+        if let id = HomeSection.recentlyEdited.expandedStorageId {
+            expandedService.setState(id: id, isExpanded: isExpanded)
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -69,9 +69,11 @@ final class UnreadSectionViewModel {
 
     private func startUnreadItemsTask() async {
         let spaceId = spaceId
-        let spaceView = workspaceStorage.spaceView(spaceId: spaceId)
-        guard !(spaceView?.isOneToOne ?? true) else { return }
-
+        // No early-exit on isOneToOne — we'd capture the space type once and never observe
+        // a 1:1 → multi-chat conversion. The combineLatest below re-fires on space-view
+        // changes and the section's own visibility is gated by `supportsMultiChats`
+        // (set in startSpaceViewTask), so 1:1 spaces simply pay the cost of a few
+        // combineLatest emissions whose result the section ignores.
         let previewsSequence = await chatMessagesPreviewsStorage.previewsSequenceWithEmpty
         let chatsSequence = await chatDetailsStorage.allChatsSequence
         let spaceViewSequence = workspaceStorage.spaceViewPublisher(spaceId: spaceId).removeDuplicates().values

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -43,8 +43,7 @@ final class UnreadSectionViewModel {
     init(spaceId: String, output: (any CommonWidgetModuleOutput)?) {
         self.spaceId = spaceId
         self.output = output
-        self.unreadSectionIsExpanded = HomeSection.unread.expandedStorageId
-            .map { expandedService.isExpanded(id: $0, defaultValue: true) } ?? true
+        self.unreadSectionIsExpanded = expandedService.isExpanded(section: .unread, defaultValue: true)
     }
 
     // MARK: - Subscriptions
@@ -59,9 +58,7 @@ final class UnreadSectionViewModel {
         withAnimation {
             unreadSectionIsExpanded = !unreadSectionIsExpanded
         }
-        if let id = HomeSection.unread.expandedStorageId {
-            expandedService.setState(id: id, isExpanded: unreadSectionIsExpanded)
-        }
+        expandedService.setState(section: .unread, isExpanded: unreadSectionIsExpanded)
     }
 
     private func startSpaceViewTask() async {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -40,12 +40,11 @@ final class UnreadSectionViewModel {
     var shouldShowUnreadSection: Bool { supportsMultiChats && unreadItems.isNotEmpty }
     var shouldHideChatBadges: Bool { shouldShowUnreadSection && unreadSectionIsExpanded }
 
-    private static let expandedStorageId = "HomeUnreadSection"
-
     init(spaceId: String, output: (any CommonWidgetModuleOutput)?) {
         self.spaceId = spaceId
         self.output = output
-        self.unreadSectionIsExpanded = expandedService.isExpanded(id: Self.expandedStorageId, defaultValue: true)
+        self.unreadSectionIsExpanded = HomeSection.unread.expandedStorageId
+            .map { expandedService.isExpanded(id: $0, defaultValue: true) } ?? true
     }
 
     // MARK: - Subscriptions
@@ -60,7 +59,9 @@ final class UnreadSectionViewModel {
         withAnimation {
             unreadSectionIsExpanded = !unreadSectionIsExpanded
         }
-        expandedService.setState(id: Self.expandedStorageId, isExpanded: unreadSectionIsExpanded)
+        if let id = HomeSection.unread.expandedStorageId {
+            expandedService.setState(id: id, isExpanded: unreadSectionIsExpanded)
+        }
     }
 
     private func startSpaceViewTask() async {


### PR DESCRIPTION
## Summary

- Split `HomeWidgetsViewModel` (~390 lines) into a thin coordinator (~180 lines) by extracting every home section into a self-contained `*SectionView` + `*SectionViewModel` pair: Pinned, Unread, ObjectTypes, MyFavorites, RecentlyEdited (Bin already had a VM, now self-renders unconditionally).
- Each section VM owns its own subscriptions and is only instantiated when its section is in the rendered tree — sections hidden via Manage Sections never start subscriptions. Bin is filtered out of `visibleSections` for readonly users so its VM also never instantiates without canEdit.
- `HomeSection.expandedStorageId` derives the UserDefaults key from the enum (existing strings preserved), and an `ExpandedServiceProtocol` extension over `HomeSection` collapses the read/write callsites in each section VM.

Plan: `plans/PLAN_IOS_6158.md`. Shipped as one PR per the master plan.