### PR TITLE
IOS-5812 Stop pinned-widget chat badges from blinking on cold open and nav-pop

### DIFF
--- a/AnyTypeTests/PresentationLayer/HomeWidgets/PinnedSectionViewModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/HomeWidgets/PinnedSectionViewModelTests.swift
@@ -58,7 +58,7 @@ struct PinnedSectionViewModelTests {
     }
 
     @Test func init_whenParticipantCanEdit_seedsReadwrite() {
-        participantsStorage.participants = [.mock(spaceId: "space-1", permission: .writer)]
+        participantsStorage.participants = [.mock(id: "p-1", permission: .writer, spaceId: "space-1")]
         let doc = makeDoc(widgetTargets: [])
 
         let model = PinnedSectionViewModel(spaceId: "space-1", channelWidgetsObject: doc)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -20,7 +20,8 @@ struct HomeWidgetsView: View {
 
 private struct HomeWidgetsInternalView: View {
     @State private var model: HomeWidgetsViewModel
-    @State private var shouldHideChatBadges: Bool = false
+    // Hide pinned-widget badges by default; UnreadSectionViewModel releases them on first tick.
+    @State private var shouldHideChatBadges: Bool = true
 
     let context: WidgetScreenContext
     weak var panelOutput: (any HomeBottomNavigationPanelModuleOutput)?
@@ -104,7 +105,7 @@ private struct HomeWidgetsInternalView: View {
             }
             .padding(.horizontal, 20)
             .fitIPadToReadableContentGuide()
-            .shouldHideChatBadges(shouldHideChatBadges)
+            .shouldHideChatBadges(model.visibleSections.contains(.unread) && shouldHideChatBadges)
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -105,7 +105,7 @@ private struct HomeWidgetsInternalView: View {
             }
             .padding(.horizontal, 20)
             .fitIPadToReadableContentGuide()
-            .shouldHideChatBadges(model.visibleSections.contains(.unread) && shouldHideChatBadges)
+            .shouldHideChatBadges(model.hasUnreadSection && shouldHideChatBadges)
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -44,6 +44,10 @@ final class HomeWidgetsViewModel {
             : sectionsConfiguration.visibleSections.filter { $0 != .bin }
     }
 
+    var hasUnreadSection: Bool {
+        sectionsConfiguration.visibleSections.contains(.unread)
+    }
+
     init(
         info: AccountInfo,
         output: (any HomeWidgetsModuleOutput)?

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionView.swift
@@ -49,12 +49,8 @@ private struct UnreadSectionViewInternal: View {
         .task {
             await model.startSubscriptions()
         }
-        .onChange(of: model.shouldHideChatBadges) { _, newValue in
+        .onChange(of: model.shouldHideChatBadges, initial: true) { _, newValue in
             onShouldHideBadgesChange(newValue)
-        }
-        .onDisappear {
-            // Section toggled off via Manage Sections — reset so chat badges aren't stuck hidden in sibling sections.
-            onShouldHideBadgesChange(false)
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -36,9 +36,14 @@ final class UnreadSectionViewModel {
     var unreadItems: [UnreadSectionRowData] = []
     var unreadSectionIsExpanded: Bool = false
     private var supportsMultiChats: Bool = false
+    // Pessimistic until the aggregator's first tick — see `shouldHideChatBadges`.
+    private var didLoadInitial: Bool = false
 
     var shouldShowUnreadSection: Bool { supportsMultiChats && unreadItems.isNotEmpty }
-    var shouldHideChatBadges: Bool { shouldShowUnreadSection && unreadSectionIsExpanded }
+    var shouldHideChatBadges: Bool {
+        guard didLoadInitial else { return true }
+        return shouldShowUnreadSection && unreadSectionIsExpanded
+    }
 
     init(spaceId: String, output: (any CommonWidgetModuleOutput)?) {
         self.spaceId = spaceId
@@ -84,6 +89,9 @@ final class UnreadSectionViewModel {
         let chatTriple = combineLatest(previewsSequence, chatsSequence, spaceViewSequence)
         for await (triple, unreadBySpace) in combineLatest(chatTriple, unreadDiscussionsSequence) {
             let (previews, chatDetails, currentSpaceView) = triple
+
+            // Flip even when the dedupe `guard` below skips the row diff — we now know the real state.
+            if !didLoadInitial { didLoadInitial = true }
 
             let nextSupportsMultiChats = !currentSpaceView.isOneToOne
             if supportsMultiChats != nextSupportsMultiChats { supportsMultiChats = nextSupportsMultiChats }


### PR DESCRIPTION
## Summary
- Pinned-widget chat badges defaulted to *visible* and the Unread section claimed them once its aggregator finished loading — visible as a "blink" on cold open. The same `UnreadSectionView.onDisappear` reset that handled Manage-Sections-toggle-off also fired on every navigation push, causing the same blink on pop-back.
- Flip the polarity: default to *hidden*, let the Unread section *release* badges on its first aggregator tick. The Manage-Sections-toggle-off case is now covered by guarding the env application on `HomeWidgetsViewModel.hasUnreadSection`, so the `onDisappear` reset is gone.
- `hasUnreadSection` reads `sectionsConfiguration.visibleSections.contains(.unread)` directly, avoiding the filter-array allocation that `visibleSections` runs on every render.