### PR TITLE
IOS-6185 Guard SFSafariViewController against non-http URL schemes

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/SafariWebView/SafariWebView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/SafariWebView/SafariWebView.swift
@@ -3,18 +3,37 @@ import SafariServices
 
 extension View {
     func safariFullScreen(url: Binding<URL?>) -> some View {
-        self.fullScreenCover(item: url) {
-            SafariWebView(url: $0)
-                .ignoresSafeArea()
-        }
+        self
+            .onChange(of: url.wrappedValue) { _, newValue in
+                guard let value = newValue, !value.containsHttpProtocol else { return }
+                url.wrappedValue = nil
+                UIApplication.shared.open(value)
+            }
+            .fullScreenCover(item: safariOnlyBinding(url)) {
+                SafariWebView(url: $0)
+                    .ignoresSafeArea()
+            }
     }
-    
+
     func safariSheet(url: Binding<URL?>) -> some View {
-        self.sheet(item: url) {
-            SafariWebView(url: $0)
-                .ignoresSafeArea()
-        }
+        self
+            .onChange(of: url.wrappedValue) { _, newValue in
+                guard let value = newValue, !value.containsHttpProtocol else { return }
+                url.wrappedValue = nil
+                UIApplication.shared.open(value)
+            }
+            .sheet(item: safariOnlyBinding(url)) {
+                SafariWebView(url: $0)
+                    .ignoresSafeArea()
+            }
     }
+}
+
+private func safariOnlyBinding(_ url: Binding<URL?>) -> Binding<URL?> {
+    Binding(
+        get: { url.wrappedValue?.containsHttpProtocol == true ? url.wrappedValue : nil },
+        set: { url.wrappedValue = $0 }
+    )
 }
 
 struct SafariWebView: UIViewControllerRepresentable {

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/SafariWebView/SafariWebView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/SafariWebView/SafariWebView.swift
@@ -4,11 +4,7 @@ import SafariServices
 extension View {
     func safariFullScreen(url: Binding<URL?>) -> some View {
         self
-            .onChange(of: url.wrappedValue) { _, newValue in
-                guard let value = newValue, !value.containsHttpProtocol else { return }
-                url.wrappedValue = nil
-                UIApplication.shared.open(value)
-            }
+            .modifier(NonHttpURLRouter(url: url))
             .fullScreenCover(item: safariOnlyBinding(url)) {
                 SafariWebView(url: $0)
                     .ignoresSafeArea()
@@ -17,15 +13,24 @@ extension View {
 
     func safariSheet(url: Binding<URL?>) -> some View {
         self
-            .onChange(of: url.wrappedValue) { _, newValue in
-                guard let value = newValue, !value.containsHttpProtocol else { return }
-                url.wrappedValue = nil
-                UIApplication.shared.open(value)
-            }
+            .modifier(NonHttpURLRouter(url: url))
             .sheet(item: safariOnlyBinding(url)) {
                 SafariWebView(url: $0)
                     .ignoresSafeArea()
             }
+    }
+}
+
+private struct NonHttpURLRouter: ViewModifier {
+    @Environment(\.openURL) private var openURL
+    @Binding var url: URL?
+
+    func body(content: Content) -> some View {
+        content.onChange(of: url) { _, newValue in
+            guard let value = newValue, !value.containsHttpProtocol else { return }
+            url = nil
+            openURL(value)
+        }
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/Modules/SafariBookmarkObject/SafariBookmarkModifier.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SafariBookmarkObject/SafariBookmarkModifier.swift
@@ -12,6 +12,7 @@ extension View {
 
 struct SafariBookmarkModifier: ViewModifier {
 
+    @Environment(\.openURL) private var openURL
     @Binding var screenData: BookmarkScreenData?
     var onOpenBookmarkAsObject: (_ data: BookmarkScreenData) -> Void
 
@@ -20,7 +21,7 @@ struct SafariBookmarkModifier: ViewModifier {
             .onChange(of: screenData) { _, newValue in
                 guard let url = newValue?.url, !url.containsHttpProtocol else { return }
                 screenData = nil
-                UIApplication.shared.open(url)
+                openURL(url)
             }
             .sheet(item: safariBinding) { data in
                 SafariBookmarkView(url: data.url) {

--- a/Anytype/Sources/PresentationLayer/Modules/SafariBookmarkObject/SafariBookmarkModifier.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SafariBookmarkObject/SafariBookmarkModifier.swift
@@ -11,18 +11,30 @@ extension View {
 }
 
 struct SafariBookmarkModifier: ViewModifier {
-    
+
     @Binding var screenData: BookmarkScreenData?
     var onOpenBookmarkAsObject: (_ data: BookmarkScreenData) -> Void
-    
+
     func body(content: Content) -> some View {
         content
-            .sheet(item: $screenData) { data in
+            .onChange(of: screenData) { _, newValue in
+                guard let url = newValue?.url, !url.containsHttpProtocol else { return }
+                screenData = nil
+                UIApplication.shared.open(url)
+            }
+            .sheet(item: safariBinding) { data in
                 SafariBookmarkView(url: data.url) {
                     screenData = nil
                     onOpenBookmarkAsObject(data)
                 }
                 .ignoresSafeArea()
             }
+    }
+
+    private var safariBinding: Binding<BookmarkScreenData?> {
+        Binding(
+            get: { screenData?.url.containsHttpProtocol == true ? screenData : nil },
+            set: { screenData = $0 }
+        )
     }
 }


### PR DESCRIPTION
## Summary

- `SFSafariViewController(url:)` raises `NSInvalidArgumentException` for non-http(s) URLs (`mailto:`, `tel:`, `obsidian://`, etc.); guards at `SafariBookmarkModifier` and the `safariSheet`/`safariFullScreen` presenters now filter non-http URLs out of the sheet binding so SFSafariVC is never constructed with an unsupported scheme.
- Non-http URLs route through SwiftUI's `\.openURL` environment, hooking into the existing `AppSceneUrlHandlerModifier.OpenURLAction` (system handler + clipboard fallback already wired).
- Extracted `NonHttpURLRouter: ViewModifier` to dedupe the routing between `safariSheet` and `safariFullScreen`.

Fixes IOS-8DM