### PR TITLE
IOS-6197 Use localizedStandardContains for user-facing string search

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/CodeLanguage/CodeLanguageListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/CodeLanguage/CodeLanguageListViewModel.swift
@@ -48,7 +48,7 @@ final class CodeLanguageListViewModel {
         
         let languages = searchText.isEmpty
             ? CodeLanguage.allCases
-            : CodeLanguage.allCases.filter { $0.title.lowercased().contains(searchText.lowercased()) }
+            : CodeLanguage.allCases.filter { $0.title.localizedStandardContains(searchText) }
         
         rows = languages.map { language in
             CodeLanguageRowModel(

--- a/Anytype/Sources/PresentationLayer/Modules/SelectMembers/SelectMembersViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SelectMembers/SelectMembersViewModel.swift
@@ -27,8 +27,8 @@ final class SelectMembersViewModel {
     var filteredContacts: [Contact] {
         guard searchText.isNotEmpty else { return contacts }
         return contacts.filter {
-            $0.name.localizedCaseInsensitiveContains(searchText) ||
-            $0.globalName.localizedCaseInsensitiveContains(searchText)
+            $0.name.localizedStandardContains(searchText) ||
+            $0.globalName.localizedStandardContains(searchText)
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/SharingExtensionShareTo/SharingExtensionShareToViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SharingExtensionShareTo/SharingExtensionShareToViewModel.swift
@@ -166,7 +166,7 @@ final class SharingExtensionShareToViewModel {
             chatDisplayMode = chatRows.isEmpty ? nil : .individualChats(chatRows)
         } else {
             let canShowSendToChat = spaceView?.canAddChatWidget ?? false
-            let matchesSearch = searchText.isEmpty || sendToChatTitle.lowercased().contains(searchText.lowercased())
+            let matchesSearch = searchText.isEmpty || sendToChatTitle.localizedStandardContains(searchText)
             if canShowSendToChat && matchesSearch {
                 chatDisplayMode = .sendToChat(SharingExtensionsChatRowData(title: sendToChatTitle, selected: sendToChatSelected))
             } else {

--- a/Anytype/Sources/PresentationLayer/Modules/SimpleSearchListView/SimpleSearchListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SimpleSearchListView/SimpleSearchListViewModel.swift
@@ -21,7 +21,7 @@ final class SimpleSearchListViewModel {
     func search() async {
         if searchText.isNotEmpty {
             searchedItems = items.filter {
-                $0.title.range(of: searchText, options: .caseInsensitive) != nil
+                $0.title.localizedStandardContains(searchText)
             }
         } else {
             searchedItems = items

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -255,7 +255,7 @@ final class SpaceHubViewModel {
             spacesToFilter = spaces
         } else {
             spacesToFilter = spaces.filter { space in
-                space.spaceView.name.localizedCaseInsensitiveContains(searchText)
+                space.spaceView.name.localizedStandardContains(searchText)
             }
         }
 

--- a/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Common/WidgetObjectListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/WidgetObjectList/Common/WidgetObjectListViewModel.swift
@@ -137,10 +137,10 @@ final class WidgetObjectListViewModel: ObservableObject, OptionsItemProvider, Wi
         
         var filteredDetails: [WidgetObjectListDetailsData]
         
-        if let searchText = searchText?.lowercased(), searchText.isNotEmpty {
+        if let searchText, searchText.isNotEmpty {
             filteredDetails = rowDetails.map { section in
                 var section = section
-                section.details = section.details.filter { $0.title.range(of: searchText, options: .caseInsensitive) != nil }
+                section.details = section.details.filter { $0.title.localizedStandardContains(searchText) }
                 return section
             }
             .filter { $0.details.isNotEmpty }

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Builders/FilterModels/SlashMenuComparator.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Builders/FilterModels/SlashMenuComparator.swift
@@ -16,7 +16,7 @@ struct SlashMenuComparator {
         let title = data.title
         let comparators = [
             SlashMenuComparator(
-                predicate: { title?.localizedStandardCompare($0) == .orderedSame },
+                predicate: { title?.compare($0, options: [.caseInsensitive, .diacriticInsensitive], locale: .current) == .orderedSame },
                 result: isSingleAction ? .singleActionFullTitle : .fullTitle
             ),
             SlashMenuComparator(

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Builders/FilterModels/SlashMenuComparator.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Builders/FilterModels/SlashMenuComparator.swift
@@ -13,27 +13,27 @@ struct SlashMenuComparator {
     @MainActor
     static func match(slashAction: SlashAction, string: String, isSingleAction: Bool = false) -> SlashActionFilterMatch? {
         let data = slashAction.displayData
-        let lowecasedTitle = data.title?.lowercased()
+        let title = data.title
         let comparators = [
             SlashMenuComparator(
-                predicate: { lowecasedTitle == $0 },
+                predicate: { title?.localizedStandardCompare($0) == .orderedSame },
                 result: isSingleAction ? .singleActionFullTitle : .fullTitle
             ),
             SlashMenuComparator(
-                predicate: { lowecasedTitle?.contains($0) ?? false },
+                predicate: { title?.localizedStandardContains($0) ?? false },
                 result: isSingleAction ? .singleActionTitleSubstring : .titleSubstring
             ),
             SlashMenuComparator(
-                predicate: { search in data.titleSynonyms?.contains { $0.lowercased().contains(search) } ?? false },
+                predicate: { search in data.titleSynonyms?.contains { $0.localizedStandardContains(search) } ?? false },
                 result: .titleSynonymsSubstring
             ),
             SlashMenuComparator(
-                predicate: { search in data.aliases?.contains { $0.contains(search) } ?? false },
+                predicate: { search in data.aliases?.contains { $0.localizedStandardContains(search) } ?? false },
                 result: .aliaseSubstring
             ),
         ]
 
-        guard let result = comparators.first(where: { $0.predicate(string.lowercased()) })?.result else {
+        guard let result = comparators.first(where: { $0.predicate(string) })?.result else {
             return nil
         }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Builders/SlashMenuCellDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/SlashMenu/Builders/SlashMenuCellDataBuilder.swift
@@ -32,7 +32,7 @@ final class SlashMenuCellDataBuilder {
             }
             return nil
         case .multi(let type, let children):
-            if type.title.localizedCaseInsensitiveContains(filter) {
+            if type.title.localizedStandardContains(filter) {
                 return SlashMenuFilteredItem(title: type.title, topMatch: .groupName, actions: children)
             } else {
                 return filterItemContent(item: item, filter: filter)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Icon/Common/CustomIcons/CustomIconGridView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Icon/Common/CustomIcons/CustomIconGridView.swift
@@ -17,7 +17,7 @@ struct CustomIconGridView: View {
             return CustomIcon.allCases
         }
         
-        return CustomIcon.allCases.filter { $0.rawValue.lowercased().contains(searchText.lowercased()) }
+        return CustomIcon.allCases.filter { $0.rawValue.localizedStandardContains(searchText) }
     }
     
     private let columns = [

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Icon/Common/Emoji/EmojiProvider.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Icon/Common/Emoji/EmojiProvider.swift
@@ -18,13 +18,11 @@ final class EmojiProvider: @unchecked Sendable {
         defer { lock.unlock() }
         
         guard !keyword.isEmpty else { return emojiGroups }
-        
-        let lowercasedKeyword = keyword.lowercased()
-        
+
         let filteredGroups: [EmojiGroup] = emojiGroups.compactMap { group in
             let filteredEmoji: [EmojiData] = group.emojis.filter { emoji in
                 emoji.searchTerms.first { searchTerm in
-                    searchTerm.lowercased().range(of: lowercasedKeyword).isNotNil
+                    searchTerm.localizedStandardContains(keyword)
                 }.isNotNil
             }
             

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Icon/Common/Emoji/EmojiProvider.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/Icon/Common/Emoji/EmojiProvider.swift
@@ -21,9 +21,7 @@ final class EmojiProvider: @unchecked Sendable {
 
         let filteredGroups: [EmojiGroup] = emojiGroups.compactMap { group in
             let filteredEmoji: [EmojiData] = group.emojis.filter { emoji in
-                emoji.searchTerms.first { searchTerm in
-                    searchTerm.localizedStandardContains(keyword)
-                }.isNotNil
+                emoji.searchTerms.contains { $0.localizedStandardContains(keyword) }
             }
             
             guard !filteredEmoji.isEmpty else { return nil }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Sorts/Search/SetPropertiesDetailsLocalSearchInteractor.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/Sorts/Search/SetPropertiesDetailsLocalSearchInteractor.swift
@@ -17,7 +17,7 @@ extension SetPropertiesDetailsLocalSearchInteractor {
         }
 
         let searchedRelations = relationsDetails.filter {
-            $0.name.range(of: text, options: .caseInsensitive) != nil
+            $0.name.localizedStandardContains(text)
         }
         
         if searchedRelations.isEmpty {


### PR DESCRIPTION
## Summary
- Migrate all 9 local user-facing string-filter sites to `localizedStandardContains` (case + diacritic + locale insensitive — Finder's behavior). Replaces a hodgepodge of `localizedCaseInsensitiveContains`, `range(of:, .caseInsensitive)`, and `.lowercased().contains(.lowercased())`.
- Fixes long-standing search papercuts: searching "cafe" now finds spaces named "Café", "munoz" finds "Muñoz", "е" finds slash-menu items with "ё", etc.
- Out of scope: middleware-backed global search (server-side FTS), internal token/identifier matching.