### PR TITLE
IOS-6189 Fix EXC_BAD_ACCESS in EditorPageController.setEditing

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
@@ -165,6 +165,7 @@ final class EditorPageController: UIViewController {
     }
 
     override func setEditing(_ editing: Bool, animated: Bool) {
+        guard isEditing != editing else { return }
         super.setEditing(editing, animated: animated)
         collectionView.isEditing = editing
         bottomNavigationManager.multiselectActive(!editing)
@@ -435,8 +436,6 @@ extension EditorPageController: EditorPageViewInput {
         case .header, .system:
             return
         }
-
-        handleState(state: viewModel.blocksStateManager.editingState)
     }
     
     func isAllSelected() -> Bool {


### PR DESCRIPTION
## Summary

- Add idempotency guard to `setEditing` override so redundant identical calls (from rapid publisher fires) are absorbed — the standard UIKit idiom on `self.isEditing`.
- Remove redundant trailing `handleState(...)` from `restoreEditingState`. `editingState = .editing` is set immediately before in `EditorPageBlocksStateManager.didSelectStyleSelection`'s `onDismiss`, and the `editorEditingStatePublisher.receiveOnMain()` chain already drives `handleState`. Removing the sync call also gets `setEditing(true)` out of the FloatingPanel animation completion block, where UIKit's cell iteration was crashing.

Fixes IOS-5AC
Fixes IOS-9MP