### PR TITLE
IOS-6181 Fix Array.insert OOB in TypePropertiesMoveHandler

### DIFF
--- a/AnyTypeTests/Helpers/TypePropertiesMoveHandler/TypePropertiesMoveHandlerAdditionalTests.swift
+++ b/AnyTypeTests/Helpers/TypePropertiesMoveHandler/TypePropertiesMoveHandlerAdditionalTests.swift
@@ -6,7 +6,8 @@ class TypePropertiesMoveHandlerAdditionalTests: XCTestCase {
     var moveHandler: TypePropertiesMoveHandler!
     var mockDocument: MockBaseDocument!
     var mockPropertiesService: MockPropertiesService!
-    
+    var mockPropertyDetailsStorage: MockPropertyDetailsStorage!
+
     override func setUp() {
         super.setUp()
         let mockPropertiesService = MockPropertiesService()
@@ -14,6 +15,7 @@ class TypePropertiesMoveHandlerAdditionalTests: XCTestCase {
         let mockPropertyDetailsStorage = MockPropertyDetailsStorage()
         Container.shared.propertyDetailsStorage.register { mockPropertyDetailsStorage }
         self.mockPropertiesService = mockPropertiesService
+        self.mockPropertyDetailsStorage = mockPropertyDetailsStorage
         mockDocument = MockBaseDocument()
         moveHandler = TypePropertiesMoveHandler()
     }
@@ -187,5 +189,49 @@ class TypePropertiesMoveHandlerAdditionalTests: XCTestCase {
         } catch let error as TypePropertiesMoveError {
             XCTAssertEqual(error, .emptySection)
         }
+    }
+
+    // MARK: - IOS-6181 regression
+
+    // Reproduces Sentry IOS-8H5: middleware returns IDs in `recommendedFeaturedRelations`
+    // for which `PropertyDetailsStorage` has no entry, so the parallel details array is shorter.
+    // Pre-fix, the handler looked up `toIndex` in the IDs array and applied `toIndex + 1` to
+    // the (shorter) details array, trapping in `Array._checkIndex`.
+    func testMoveFromFieldsMenuToHeaderWithMissingFeaturedDetails() async throws {
+        // "h1" exists in the IDs array but the storage drops it (no PropertyDetails).
+        // So recommendedFeaturedRelationsDetails resolves to only [h2] — length 1.
+        mockPropertyDetailsStorage.missingIds = ["h1"]
+
+        let relationRows: [TypePropertiesRow] = [
+            .header(.header),
+            .relation(TypePropertiesRelationRow(section: .header, relation: .mock(id: "h2"), canDrag: true)),
+            .header(.fieldsMenu),
+            .relation(TypePropertiesRelationRow(section: .fieldsMenu, relation: .mock(id: "f1"), canDrag: true))
+        ]
+
+        mockDocument.mockDetails = ObjectDetails.mock(
+            recommendedFeaturedRelations: ["h1", "h2"],
+            recommendedRelations: ["f1"]
+        )
+
+        // Drag f1 onto h2 row in the header section. Pre-fix this trapped at
+        // `newFeaturedRelations.insert(fromRelation, at: toIndex + 1)`.
+        try await moveHandler.onMove(
+            from: 3,
+            to: 1,
+            relationRows: relationRows,
+            document: mockDocument
+        )
+
+        // f1 lands after h2 in the featured array; the orphaned h1 ID is dropped from the
+        // payload (it had no details, so it was never visible to the user anyway).
+        XCTAssertEqual(
+            mockPropertiesService.lastUpdateTypeProperties?.recommendedFeaturedProperties.map(\.id),
+            ["h2", "f1"]
+        )
+        XCTAssertEqual(
+            mockPropertiesService.lastUpdateTypeProperties?.recommendedProperties.map(\.id),
+            []
+        )
     }
 }

--- a/AnyTypeTests/Markdown/Mocks/MockPropertyDetailsStorage.swift
+++ b/AnyTypeTests/Markdown/Mocks/MockPropertyDetailsStorage.swift
@@ -5,26 +5,30 @@ import Services
 
 
 final class MockPropertyDetailsStorage: PropertyDetailsStorageProtocol, @unchecked Sendable {
+    // IDs the storage should pretend it has no PropertyDetails for. Mirrors the production
+    // case where `relationsDetails(ids:)` silently drops unknown IDs via compactMap.
+    var missingIds: Set<String> = []
+
     // Publisher for sync events
     private let syncSubject = PassthroughSubject<Void, Never>()
     var syncPublisher: AnyPublisher<Void, Never> {
         return syncSubject.eraseToAnyPublisher()
     }
-    
+
     func relationsDetails(keys: [String], spaceId: String) -> [PropertyDetails] {
         return keys.map { PropertyDetails.mock(key: $0) }
     }
-    
+
     func relationsDetails(key: String, spaceId: String) throws -> PropertyDetails {
         PropertyDetails.mock(key: key)
     }
-    
+
     func relationsDetails(bundledKey: BundledPropertyKey, spaceId: String) throws -> PropertyDetails {
         PropertyDetails.mock(key: bundledKey.rawValue)
     }
-    
+
     func relationsDetails(ids: [String], spaceId: String) -> [PropertyDetails] {
-        return ids.map { PropertyDetails.mock(id: $0) }
+        return ids.compactMap { missingIds.contains($0) ? nil : PropertyDetails.mock(id: $0) }
     }
     
     func relationsDetails(spaceId: String) -> [PropertyDetails] {

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/TypePropertiesView/Model/TypePropertiesMoveHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Properties/Views/TypePropertiesView/Model/TypePropertiesMoveHandler.swift
@@ -98,14 +98,11 @@ final class TypePropertiesMoveHandler: Sendable {
         
         switch from.section {
         case .header:
-            guard let fromIndex = details.recommendedFeaturedRelations.firstIndex(of: from.relation.id) else { return }
-            
-            let fromRelation = details.recommendedFeaturedRelationsDetails[fromIndex]
-            let newRecommendedRelations = [fromRelation]
-            
             var newFeaturedRelations = details.recommendedFeaturedRelationsDetails
-            newFeaturedRelations.remove(at: fromIndex)
-            
+            guard let fromIndex = newFeaturedRelations.firstIndex(where: { $0.id == from.relation.id }) else { return }
+            let fromRelation = newFeaturedRelations.remove(at: fromIndex)
+            let newRecommendedRelations = [fromRelation]
+
             try await move(
                 typeId: document.objectId,
                 from: from.section,
@@ -115,17 +112,14 @@ final class TypePropertiesMoveHandler: Sendable {
                 recommendedHiddenRelationsIds: details.recommendedHiddenRelationsDetails
             )
         case .fieldsMenu:
-            guard let fromIndex = details.recommendedRelations.firstIndex(of: from.relation.id) else { return }
-            
-            let fromRelation = details.recommendedRelationsDetails[fromIndex]
-            
             var newRecommendedRelations = details.recommendedRelationsDetails
-            newRecommendedRelations.remove(at: fromIndex)
-            
+            guard let fromIndex = newRecommendedRelations.firstIndex(where: { $0.id == from.relation.id }) else { return }
+            let fromRelation = newRecommendedRelations.remove(at: fromIndex)
+
             switch to {
             case .header:
                 let newFeaturedRelations = [fromRelation]
-                
+
                 try await move(
                     typeId: document.objectId,
                     from: from.section,
@@ -138,7 +132,7 @@ final class TypePropertiesMoveHandler: Sendable {
                 throw TypePropertiesMoveError.movingSectionToItself
             case .hidden:
                 let newHiddenRelations = [fromRelation]
-                
+
                 try await move(
                     typeId: document.objectId,
                     from: from.section,
@@ -149,15 +143,11 @@ final class TypePropertiesMoveHandler: Sendable {
                 )
             }
         case .hidden:
-            guard let fromIndex = details.recommendedHiddenRelations.firstIndex(of: from.relation.id) else { return }
-            
-            let fromRelation = details.recommendedHiddenRelationsDetails[fromIndex]
-            
             var newHiddenRelations = details.recommendedHiddenRelationsDetails
-            newHiddenRelations.remove(at: fromIndex)
-            
+            guard let fromIndex = newHiddenRelations.firstIndex(where: { $0.id == from.relation.id }) else { return }
+            let fromRelation = newHiddenRelations.remove(at: fromIndex)
             let newRecommendedRelations = [fromRelation]
-            
+
             try await move(
                 typeId: document.objectId,
                 from: from.section,
@@ -184,12 +174,12 @@ final class TypePropertiesMoveHandler: Sendable {
         
         switch from.section {
         case .header:
-            guard let fromIndex = details.recommendedFeaturedRelations.firstIndex(of: from.relation.id) else { return }
-            guard let toIndex = details.recommendedFeaturedRelations.firstIndex(of: to.relation.id) else { return }
             var recommendedFeaturedRelationsDetails = details.recommendedFeaturedRelationsDetails
+            guard let fromIndex = recommendedFeaturedRelationsDetails.firstIndex(where: { $0.id == from.relation.id }),
+                  let toIndex = recommendedFeaturedRelationsDetails.firstIndex(where: { $0.id == to.relation.id }) else { return }
             recommendedFeaturedRelationsDetails.moveElement(from: fromIndex, to: toIndex)
             AnytypeAnalytics.instance().logReorderRelation(group: nil)
-            
+
             try await move(
                 typeId: document.objectId,
                 from: from.section,
@@ -199,12 +189,12 @@ final class TypePropertiesMoveHandler: Sendable {
                 recommendedHiddenRelationsIds: details.recommendedHiddenRelationsDetails
             )
         case .fieldsMenu:
-            guard let fromIndex = details.recommendedRelations.firstIndex(of: from.relation.id) else { return }
-            guard let toIndex = details.recommendedRelations.firstIndex(of: to.relation.id) else { return }
             var recommendedRelationsDetails = details.recommendedRelationsDetails
+            guard let fromIndex = recommendedRelationsDetails.firstIndex(where: { $0.id == from.relation.id }),
+                  let toIndex = recommendedRelationsDetails.firstIndex(where: { $0.id == to.relation.id }) else { return }
             recommendedRelationsDetails.moveElement(from: fromIndex, to: toIndex)
             AnytypeAnalytics.instance().logReorderRelation(group: nil)
-            
+
             try await move(
                 typeId: document.objectId,
                 from: from.section,
@@ -214,12 +204,12 @@ final class TypePropertiesMoveHandler: Sendable {
                 recommendedHiddenRelationsIds: details.recommendedHiddenRelationsDetails
             )
         case .hidden:
-            guard let fromIndex = details.recommendedHiddenRelations.firstIndex(of: from.relation.id) else { return }
-            guard let toIndex = details.recommendedHiddenRelations.firstIndex(of: to.relation.id) else { return }
             var recommendedHiddenRelationsDetails = details.recommendedHiddenRelationsDetails
+            guard let fromIndex = recommendedHiddenRelationsDetails.firstIndex(where: { $0.id == from.relation.id }),
+                  let toIndex = recommendedHiddenRelationsDetails.firstIndex(where: { $0.id == to.relation.id }) else { return }
             recommendedHiddenRelationsDetails.moveElement(from: fromIndex, to: toIndex)
             AnytypeAnalytics.instance().logReorderRelation(group: nil)
-            
+
             try await move(
                 typeId: document.objectId,
                 from: from.section,
@@ -236,17 +226,14 @@ final class TypePropertiesMoveHandler: Sendable {
         
         switch from.section {
         case .header:
-            guard let fromIndex = details.recommendedFeaturedRelations.firstIndex(of: from.relation.id) else { return }
-            guard let toIndex = details.recommendedRelations.firstIndex(of: to.relation.id) else { return }
-            
-            let fromRelation = details.recommendedFeaturedRelationsDetails[fromIndex]
-            
             var newFeaturedRelations = details.recommendedFeaturedRelationsDetails
-            newFeaturedRelations.remove(at: fromIndex)
-            
+            guard let fromIndex = newFeaturedRelations.firstIndex(where: { $0.id == from.relation.id }) else { return }
+            let fromRelation = newFeaturedRelations.remove(at: fromIndex)
+
             var newRecommendedRelations = details.recommendedRelationsDetails
+            guard let toIndex = newRecommendedRelations.firstIndex(where: { $0.id == to.relation.id }) else { return }
             newRecommendedRelations.insert(fromRelation, at: toIndex)
-            
+
             try await move(
                 typeId: document.objectId,
                 from: from.section,
@@ -256,19 +243,16 @@ final class TypePropertiesMoveHandler: Sendable {
                 recommendedHiddenRelationsIds: details.recommendedHiddenRelationsDetails
             )
         case .fieldsMenu:
-            guard let fromIndex = details.recommendedRelations.firstIndex(of: from.relation.id) else { return }
-            
-            let fromRelation = details.recommendedRelationsDetails[fromIndex]
-            
             var newRecommendedRelations = details.recommendedRelationsDetails
-            newRecommendedRelations.remove(at: fromIndex)
-            
+            guard let fromIndex = newRecommendedRelations.firstIndex(where: { $0.id == from.relation.id }) else { return }
+            let fromRelation = newRecommendedRelations.remove(at: fromIndex)
+
             switch to.section {
             case .header:
-                guard let toIndex = details.recommendedFeaturedRelations.firstIndex(of: to.relation.id) else { return }
                 var newFeaturedRelations = details.recommendedFeaturedRelationsDetails
+                guard let toIndex = newFeaturedRelations.firstIndex(where: { $0.id == to.relation.id }) else { return }
                 newFeaturedRelations.insert(fromRelation, at: toIndex + 1) // Insert below target
-                
+
                 try await move(
                     typeId: document.objectId,
                     from: from.section,
@@ -280,17 +264,14 @@ final class TypePropertiesMoveHandler: Sendable {
             case .fieldsMenu:
                 throw TypePropertiesMoveError.movingSectionToItself
             case .hidden:
-                let newHiddenRelations: [PropertyDetails]
-                    
-                if details.recommendedHiddenRelations.isEmpty {
+                var newHiddenRelations = details.recommendedHiddenRelationsDetails
+                if newHiddenRelations.isEmpty {
                     newHiddenRelations = [fromRelation]
                 } else {
-                    guard let toIndex = details.recommendedHiddenRelations.firstIndex(of: to.relation.id) else { return }
-                    var recommendedHiddenRelationsDetails = details.recommendedHiddenRelationsDetails
-                    recommendedHiddenRelationsDetails.insert(fromRelation, at: toIndex)
-                    newHiddenRelations = recommendedHiddenRelationsDetails
+                    guard let toIndex = newHiddenRelations.firstIndex(where: { $0.id == to.relation.id }) else { return }
+                    newHiddenRelations.insert(fromRelation, at: toIndex)
                 }
-                
+
                 try await move(
                     typeId: document.objectId,
                     from: from.section,
@@ -301,17 +282,14 @@ final class TypePropertiesMoveHandler: Sendable {
                 )
             }
         case .hidden:
-            guard let fromIndex = details.recommendedHiddenRelations.firstIndex(of: from.relation.id) else { return }
-            guard let toIndex = details.recommendedRelations.firstIndex(of: to.relation.id) else { return }
-            
-            let fromRelation = details.recommendedHiddenRelationsDetails[fromIndex]
-            
             var newHiddenRelations = details.recommendedHiddenRelationsDetails
-            newHiddenRelations.remove(at: fromIndex)
-            
+            guard let fromIndex = newHiddenRelations.firstIndex(where: { $0.id == from.relation.id }) else { return }
+            let fromRelation = newHiddenRelations.remove(at: fromIndex)
+
             var newRecommendedRelations = details.recommendedRelationsDetails
+            guard let toIndex = newRecommendedRelations.firstIndex(where: { $0.id == to.relation.id }) else { return }
             newRecommendedRelations.insert(fromRelation, at: toIndex + 1) // Insert below target
-            
+
             try await move(
                 typeId: document.objectId,
                 from: from.section,


### PR DESCRIPTION
## Summary

- Fixes Sentry IOS-8H5: `EXC_BREAKPOINT` in `Array._checkIndex` from `TypePropertiesMoveHandler.moveBetweenSections`.
- Root cause: index lookups went through the parallel `recommendedFeaturedRelations` (IDs) array, but mutations were applied to `recommendedFeaturedRelationsDetails`. `PropertyDetailsStorage.relationsDetails(ids:)` `compactMap`s unresolved IDs, so the details array can be shorter than the IDs array, and `toIndex + 1` traps.
- Fix: search by `.id` directly inside the same details array we mutate, applied uniformly to all ~10 sites in the file (move-to-empty-section, moveWithinSection, moveBetweenSections × 3 from-section branches each). The OOB becomes structurally impossible.
- Adds a `missingIds` knob to `MockPropertyDetailsStorage` and a regression test reproducing the `.fieldsMenu → .header` crash path.

Fixes IOS-8H5