### PR TITLE
IOS-6182 Gate ChatContainerCell rebuilds on item identity

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatContainerCell.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatContainerCell.swift
@@ -23,6 +23,10 @@ final class ChatContainerCell<Item: Equatable & Hashable, Content: View>: UIColl
         guard let item, let builder, configuredItem != item else { return }
         configuredItem = item
 
+        // Builder is intentionally reused across SwiftUI update cycles for equal
+        // items. Any dynamic state it reads must be captured by reference (class)
+        // or via observation, never by value — otherwise the gate above will
+        // serve stale data.
         contentConfiguration = UIHostingConfiguration { [item, builder] in
             builder(item)
         }

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatContainerCell.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Collection/ChatContainerCell.swift
@@ -2,25 +2,36 @@ import UIKit
 import SwiftUI
 
 final class ChatContainerCell<Item: Equatable & Hashable, Content: View>: UICollectionViewCell {
-    
+
     private var item: Item?
     private var builder: ((Item) -> Content)?
-    
+    // Skipping rebuilds for transient UICellConfigurationState changes (focus,
+    // highlight, trait collection) avoids tearing down UIHostingContentView on
+    // every state transition — a known source of weak-store races during fast
+    // cell reuse on iOS 18.x.
+    private var configuredItem: Item?
+
     func setItem(_ item: Item, builder: ((Item) -> Content)?) {
         self.item = item
         self.builder = builder
         setNeedsUpdateConfiguration()
     }
-    
+
     override func updateConfiguration(using state: UICellConfigurationState) {
         super.updateConfiguration(using: state)
-        
-        if let item, let builder {
-            contentConfiguration = UIHostingConfiguration { [item, builder] in
-                builder(item)
-            }
-            .margins(.all, 0)
-            .minSize(height: 0)
+
+        guard let item, let builder, configuredItem != item else { return }
+        configuredItem = item
+
+        contentConfiguration = UIHostingConfiguration { [item, builder] in
+            builder(item)
         }
+        .margins(.all, 0)
+        .minSize(height: 0)
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        configuredItem = nil
     }
 }


### PR DESCRIPTION
## Summary

- `ChatContainerCell.updateConfiguration(using:)` was rebuilding `UIHostingConfiguration` on every UIKit state transition (focus, highlight, traits), not just on item changes. Each call discards the previous `UIHostingContentView` and instantiates a new one, opening a weak-store race window during fast cell reuse on iOS 18.x — root cause of Sentry IOS-5EM (38 events / 4 users on iPhone 13 / iOS 18.3.2).
- Fix: gate the rebuild on item identity via a `configuredItem` field; `prepareForReuse` clears the gate so the next item always installs fresh.
- Sentry breadcrumbs corroborate the diagnosis — a 28-event burst of `resignFirstResponder` (one per ~17ms frame) during the navigation transition into chat preceded the crash, exactly the focus-state churn that drove the wasted rebuilds.

Fixes IOS-5EM