### PR TITLE
IOS-6188 Defer animated reloadInputViews to avoid cell dequeue crash

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewSwitcher.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewSwitcher.swift
@@ -110,13 +110,13 @@ final class AccessoryViewSwitcher: AccessoryViewSwitcherProtocol {
         }
         accessoryView.transform = CGAffineTransform(translationX: 0, y: accessoryView.bounds.size.height)
 
-        if animation {
-            UIView.animate(withDuration: CATransaction.animationDuration()) {
-                reloadInputViews()
-            }
-        } else {
-            // Defer: this can be reached from a UITextView delegate during cell dequeue; flushing layout there crashes on iOS 26.
-            DispatchQueue.main.async {
+        // Defer: this can be reached from a UITextView delegate during cell dequeue; flushing layout there crashes on iOS 26.
+        DispatchQueue.main.async {
+            if animation {
+                UIView.animate(withDuration: CATransaction.animationDuration()) {
+                    reloadInputViews()
+                }
+            } else {
                 reloadInputViews()
             }
         }


### PR DESCRIPTION
## Summary

- Hoist `DispatchQueue.main.async` outside the `if animation` branch in `AccessoryViewSwitcher.changeAccessoryView` so both animated and non-animated paths defer the layout flush.
- Closes the remaining iOS 26 cell-dequeue crash path that the IOS-6144 mitigation didn't cover (the animated branch was still calling `reloadInputViews()` synchronously inside `UIView.animate`, triggering `layoutIfNeeded` from a UITextView delegate during cell configuration).

Fixes IOS-91H
Fixes IOS-90A