### PR TITLE
IOS-5812 Sync-seed SetDocument participant to drop pinned-set + button blink

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
@@ -292,16 +292,15 @@ final class SetObjectWidgetInternalViewModel {
         setDocument = newSetDocument
         try? await newSetDocument.open()
 
-        // dataView blocks and participant permissions may sync after open() returns;
-        // re-pull body state and create-permission when SetDocument re-emits.
+        // dataView blocks and permissions sync after open(); re-pull on emit.
         dataviewUpdateTask = Task { [weak self] in
             for await update in newSetDocument.setUpdatePublisher.values {
                 guard case .dataviewUpdated = update else { continue }
-                await self?.updateBodyState()
                 guard let self else { continue }
+                await updateBodyState()
                 let nextAllowCreate = newSetDocument.setPermissions.canCreateObject
-                if self.allowCreateObject != nextAllowCreate {
-                    self.allowCreateObject = nextAllowCreate
+                if allowCreateObject != nextAllowCreate {
+                    allowCreateObject = nextAllowCreate
                 }
             }
         }
@@ -314,11 +313,7 @@ final class SetObjectWidgetInternalViewModel {
     
     private func updateModelState() async {
         await updateBodyState()
-
-        // Don't read setPermissions here: it's only assigned inside SetDocument.updateData(),
-        // which is dispatched async via syncPublisher.receiveOnMain(). At this point we'd see
-        // the all-false SetPermissions() default. The dataviewUpdated subscription below
-        // catches the real value as soon as updateData() runs.
+        // setPermissions is assigned async by SetDocument.updateData(); read it in dataviewUpdateTask.
         guard let setDocument, let details = setDocument.details else { return }
         name = details.pluralTitle
         icon = details.objectIconImage

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
@@ -292,11 +292,17 @@ final class SetObjectWidgetInternalViewModel {
         setDocument = newSetDocument
         try? await newSetDocument.open()
 
-        // dataView blocks may sync after open() returns; re-trigger updateBodyState when they do.
+        // dataView blocks and participant permissions may sync after open() returns;
+        // re-pull body state and create-permission when SetDocument re-emits.
         dataviewUpdateTask = Task { [weak self] in
             for await update in newSetDocument.setUpdatePublisher.values {
                 guard case .dataviewUpdated = update else { continue }
                 await self?.updateBodyState()
+                guard let self else { continue }
+                let nextAllowCreate = newSetDocument.setPermissions.canCreateObject
+                if self.allowCreateObject != nextAllowCreate {
+                    self.allowCreateObject = nextAllowCreate
+                }
             }
         }
 
@@ -308,11 +314,12 @@ final class SetObjectWidgetInternalViewModel {
     
     private func updateModelState() async {
         await updateBodyState()
-    
-        guard let setDocument else { return }
-        allowCreateObject = setDocument.setPermissions.canCreateObject
-        
-        guard let details = setDocument.details else { return }
+
+        // Don't read setPermissions here: it's only assigned inside SetDocument.updateData(),
+        // which is dispatched async via syncPublisher.receiveOnMain(). At this point we'd see
+        // the all-false SetPermissions() default. The dataviewUpdated subscription below
+        // catches the real value as soon as updateData() runs.
+        guard let setDocument, let details = setDocument.details else { return }
         name = details.pluralTitle
         icon = details.objectIconImage
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/SetDocument.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/SetDocument.swift
@@ -250,10 +250,7 @@ final class SetDocument: SetDocumentProtocol, @unchecked Sendable {
     
     private func setup() {
         guard subscriptions.isEmpty else { return }
-        // Seed participant before any updateData() runs, otherwise the first
-        // setPermissions build sees the stale `false` default and consumers
-        // observe a brief permission-denied flicker before the canEditSequence
-        // Task yields.
+        // Seed before first updateData(); canEditSequence yields async and would flicker setPermissions.
         participantIsEditor = accountParticipantsStorage.canEdit(spaceId: spaceId)
         document.syncPublisher.receiveOnMain().sink { [weak self] update in
             self?.updateData()

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/SetDocument.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/SetDocument.swift
@@ -250,6 +250,11 @@ final class SetDocument: SetDocumentProtocol, @unchecked Sendable {
     
     private func setup() {
         guard subscriptions.isEmpty else { return }
+        // Seed participant before any updateData() runs, otherwise the first
+        // setPermissions build sees the stale `false` default and consumers
+        // observe a brief permission-denied flicker before the canEditSequence
+        // Task yields.
+        participantIsEditor = accountParticipantsStorage.canEdit(spaceId: spaceId)
         document.syncPublisher.receiveOnMain().sink { [weak self] update in
             self?.updateData()
         }
@@ -291,7 +296,7 @@ final class SetDocument: SetDocumentProtocol, @unchecked Sendable {
         let shouldClearState = shouldClearState(prevActiveView: prevActiveView)
         updateSubject.send(.dataviewUpdated(clearState: shouldClearState))
         setPermissions = permissionsBuilder.build(setDocument: self, participantCanEdit: participantIsEditor)
-        
+
         triggerSync()
     }
     


### PR DESCRIPTION
## Summary
- Pinned set/chat/object-type widgets briefly flicker their `+` button (`true → false → true`) on space open. Cause: `SetDocument.participantIsEditor` defaults to `false` and is only updated by an internal async `canEditSequence` Task — so the first `setPermissions` build uses stale inputs and consumers observe the flip.
- Sync-seed `participantIsEditor` in `SetDocument.setup()` from the existing `accountParticipantsStorage.canEdit(spaceId:)` helper before any `updateData()` runs. The first `setPermissions` is now correct, no flip.
- In `SetObjectWidgetInternalViewModel`, drop the stale `setPermissions` read in `updateModelState()` (it always saw the all-`false` `SetPermissions()` default since `setPermissions` is only assigned inside `updateData()` dispatched async via `syncPublisher.receiveOnMain()`). Read from the `dataviewUpdated` subscription instead, with a `!=` guard so repeated fires don't churn `@Observable`.