### PR TITLE
IOS-6178 Re-select spreadsheet cells by item identity after snapshot apply

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/CompositionalBlock/SpreadsheetDataSource.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/CompositionalBlock/SpreadsheetDataSource.swift
@@ -163,12 +163,14 @@ final class SpreadsheetViewDataSource {
         _ snapshot: Snapshot,
         animatingDifferences: Bool
     ) {
-        let selectedIndexPath = collectionView.indexPathsForSelectedItems
+        let selectedItems = collectionView.indexPathsForSelectedItems?
+            .compactMap { dataSource.itemIdentifier(for: $0) } ?? []
 
         dataSource.apply(snapshot, animatingDifferences: animatingDifferences)
 
-        selectedIndexPath?.forEach {
-            self.collectionView.selectItem(at: $0, animated: false, scrollPosition: [])
+        selectedItems.forEach { item in
+            guard let indexPath = dataSource.indexPath(for: item) else { return }
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix `NSInternalInconsistencyException` in `SpreadsheetViewDataSource.applyBlocksSectionSnapshot` when middleware emits `resetBlocks` and the new snapshot has fewer sections than were selected (Sentry `IOS-59D`, 293 events / 10 users).
- Capture selected `EditorItem`s by identity before `dataSource.apply`, then re-select via `dataSource.indexPath(for:)` after — items that no longer exist return `nil` and are skipped, eliminating the out-of-bounds crash.
- Bonus: selection now follows the same logical cell across row deletes instead of landing on whatever happened to shift into the old indexPath.

Fixes IOS-59D