### PR TITLE
IOS-6186 Stabilize Set sorts/filters row ids by underlying UUID

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/List/SetFiltersListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Filters/List/SetFiltersListViewModel.swift
@@ -105,7 +105,7 @@ extension SetFiltersListViewModel {
         rows = activeFilters.enumerated().map { index, filter in
             let isAdvanced = filter.isAdvanced
             return SetFilterRowConfiguration(
-                id: "\(filter.relationDetails.id)_\(index)",
+                id: filter.filter.id,
                 title: isAdvanced ? Loc.EditSet.Popup.Filter.Advanced.title : filter.relationDetails.name,
                 subtitle: isAdvanced ? Loc.EditSet.Popup.Filter.Advanced.subtitle : filter.conditionString,
                 iconAsset: isAdvanced ? .X24.lock : filter.relationDetails.format.iconAsset,

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Sorts/List/SetSortsListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Sorts/List/SetSortsListViewModel.swift
@@ -130,7 +130,7 @@ extension SetSortsListViewModel {
         let activeSorts = sorts.filter { !deletingSortIds.contains($0.sort.id) }
         rows = activeSorts.enumerated().map { index, sort in
             SetSortRowConfiguration(
-                id: "\(sort.relationDetails.id)_\(index)",
+                id: sort.sort.id,
                 title: sort.relationDetails.name,
                 subtitle: sort.typeTitle() ?? "",
                 iconAsset: sort.relationDetails.format.iconAsset,


### PR DESCRIPTION
## Summary
- Fixes recurring `NSInternalInconsistencyException` in `UpdateCoalescingCollectionView` when rapidly deleting rows in Edit mode on Set Sorts / Filters popups (Sentry IOS-5F5: 989 events / 216 users since 2024-08).
- Root cause: `SetSortsListViewModel` and `SetFiltersListViewModel` derived row `Identifiable.id` as `"\(relationDetails.id)_\(index)"`. The index suffix made identity unstable across `syncPublisher` re-emissions; combined with optimistic `rows.remove(atOffsets:)` and middleware-ack races, three rapid Edit-mode deletes land with renamed identities and trip the diff-vs-snapshot consistency check ("16 before, 14 after, 3 deletions / 0 insertions, short by 1").
- Fix: use `sort.sort.id` / `filter.filter.id` directly. These middleware-assigned UUIDs are already used as the dedup key in `deletingSortIds` / `deletingFilterIds`, so per-row uniqueness is established.

Fixes IOS-5F5