### PR TITLE
IOS-6180 Guard against stale offsets in slash/mention text replace

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewStateManager.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewStateManager.swift
@@ -301,10 +301,17 @@ final class AccessoryViewStateManagerImpl: AccessoryViewStateManager, CursorMode
         
         let startPosition = configuration.textView.offsetFromBegining(newMentionPosition)
         let caretOffsetFromStart = configuration.textView.offset(from: newMentionPosition, to: caretPosition)
-        
+
         let mutableString = NSMutableAttributedString(attributedString: configuration.textView.attributedText)
+
+        guard startPosition >= 0,
+              caretOffsetFromStart >= 0,
+              startPosition + caretOffsetFromStart <= mutableString.length else {
+            return nil
+        }
+
         mutableString.replaceCharacters(in: .init(location: startPosition, length: caretOffsetFromStart), with: "")
-        
+
         return (mutableString, startPosition)
     }
 }


### PR DESCRIPTION
## Summary
- Guard `attributedStringWithoutSearchSymbols` against stale offsets so a shrunken `attributedText` (CJK IME composition, `zh_CN` repro) no longer crashes `replaceCharacters` with `NSRangeException`.
- Validate `startPosition`, `caretOffsetFromStart`, and the combined upper bound against the snapshot length; both call sites already early-return on `nil`.
- No silent clamping — avoids leaving partial `/foo` artifacts in the saved block when state is stale.

Fixes IOS-93H