### PR TITLE
IOS-5812 Sync-seed home widget section VMs

### DIFF
--- a/AnyTypeTests/PresentationLayer/HomeWidgets/PinnedSectionViewModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/HomeWidgets/PinnedSectionViewModelTests.swift
@@ -58,7 +58,7 @@ struct PinnedSectionViewModelTests {
     }
 
     @Test func init_whenParticipantCanEdit_seedsReadwrite() {
-        participantsStorage.participants = [.mock(spaceId: "space-1", permission: .writer)]
+        participantsStorage.participants = [.mock(id: "p-1", permission: .writer, spaceId: "space-1")]
         let doc = makeDoc(widgetTargets: [])
 
         let model = PinnedSectionViewModel(spaceId: "space-1", channelWidgetsObject: doc)

--- a/AnyTypeTests/PresentationLayer/HomeWidgets/PinnedSectionViewModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/HomeWidgets/PinnedSectionViewModelTests.swift
@@ -57,6 +57,23 @@ struct PinnedSectionViewModelTests {
         #expect(recentStateManager.setupCallCount == 1)
     }
 
+    @Test func init_whenParticipantCanEdit_seedsReadwrite() {
+        participantsStorage.participants = [.mock(spaceId: "space-1", permission: .writer)]
+        let doc = makeDoc(widgetTargets: [])
+
+        let model = PinnedSectionViewModel(spaceId: "space-1", channelWidgetsObject: doc)
+
+        #expect(model.homeState == .readwrite)
+    }
+
+    @Test func init_whenNoParticipantForSpace_seedsReadonly() {
+        let doc = makeDoc(widgetTargets: [])
+
+        let model = PinnedSectionViewModel(spaceId: "space-1", channelWidgetsObject: doc)
+
+        #expect(model.homeState == .readonly)
+    }
+
     // MARK: - subscription path
 
     @Test func subscription_emittingSameState_keepsWidgetBlocksEqual() async throws {
@@ -156,7 +173,7 @@ private final class TestRecentStateManager: HomeWidgetsRecentStateManagerProtoco
 }
 
 private final class TestParticipantsStorage: ParticipantsStorageProtocol, @unchecked Sendable {
-    var participants: [Participant] { [] }
+    var participants: [Participant] = []
 
     var participantsSequence: AnyAsyncSequence<[Participant]> {
         AsyncStream<[Participant]> { _ in }.eraseToAnyAsyncSequence()

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
@@ -45,9 +45,7 @@ final class ObjectTypesSectionViewModel {
         self.spaceId = spaceId
         self.output = output
         self.objectTypeSectionIsExpanded = expandedService.isExpanded(section: .objects, defaultValue: true)
-        self.canCreateObjectType = participantsStorage.participants
-            .first { $0.spaceId == spaceId }?
-            .canEdit ?? false
+        self.canCreateObjectType = participantsStorage.canEdit(spaceId: spaceId)
     }
 
     // MARK: - Subscriptions

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesSectionViewModel.swift
@@ -45,6 +45,9 @@ final class ObjectTypesSectionViewModel {
         self.spaceId = spaceId
         self.output = output
         self.objectTypeSectionIsExpanded = expandedService.isExpanded(section: .objects, defaultValue: true)
+        self.canCreateObjectType = participantsStorage.participants
+            .first { $0.spaceId == spaceId }?
+            .canEdit ?? false
     }
 
     // MARK: - Subscriptions

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
@@ -36,6 +36,10 @@ final class PinnedSectionViewModel {
         self.spaceId = spaceId
         self.channelWidgetsObject = channelWidgetsObject
         self.widgetBlocks = buildWidgetBlocks()
+        let canEdit = participantsStorage.participants
+            .first { $0.spaceId == spaceId }?
+            .canEdit ?? false
+        self.homeState = canEdit ? .readwrite : .readonly
     }
 
     // MARK: - Subscriptions
@@ -62,7 +66,9 @@ final class PinnedSectionViewModel {
 
     private func startCanEditSubscription() async {
         for await canEdit in participantsStorage.canEditSequence(spaceId: spaceId) {
-            homeState = canEdit ? .readwrite : .readonly
+            let next: HomeWidgetsState = canEdit ? .readwrite : .readonly
+            guard homeState != next else { continue }
+            homeState = next
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
@@ -36,10 +36,7 @@ final class PinnedSectionViewModel {
         self.spaceId = spaceId
         self.channelWidgetsObject = channelWidgetsObject
         self.widgetBlocks = buildWidgetBlocks()
-        let canEdit = participantsStorage.participants
-            .first { $0.spaceId == spaceId }?
-            .canEdit ?? false
-        self.homeState = canEdit ? .readwrite : .readonly
+        self.homeState = participantsStorage.canEdit(spaceId: spaceId) ? .readwrite : .readonly
     }
 
     // MARK: - Subscriptions

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -44,14 +44,15 @@ final class UnreadSectionViewModel {
         self.spaceId = spaceId
         self.output = output
         self.unreadSectionIsExpanded = expandedService.isExpanded(section: .unread, defaultValue: true)
+        // Default to multi-chat when spaceView isn't loaded yet — the section is also gated
+        // by `unreadItems.isNotEmpty`, so multi-chat-but-empty stays invisible.
+        self.supportsMultiChats = !(workspaceStorage.spaceView(spaceId: spaceId)?.isOneToOne ?? false)
     }
 
     // MARK: - Subscriptions
 
     func startSubscriptions() async {
-        async let unreadSub: () = startUnreadItemsTask()
-        async let spaceViewSub: () = startSpaceViewTask()
-        _ = await (unreadSub, spaceViewSub)
+        await startUnreadItemsTask()
     }
 
     func onTapUnreadHeader() {
@@ -67,19 +68,13 @@ final class UnreadSectionViewModel {
         output?.onObjectSelected(screenData: data.details.screenData())
     }
 
-    private func startSpaceViewTask() async {
-        for await spaceView in workspaceStorage.spaceViewPublisher(spaceId: spaceId).removeDuplicates().values {
-            supportsMultiChats = !spaceView.isOneToOne
-        }
-    }
-
     private func startUnreadItemsTask() async {
         let spaceId = spaceId
         // No early-exit on isOneToOne — we'd capture the space type once and never observe
         // a 1:1 → multi-chat conversion. The combineLatest below re-fires on space-view
         // changes and the section's own visibility is gated by `supportsMultiChats`
-        // (set in startSpaceViewTask), so 1:1 spaces simply pay the cost of a few
-        // combineLatest emissions whose result the section ignores.
+        // (re-derived from each tick's `currentSpaceView`), so 1:1 spaces simply pay the
+        // cost of a few combineLatest emissions whose result the section ignores.
         let previewsSequence = await chatMessagesPreviewsStorage.previewsSequenceWithEmpty
         let chatsSequence = await chatDetailsStorage.allChatsSequence
         let spaceViewSequence = workspaceStorage.spaceViewPublisher(spaceId: spaceId).removeDuplicates().values
@@ -89,6 +84,9 @@ final class UnreadSectionViewModel {
         let chatTriple = combineLatest(previewsSequence, chatsSequence, spaceViewSequence)
         for await (triple, unreadBySpace) in combineLatest(chatTriple, unreadDiscussionsSequence) {
             let (previews, chatDetails, currentSpaceView) = triple
+
+            let nextSupportsMultiChats = !currentSpaceView.isOneToOne
+            if supportsMultiChats != nextSupportsMultiChats { supportsMultiChats = nextSupportsMultiChats }
 
             let chatItems: [UnreadSectionRowData] = previews.compactMap { preview in
                 guard preview.spaceId == spaceId else { return nil }

--- a/Anytype/Sources/ServiceLayer/ParticipantStorage/ParticipantsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/ParticipantStorage/ParticipantsStorage.swift
@@ -24,6 +24,10 @@ extension ParticipantsStorageProtocol {
     func canEditSequence(spaceId: String) -> AnyAsyncSequence<Bool> {
         participantSequence(spaceId: spaceId).map(\.permission.canEdit).removeDuplicates().eraseToAnyAsyncSequence()
     }
+
+    func canEdit(spaceId: String) -> Bool {
+        participants.first { $0.spaceId == spaceId }?.canEdit ?? false
+    }
 }
 
 actor ParticipantsStorage: ParticipantsStorageProtocol, Sendable {


### PR DESCRIPTION
## Summary

- `UnreadSectionViewModel`: sync-seed `supportsMultiChats` from `workspaceStorage.spaceView(spaceId:)?.isOneToOne` and drop the redundant second subscription to `spaceViewPublisher` — the same data is already in scope inside the existing `combineLatest`.
- `PinnedSectionViewModel` + `ObjectTypesSectionViewModel`: sync-seed `homeState` / `canCreateObjectType` from `participantsStorage.participants` in `init`, eliminating the brief readonly/disabled flash for editors during cold start.
- New `ParticipantsStorageProtocol.canEdit(spaceId:) -> Bool` extension mirroring the existing `canEditSequence(spaceId:)` async helper.