### PR TITLE
IOS-6190 Defer featured properties reconfigure to next runloop

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedPropertiesBlockViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/FeaturedRelations/FeaturedPropertiesBlockViewModel.swift
@@ -32,9 +32,13 @@ final class FeaturedPropertiesBlockViewModel: BlockViewModelProtocol {
             .receiveOnMain()
             .removeDuplicates()
             .sink { [weak self] newFeaturedRelations in
-                guard let self else { return }
-                if featuredRelations != newFeaturedRelations {
-                    self.featuredRelations = newFeaturedRelations
+                guard let self, featuredRelations != newFeaturedRelations else { return }
+                self.featuredRelations = newFeaturedRelations
+                // Defer reconfigure to next runloop tick so it never lands on the main queue
+                // while an animated dataSource.apply from applyBlocksSectionSnapshot is in flight
+                // (UIKit's diffable data source deadlock detector otherwise throws).
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
                     collectionController.reconfigure(items: [.block(self)])
                 }
             }.store(in: &cancellables)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
@@ -315,38 +315,33 @@ extension EditorPageController: EditorPageViewInput {
     func reconfigure(items: [EditorItem]) {
         guard items.count > 0 else { return }
 
-        let snapshot = dataSource.snapshot()
-        let existingItems = items.filter { snapshot.itemIdentifiers.contains($0) }
+        var snapshot = dataSource.snapshot()
         let notExistingItems = items.filter { !snapshot.itemIdentifiers.contains($0) }
-
-        // Refresh visible cells directly to avoid racing dataSource.apply against
-        // an in-flight applyBlocksSectionSnapshot (UIKit deadlock detector trips).
-        // Off-screen cells pick up the new configuration via cellRegistration on dequeue.
-        existingItems.forEach { reloadCell(for: $0) }
-
-        // Identity swap (e.g. BlockFileViewModel -> BlockImageViewModel on upload)
-        // still requires a snapshot edit.
-        guard !notExistingItems.isEmpty else { return }
-
-        var swapSnapshot = snapshot
+        
+        // If we received an update for item not presented in a data source
+        // probably the new item is a new view model for an existing block. So we have to check by ID.
+        // Example: BlockFileViewModel -> BlockImageViewModel when uploading image into file block
         for item in notExistingItems {
-            guard let oldItem = swapSnapshot.itemIdentifiers.first(where: { $0.blockId == item.blockId }) else {
+            guard let oldItem = snapshot.itemIdentifiers.first(where: { $0.blockId == item.blockId }) else {
                 continue
             }
-            guard let index = swapSnapshot.indexOfItem(oldItem),
-                  let previousItem = swapSnapshot.itemIdentifiers[safe: index - 1] else {
+            guard let index = snapshot.indexOfItem(oldItem) else { continue }
+            guard let previousItem = snapshot.itemIdentifiers[safe: index - 1] else {
                 anytypeAssertionFailure(
                     "Not found previous item in snapshot",
                     info: ["oldItem": String(describing: oldItem)]
                 )
                 continue
             }
-
-            swapSnapshot.deleteItems([oldItem])
-            swapSnapshot.insertItems([item], afterItem: previousItem)
+            
+            snapshot.deleteItems([oldItem])
+            snapshot.insertItems([item], afterItem: previousItem)
         }
-
-        dataSource.apply(swapSnapshot, animatingDifferences: true)
+        
+        let existingItems = items.filter { snapshot.itemIdentifiers.contains($0) }
+        snapshot.reconfigureItems(existingItems)
+        
+        dataSource.apply(snapshot, animatingDifferences: true)
     }
 
     func update(

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
@@ -315,33 +315,38 @@ extension EditorPageController: EditorPageViewInput {
     func reconfigure(items: [EditorItem]) {
         guard items.count > 0 else { return }
 
-        var snapshot = dataSource.snapshot()
+        let snapshot = dataSource.snapshot()
+        let existingItems = items.filter { snapshot.itemIdentifiers.contains($0) }
         let notExistingItems = items.filter { !snapshot.itemIdentifiers.contains($0) }
-        
-        // If we received an update for item not presented in a data source
-        // probably the new item is a new view model for an existing block. So we have to check by ID.
-        // Example: BlockFileViewModel -> BlockImageViewModel when uploading image into file block
+
+        // Refresh visible cells directly to avoid racing dataSource.apply against
+        // an in-flight applyBlocksSectionSnapshot (UIKit deadlock detector trips).
+        // Off-screen cells pick up the new configuration via cellRegistration on dequeue.
+        existingItems.forEach { reloadCell(for: $0) }
+
+        // Identity swap (e.g. BlockFileViewModel -> BlockImageViewModel on upload)
+        // still requires a snapshot edit.
+        guard !notExistingItems.isEmpty else { return }
+
+        var swapSnapshot = snapshot
         for item in notExistingItems {
-            guard let oldItem = snapshot.itemIdentifiers.first(where: { $0.blockId == item.blockId }) else {
+            guard let oldItem = swapSnapshot.itemIdentifiers.first(where: { $0.blockId == item.blockId }) else {
                 continue
             }
-            guard let index = snapshot.indexOfItem(oldItem) else { continue }
-            guard let previousItem = snapshot.itemIdentifiers[safe: index - 1] else {
+            guard let index = swapSnapshot.indexOfItem(oldItem),
+                  let previousItem = swapSnapshot.itemIdentifiers[safe: index - 1] else {
                 anytypeAssertionFailure(
                     "Not found previous item in snapshot",
                     info: ["oldItem": String(describing: oldItem)]
                 )
                 continue
             }
-            
-            snapshot.deleteItems([oldItem])
-            snapshot.insertItems([item], afterItem: previousItem)
+
+            swapSnapshot.deleteItems([oldItem])
+            swapSnapshot.insertItems([item], afterItem: previousItem)
         }
-        
-        let existingItems = items.filter { snapshot.itemIdentifiers.contains($0) }
-        snapshot.reconfigureItems(existingItems)
-        
-        dataSource.apply(snapshot, animatingDifferences: true)
+
+        dataSource.apply(swapSnapshot, animatingDifferences: true)
     }
 
     func update(


### PR DESCRIPTION
## Summary

- Defers `collectionController.reconfigure(items:)` in `FeaturedPropertiesBlockViewModel` to the next runloop tick via `DispatchQueue.main.async`, so it never races a still-in-flight animated `dataSource.apply` from `applyBlocksSectionSnapshot`. UIKit's diffable-data-source deadlock detector throws otherwise.
- Surgical fix at one callsite — narrows the IOS-9ZR race window for the only caller production has actually flagged. Other reconfigure callsites stay on their current path.

Fixes IOS-9ZR