### PR TITLE
IOS-5812 Pre-open widget docs in Home flow to fix mid-transition pop-in

### DIFF
--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsCoordinatorView.swift
@@ -32,8 +32,15 @@ struct HomeWidgetsCoordinatorView: View {
     let context: WidgetScreenContext
 
     var body: some View {
-        SpaceLoadingContainerView(spaceId: data.spaceId, showBackground: true) {
-            HomeWidgetsCoordinatorInternalView(info: $0, context: context)
+        SpaceLoadingContainerView(spaceId: data.spaceId, showBackground: true) { info in
+            HomeWidgetsDocumentsLoaderView(info: info) { channelDoc, personalDoc in
+                HomeWidgetsCoordinatorInternalView(
+                    info: info,
+                    channelWidgetsObject: channelDoc,
+                    personalWidgetsObject: personalDoc,
+                    context: context
+                )
+            }
         }
     }
 }
@@ -44,15 +51,30 @@ private struct HomeWidgetsCoordinatorInternalView: View {
     @Environment(\.pageNavigation) private var pageNavigation
     @Environment(\.dismiss) private var dismiss
 
+    let channelWidgetsObject: any BaseDocumentProtocol
+    let personalWidgetsObject: any BaseDocumentProtocol
     let context: WidgetScreenContext
 
-    init(info: AccountInfo, context: WidgetScreenContext) {
+    init(
+        info: AccountInfo,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        personalWidgetsObject: any BaseDocumentProtocol,
+        context: WidgetScreenContext
+    ) {
         self._model = State(wrappedValue: HomeWidgetsCoordinatorViewModel(info: info))
+        self.channelWidgetsObject = channelWidgetsObject
+        self.personalWidgetsObject = personalWidgetsObject
         self.context = context
     }
 
     var body: some View {
-        HomeWidgetsView(info: model.spaceInfo, context: context, output: model)
+        HomeWidgetsView(
+            info: model.spaceInfo,
+            channelWidgetsObject: channelWidgetsObject,
+            personalWidgetsObject: personalWidgetsObject,
+            context: context,
+            output: model
+        )
             .onAppear {
                 model.pageNavigation = pageNavigation
             }

--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsDocumentsLoaderView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsDocumentsLoaderView.swift
@@ -23,8 +23,7 @@ struct HomeWidgetsDocumentsLoaderView<Content: View>: View {
             if let documents = model.documents {
                 content(documents.channelWidgets, documents.personalWidgets)
             } else {
-                // Bridge frame between SpaceLoadingContainerView's loading state and content.
-                // Same wallpaper background, no icon — pulse already played in SpaceLoadingContainerView.
+                // No icon here — SpaceLoadingContainerView's pulse already played; replaying would feel jarring.
                 HomeWallpaperView(spaceId: info.accountSpaceId)
             }
         }

--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsDocumentsLoaderView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsDocumentsLoaderView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import Services
+
+struct HomeWidgetsDocumentsLoaderView<Content: View>: View {
+
+    private let info: AccountInfo
+    private let content: (_ channelWidgets: any BaseDocumentProtocol,
+                          _ personalWidgets: any BaseDocumentProtocol) -> Content
+
+    @State private var model: HomeWidgetsDocumentsLoaderViewModel
+
+    init(
+        info: AccountInfo,
+        @ViewBuilder content: @escaping (any BaseDocumentProtocol, any BaseDocumentProtocol) -> Content
+    ) {
+        self.info = info
+        self.content = content
+        self._model = State(wrappedValue: HomeWidgetsDocumentsLoaderViewModel(info: info))
+    }
+
+    var body: some View {
+        ZStack {
+            if let documents = model.documents {
+                content(documents.channelWidgets, documents.personalWidgets)
+            } else {
+                // Bridge frame between SpaceLoadingContainerView's loading state and content.
+                // Same wallpaper background, no icon — pulse already played in SpaceLoadingContainerView.
+                HomeWallpaperView(spaceId: info.accountSpaceId)
+            }
+        }
+        .task {
+            await model.openDocuments()
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsDocumentsLoaderViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/HomeWidgetsCoordinator/HomeWidgetsDocumentsLoaderViewModel.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Services
+import AnytypeCore
+
+@MainActor
+@Observable
+final class HomeWidgetsDocumentsLoaderViewModel {
+    struct Documents {
+        let channelWidgets: any BaseDocumentProtocol
+        let personalWidgets: any BaseDocumentProtocol
+    }
+
+    @ObservationIgnored
+    @Injected(\.documentsProvider)
+    private var documentsProvider: any DocumentsProviderProtocol
+
+    @ObservationIgnored
+    private let info: AccountInfo
+
+    var documents: Documents?
+
+    init(info: AccountInfo) {
+        self.info = info
+    }
+
+    func openDocuments() async {
+        let channel = documentsProvider.document(
+            objectId: info.widgetsId,
+            spaceId: info.accountSpaceId,
+            mode: .handling
+        )
+        let personal = documentsProvider.document(
+            objectId: info.personalWidgetsId,
+            spaceId: info.accountSpaceId,
+            mode: .handling
+        )
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { try? await channel.open() }
+            group.addTask { try? await personal.open() }
+        }
+
+        documents = Documents(channelWidgets: channel, personalWidgets: personal)
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -5,12 +5,20 @@ import AnytypeCore
 
 struct HomeWidgetsView: View {
     let info: AccountInfo
+    let channelWidgetsObject: any BaseDocumentProtocol
+    let personalWidgetsObject: any BaseDocumentProtocol
     let context: WidgetScreenContext
     let output: (any HomeWidgetsModuleOutput & HomeBottomNavigationPanelModuleOutput)?
 
     var body: some View {
-        HomeWidgetsInternalView(info: info, context: context, output: output)
-            .id(info.hashValue)
+        HomeWidgetsInternalView(
+            info: info,
+            channelWidgetsObject: channelWidgetsObject,
+            personalWidgetsObject: personalWidgetsObject,
+            context: context,
+            output: output
+        )
+        .id(info.hashValue)
     }
 }
 
@@ -24,8 +32,19 @@ private struct HomeWidgetsInternalView: View {
     let context: WidgetScreenContext
     weak var panelOutput: (any HomeBottomNavigationPanelModuleOutput)?
 
-    init(info: AccountInfo, context: WidgetScreenContext, output: (any HomeWidgetsModuleOutput & HomeBottomNavigationPanelModuleOutput)?) {
-        self._model = State(wrappedValue: HomeWidgetsViewModel(info: info, output: output))
+    init(
+        info: AccountInfo,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        personalWidgetsObject: any BaseDocumentProtocol,
+        context: WidgetScreenContext,
+        output: (any HomeWidgetsModuleOutput & HomeBottomNavigationPanelModuleOutput)?
+    ) {
+        self._model = State(wrappedValue: HomeWidgetsViewModel(
+            info: info,
+            channelWidgetsObject: channelWidgetsObject,
+            personalWidgetsObject: personalWidgetsObject,
+            output: output
+        ))
         self.context = context
         self.panelOutput = output
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -14,7 +14,6 @@ final class HomeWidgetsViewModel {
     let channelWidgetsObject: any BaseDocumentProtocol
     let personalWidgetsObject: any BaseDocumentProtocol
 
-    private let documentService: any OpenedDocumentsProviderProtocol = Container.shared.openedDocumentProvider()
     @Injected(\.documentsProvider) @ObservationIgnored
     private var documentsProvider: any DocumentsProviderProtocol
     @Injected(\.participantSpacesStorage) @ObservationIgnored
@@ -47,15 +46,14 @@ final class HomeWidgetsViewModel {
 
     init(
         info: AccountInfo,
+        channelWidgetsObject: any BaseDocumentProtocol,
+        personalWidgetsObject: any BaseDocumentProtocol,
         output: (any HomeWidgetsModuleOutput)?
     ) {
         self.info = info
+        self.channelWidgetsObject = channelWidgetsObject
+        self.personalWidgetsObject = personalWidgetsObject
         self.output = output
-        self.channelWidgetsObject = documentService.document(objectId: info.widgetsId, spaceId: info.accountSpaceId)
-        self.personalWidgetsObject = documentService.document(
-            objectId: info.personalWidgetsId,
-            spaceId: info.accountSpaceId
-        )
     }
 
     func startSubscriptions() async {


### PR DESCRIPTION
## Summary
- Pre-open `info.widgetsId` and `info.personalWidgetsId` in parallel before mounting widget sections, so `Pinned` / `MyFavorites` no longer pop in mid-transition.
- New `HomeWidgetsDocumentsLoaderView` + VM gate the content closure inside `SpaceLoadingContainerView`; while docs load they show a wallpaper-only bridge frame (no second pulse).
- `HomeWidgetsViewModel.init` now receives the two opened docs as parameters instead of constructing them via `OpenedDocumentsProvider` (which was fire-and-forget).

Plan: `plans/PLAN_IOS_5812.md` (PR 1).