### PR TITLE
IOS-6184 Deduplicate children by id in BaseDocument.makeChildren

### DIFF
--- a/Anytype/Sources/Models/Documents/Document/BaseDocument.swift
+++ b/Anytype/Sources/Models/Documents/Document/BaseDocument.swift
@@ -204,7 +204,23 @@ final class BaseDocument: BaseDocumentProtocol, @unchecked Sendable {
         guard let model = infoContainer.get(id: objectId) else {
             return children
         }
-        return model.flatChildrenTree(container: infoContainer)
+        let flat = model.flatChildrenTree(container: infoContainer)
+        var seen = Set<String>()
+        seen.reserveCapacity(flat.count)
+        var unique = [BlockInformation]()
+        unique.reserveCapacity(flat.count)
+        for info in flat {
+            if seen.insert(info.id).inserted {
+                unique.append(info)
+            }
+        }
+        if unique.count != flat.count {
+            anytypeAssertionFailure(
+                "Duplicate block ids in flat children tree",
+                info: ["objectId": objectId, "duplicates": "\(flat.count - unique.count)"]
+            )
+        }
+        return unique
     }
     
     private func triggerSync(updates: [DocumentUpdate]) {


### PR DESCRIPTION
## Summary
- Fixes `Dictionary(uniqueKeysWithValues:)` trap in `EditorCollectionFlowLayout.blockLayoutDetails` (Sentry IOS-8YX, 118 events / 47 users on 0.46.1+6).
- `ChildrenInfoTreeBuilder.flatList` has no visited-set guard, so a transient malformed middleware sequence can produce a flat list with duplicate ids. Enforce unique-by-id at the `BaseDocument` boundary so all downstream consumers (`childrenPublisher`, `flattenBlockIds`, `blockLayoutDetailsPublisher`, `isEmpty`) inherit the invariant.
- Single `anytypeAssertionFailure` per call (with duplicate count) surfaces upstream issues in DEBUG without spamming Sentry on corrupt trees. Likely also resolves the related `DynamicCollectionView.layoutSubviews` crash (IOS-259).

Fixes IOS-8YX