### PR TITLE
IOS-6187 Invalidate layout instead of reapplying snapshot in itemDidChangeFrame

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
@@ -396,8 +396,11 @@ extension EditorPageController: EditorPageViewInput {
 
     func itemDidChangeFrame(item: EditorItem) {
         DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            dataSource.apply(dataSource.snapshot(), animatingDifferences: true)
+            guard let self,
+                  let indexPath = dataSource.indexPath(for: item) else { return }
+            collectionView.collectionViewLayout.invalidateLayout(
+                with: CustomInvalidation(indexPaths: [indexPath])
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

- `EditorPageController.itemDidChangeFrame` was reapplying an identical snapshot (`dataSource.apply(dataSource.snapshot(), animatingDifferences: true)`) just to nudge UIKit into remeasuring one cell whose height changed. Because the outer `applyBlocksSectionSnapshot` is also async-animated, the synthetic re-apply interleaved with in-flight middleware updates and tripped UIKit's diffable reentrance guard (IOS-7DW, 42 events / 5 users) or returned a recycled cell mid-apply (IOS-5DF, 802 events / 83 users).
- Replace the snapshot reapply with a targeted `collectionViewLayout.invalidateLayout(with: CustomInvalidation([indexPath]))` — the same machinery `EditorCollectionFlowLayout` already uses for `blockLayoutDetailsPublisher` updates. Routes through the existing self-sizing handshake (`shouldInvalidateLayout` → `invalidationContext`) without entering the diffable apply queue, so reentrance is no longer possible.
- The Linear ticket's proposed fix #2 ("UIHostingConfiguration self-sizes, just remove the call") was rejected — text blocks use a custom UIKit `BlockConfiguration`, not `UIHostingConfiguration`; removing the call would break text-block growth while typing.

Fixes IOS-7DW
Fixes IOS-5DF