### PR TITLE
IOS-6198 Show set widgets with already loaded child

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetSubmoduleView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetSubmoduleView.swift
@@ -10,8 +10,9 @@ struct HomeWidgetSubmoduleView: View {
     let personalWidgetsObject: any BaseDocumentProtocol
     let workspaceInfo: AccountInfo
     @Binding var homeState: HomeWidgetsState
+    let prefetchedSetSubscription: PrefetchedSetSubscription?
     let output: (any CommonWidgetModuleOutput)?
-    
+
     var body: some View {
         switch widgetInfo.source {
         case .object(let objectDetails):
@@ -79,7 +80,8 @@ struct HomeWidgetSubmoduleView: View {
             homeState: $homeState,
             spaceInfo: workspaceInfo,
             output: output,
-            prefetchedDetails: prefetchedDetails
+            prefetchedDetails: prefetchedDetails,
+            prefetchedSetSubscription: prefetchedSetSubscription
         )
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -121,6 +121,7 @@ private struct HomeWidgetsInternalView: View {
                 info: model.info,
                 channelWidgetsObject: channelWidgetsObject,
                 personalWidgetsObject: personalWidgetsObject,
+                prefetchedSetSubscriptions: model.prefetchedSetSubscriptions,
                 output: model.output
             )
         case .unread:

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -20,6 +20,14 @@ final class HomeWidgetsViewModel {
     private var homeSectionsStorage: any HomeSectionsStorageProtocol
     @Injected(\.participantsStorage) @ObservationIgnored
     private var accountParticipantStorage: any ParticipantsStorageProtocol
+    @Injected(\.expandedService) @ObservationIgnored
+    private var expandedService: any ExpandedServiceProtocol
+    @Injected(\.setSubscriptionDataBuilder) @ObservationIgnored
+    private var setSubscriptionDataBuilder: any SetSubscriptionDataBuilderProtocol
+    @Injected(\.subscriptionStorageProvider) @ObservationIgnored
+    private var subscriptionStorageProvider: any SubscriptionStorageProviderProtocol
+    @Injected(\.spaceViewsStorage) @ObservationIgnored
+    private var spaceViewsStorage: any SpaceViewsStorageProtocol
 
     @ObservationIgnored
     weak var output: (any HomeWidgetsModuleOutput)?
@@ -30,6 +38,9 @@ final class HomeWidgetsViewModel {
     var sectionsConfiguration: HomeSectionsConfiguration = .default
     private(set) var channelWidgetsObject: (any BaseDocumentProtocol)?
     private(set) var personalWidgetsObject: (any BaseDocumentProtocol)?
+    /// Pre-warmed Set/Type widget subscriptions keyed by widgetBlockId, populated in `openWidgetObjects`.
+    /// Allows Set/Type widgets to render rows on first frame and avoids the mid-transition row pop.
+    private(set) var prefetchedSetSubscriptions: [String: PrefetchedSetSubscription] = [:]
 
     // Default false so readonly users never see (and can never tap) the Bin's empty-bin
     // action before `canEdit` resolves. Editors briefly see no Bin section until then —
@@ -74,8 +85,17 @@ final class HomeWidgetsViewModel {
         }
 
         guard !Task.isCancelled else { return }
+
+        // Pre-warm Set/Type widget subscriptions before flipping the section gate.
+        // Rows are ready on first frame — no mid-transition row-pop jump. Runs in
+        // every context (slide-in and overlay) because a visible jump is worse
+        // than a small loader delay regardless of how the screen was presented.
+        let prefetched = await prewarmSetWidgetSubscriptions(channelWidgetsObject: channel)
+
+        guard !Task.isCancelled else { return }
         channelWidgetsObject = channel
         personalWidgetsObject = personal
+        prefetchedSetSubscriptions = prefetched
     }
 
     func startSubscriptions() async {
@@ -166,6 +186,141 @@ final class HomeWidgetsViewModel {
             homepageTask = Task { [weak self] in
                 await self?.observeHomepageObject(objectId: next.objectId, canSetHomepage: next.canSetHomepage)
             }
+        }
+    }
+
+    // MARK: - Set/Type widget pre-warm
+
+    /// Maximum time we hold the gate waiting for any single widget's subscription
+    /// to first-emit. If a widget exceeds this, that one widget falls back to today's
+    /// behavior (header first, rows later) while the rest of the screen renders clean.
+    private static let prewarmTimeout: TimeInterval = 0.6
+
+    private func prewarmSetWidgetSubscriptions(
+        channelWidgetsObject: any BaseDocumentProtocol
+    ) async -> [String: PrefetchedSetSubscription] {
+        let setWidgets = channelWidgetsObject.children
+            .filter(\.isWidget)
+            .compactMap { channelWidgetsObject.widgetInfo(block: $0) }
+            .filter { Self.isSetTypeWidget(widgetInfo: $0) }
+            .filter { expandedService.isExpanded(id: $0.id, defaultValue: true) }
+
+        guard setWidgets.isNotEmpty else { return [:] }
+
+        return await withTaskGroup(of: (String, PrefetchedSetSubscription)?.self) { group in
+            for widgetInfo in setWidgets {
+                group.addTask { [weak self] in
+                    guard let self else { return nil }
+                    guard let prefetched = await prewarmSingleSetWidget(widgetInfo: widgetInfo) else { return nil }
+                    return (widgetInfo.id, prefetched)
+                }
+            }
+
+            var result: [String: PrefetchedSetSubscription] = [:]
+            for await pair in group {
+                if let (id, prefetched) = pair {
+                    result[id] = prefetched
+                }
+            }
+            return result
+        }
+    }
+
+    /// Matches `HomeWidgetSubmoduleView`'s Set/Type routing: `.list`/`.type` objects shown
+    /// as `.view` / `.list` / `.compactList` layouts. Tree widgets (`.tree` + `.page`) are
+    /// not pre-warmed — their `ObjectSubscribeIds` already settles in single-digit ms.
+    private static func isSetTypeWidget(widgetInfo: BlockWidgetInfo) -> Bool {
+        guard case let .object(details) = widgetInfo.source else { return false }
+        let validViewType = details.editorViewType == .list || details.editorViewType == .type
+        let validLayout: [BlockWidget.Layout] = [.view, .list, .compactList]
+        return validViewType && validLayout.contains(widgetInfo.fixedLayout)
+    }
+
+    private func prewarmSingleSetWidget(widgetInfo: BlockWidgetInfo) async -> PrefetchedSetSubscription? {
+        guard case let .object(setDetails) = widgetInfo.source else { return nil }
+
+        return await withTimeout(seconds: Self.prewarmTimeout) { [self] in
+            let setDocument = documentsProvider.setDocument(
+                objectId: setDetails.id,
+                spaceId: info.accountSpaceId,
+                mode: .preview
+            )
+
+            do { try await setDocument.open() } catch { return nil }
+
+            // After `open()` returns, `setDocument.updateData()` runs on the next main-queue tick
+            // (BaseDocument's `syncPublisher` replays `[.general]` via `receiveOnMain`). Subscribe
+            // to `setUpdatePublisher` to catch that first `.dataviewUpdated` event; check the
+            // populated state first in case it raced us.
+            if !setDocument.dataView.views.isNotEmpty {
+                for await update in setDocument.setUpdatePublisher.values {
+                    if case .dataviewUpdated = update { break }
+                }
+            }
+
+            guard setDocument.canStartSubscription(), setDocument.dataView.views.isNotEmpty else {
+                return nil
+            }
+
+            let subscriptionData = buildSubscriptionData(
+                widgetInfo: widgetInfo,
+                setDocument: setDocument
+            )
+
+            let storage = subscriptionStorageProvider.createSubscriptionStorage(
+                subId: subscriptionData.identifier
+            )
+            do {
+                try await storage.startOrUpdateSubscription(data: subscriptionData)
+            } catch {
+                return nil
+            }
+
+            // `statePublisher` is built from CurrentValueSubject, so a subscribe AFTER the
+            // start-or-update call replays the current state synchronously through the filter.
+            for await state in storage.statePublisher.values {
+                return PrefetchedSetSubscription(
+                    setDocument: setDocument,
+                    subscriptionStorage: storage,
+                    state: state
+                )
+            }
+            return nil
+        }
+    }
+
+    private func buildSubscriptionData(
+        widgetInfo: BlockWidgetInfo,
+        setDocument: any SetDocumentProtocol
+    ) -> SubscriptionData {
+        let identifier = "SetWidget-\(UUID().uuidString)"
+        let spaceType = spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.spaceType
+        let setSubData = SetSubscriptionData(
+            identifier: identifier,
+            document: setDocument,
+            groupFilter: nil,
+            currentPage: 0,
+            numberOfRowsPerPage: widgetInfo.fixedLimit,
+            collectionId: setDocument.isCollection() ? setDocument.objectId : nil,
+            objectOrderIds: setDocument.objectOrderIds(for: setSubscriptionDataBuilder.subscriptionId),
+            spaceType: spaceType
+        )
+        return setSubscriptionDataBuilder.set(setSubData)
+    }
+
+    private func withTimeout<T: Sendable>(
+        seconds: TimeInterval,
+        operation: @escaping @MainActor () async -> T?
+    ) async -> T? {
+        await withTaskGroup(of: T?.self) { group in
+            group.addTask { @MainActor in await operation() }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(seconds))
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -77,22 +77,25 @@ final class HomeWidgetsViewModel {
             mode: .handling
         )
 
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask { try? await channel.open() }
-            group.addTask { try? await personal.open() }
-        }
+        // Personal opens independently of pre-warm (set widgets live in channel only),
+        // so we start it now and only await it before the final gate flip — letting it
+        // overlap with both channel.open() and the per-widget pre-warm work.
+        async let personalOpen: Void? = try? await personal.open()
+        try? await channel.open()
 
         guard !Task.isCancelled else { return }
 
         // Pre-warm before flipping the section gate so Set/Type widgets render rows
         // on the first frame. We accept the loader extension in every context — a
         // visible row-pop is worse than a small delay regardless of presentation.
-        let prefetched = await prewarmSetWidgetSubscriptions(channelWidgetsObject: channel)
+        async let prefetched = prewarmSetWidgetSubscriptions(channelWidgetsObject: channel)
+        _ = await personalOpen
+        let result = await prefetched
 
         guard !Task.isCancelled else { return }
         channelWidgetsObject = channel
         personalWidgetsObject = personal
-        prefetchedSetSubscriptions = prefetched
+        prefetchedSetSubscriptions = result
     }
 
     func startSubscriptions() async {
@@ -315,9 +318,9 @@ final class HomeWidgetsViewModel {
                 try? await Task.sleep(for: .seconds(seconds))
                 return nil
             }
-            let first = await group.next() ?? nil
-            group.cancelAll()
-            return first
+            defer { group.cancelAll() }
+            // `next()` returns Element? = T??; the `?? nil` flattens to T?.
+            return await group.next() ?? nil
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -250,11 +250,13 @@ final class HomeWidgetsViewModel {
             do { try await setDocument.open() } catch { return nil }
 
             // `setDocument.updateData()` runs on the next main-queue tick after open()
-            // returns (syncPublisher replays via `receiveOnMain`). Check first in case
-            // it already populated; otherwise await the `.dataviewUpdated` emission.
+            // returns (syncPublisher replays via `receiveOnMain`). Check the actual
+            // state on every emission — `setUpdatePublisher` can emit `.syncStatus`
+            // before `.dataviewUpdated`, and we'd loop without progress if we only
+            // matched on the event variant.
             if !setDocument.dataView.views.isNotEmpty {
-                for await update in setDocument.setUpdatePublisher.values {
-                    if case .dataviewUpdated = update { break }
+                for await _ in setDocument.setUpdatePublisher.values {
+                    if setDocument.dataView.views.isNotEmpty { break }
                 }
             }
 
@@ -293,19 +295,12 @@ final class HomeWidgetsViewModel {
         widgetInfo: BlockWidgetInfo,
         setDocument: any SetDocumentProtocol
     ) -> SubscriptionData {
-        let identifier = "SetWidget-\(UUID().uuidString)"
-        let spaceType = spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.spaceType
-        let setSubData = SetSubscriptionData(
-            identifier: identifier,
-            document: setDocument,
-            groupFilter: nil,
-            currentPage: 0,
-            numberOfRowsPerPage: widgetInfo.fixedLimit,
-            collectionId: setDocument.isCollection() ? setDocument.objectId : nil,
-            objectOrderIds: setDocument.objectOrderIds(for: setSubscriptionDataBuilder.subscriptionId),
-            spaceType: spaceType
+        setSubscriptionDataBuilder.widgetSubscriptionData(
+            widgetInfo: widgetInfo,
+            setDocument: setDocument,
+            identifier: "SetWidget-\(UUID().uuidString)",
+            spaceType: spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.spaceType
         )
-        return setSubscriptionDataBuilder.set(setSubData)
     }
 
     private func withTimeout<T: Sendable>(

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -38,8 +38,6 @@ final class HomeWidgetsViewModel {
     var sectionsConfiguration: HomeSectionsConfiguration = .default
     private(set) var channelWidgetsObject: (any BaseDocumentProtocol)?
     private(set) var personalWidgetsObject: (any BaseDocumentProtocol)?
-    /// Pre-warmed Set/Type widget subscriptions keyed by widgetBlockId, populated in `openWidgetObjects`.
-    /// Allows Set/Type widgets to render rows on first frame and avoids the mid-transition row pop.
     private(set) var prefetchedSetSubscriptions: [String: PrefetchedSetSubscription] = [:]
 
     // Default false so readonly users never see (and can never tap) the Bin's empty-bin
@@ -86,10 +84,9 @@ final class HomeWidgetsViewModel {
 
         guard !Task.isCancelled else { return }
 
-        // Pre-warm Set/Type widget subscriptions before flipping the section gate.
-        // Rows are ready on first frame — no mid-transition row-pop jump. Runs in
-        // every context (slide-in and overlay) because a visible jump is worse
-        // than a small loader delay regardless of how the screen was presented.
+        // Pre-warm before flipping the section gate so Set/Type widgets render rows
+        // on the first frame. We accept the loader extension in every context — a
+        // visible row-pop is worse than a small delay regardless of presentation.
         let prefetched = await prewarmSetWidgetSubscriptions(channelWidgetsObject: channel)
 
         guard !Task.isCancelled else { return }
@@ -191,19 +188,21 @@ final class HomeWidgetsViewModel {
 
     // MARK: - Set/Type widget pre-warm
 
-    /// Maximum time we hold the gate waiting for any single widget's subscription
-    /// to first-emit. If a widget exceeds this, that one widget falls back to today's
-    /// behavior (header first, rows later) while the rest of the screen renders clean.
+    /// Per-widget budget. A slow widget falls back to its own mount-time open
+    /// (header first, rows later) instead of stalling the whole gate.
     private static let prewarmTimeout: TimeInterval = 0.6
 
     private func prewarmSetWidgetSubscriptions(
         channelWidgetsObject: any BaseDocumentProtocol
     ) async -> [String: PrefetchedSetSubscription] {
-        let setWidgets = channelWidgetsObject.children
-            .filter(\.isWidget)
-            .compactMap { channelWidgetsObject.widgetInfo(block: $0) }
-            .filter { Self.isSetTypeWidget(widgetInfo: $0) }
-            .filter { expandedService.isExpanded(id: $0.id, defaultValue: true) }
+        let setWidgets = channelWidgetsObject.children.compactMap { child -> BlockWidgetInfo? in
+            guard child.isWidget,
+                  let info = channelWidgetsObject.widgetInfo(block: child),
+                  Self.isSetTypeWidget(widgetInfo: info),
+                  expandedService.isExpanded(id: info.id, defaultValue: true)
+            else { return nil }
+            return info
+        }
 
         guard setWidgets.isNotEmpty else { return [:] }
 
@@ -226,9 +225,8 @@ final class HomeWidgetsViewModel {
         }
     }
 
-    /// Matches `HomeWidgetSubmoduleView`'s Set/Type routing: `.list`/`.type` objects shown
-    /// as `.view` / `.list` / `.compactList` layouts. Tree widgets (`.tree` + `.page`) are
-    /// not pre-warmed — their `ObjectSubscribeIds` already settles in single-digit ms.
+    /// Matches `HomeWidgetSubmoduleView`'s Set/Type routing — Tree widgets aren't
+    /// pre-warmed because their `ObjectSubscribeIds` settles in single-digit ms.
     private static func isSetTypeWidget(widgetInfo: BlockWidgetInfo) -> Bool {
         guard case let .object(details) = widgetInfo.source else { return false }
         let validViewType = details.editorViewType == .list || details.editorViewType == .type
@@ -248,10 +246,9 @@ final class HomeWidgetsViewModel {
 
             do { try await setDocument.open() } catch { return nil }
 
-            // After `open()` returns, `setDocument.updateData()` runs on the next main-queue tick
-            // (BaseDocument's `syncPublisher` replays `[.general]` via `receiveOnMain`). Subscribe
-            // to `setUpdatePublisher` to catch that first `.dataviewUpdated` event; check the
-            // populated state first in case it raced us.
+            // `setDocument.updateData()` runs on the next main-queue tick after open()
+            // returns (syncPublisher replays via `receiveOnMain`). Check first in case
+            // it already populated; otherwise await the `.dataviewUpdated` emission.
             if !setDocument.dataView.views.isNotEmpty {
                 for await update in setDocument.setUpdatePublisher.values {
                     if case .dataviewUpdated = update { break }
@@ -276,8 +273,8 @@ final class HomeWidgetsViewModel {
                 return nil
             }
 
-            // `statePublisher` is built from CurrentValueSubject, so a subscribe AFTER the
-            // start-or-update call replays the current state synchronously through the filter.
+            // `statePublisher` is backed by CurrentValueSubject, so subscribing after
+            // `startOrUpdateSubscription` returns replays the current state immediately.
             for await state in storage.statePublisher.values {
                 return PrefetchedSetSubscription(
                     setDocument: setDocument,

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/SetSubscriptionDataBuilder+Widget.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/SetSubscriptionDataBuilder+Widget.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Services
+
+extension SetSubscriptionDataBuilderProtocol {
+    func widgetSubscriptionData(
+        widgetInfo: BlockWidgetInfo,
+        setDocument: any SetDocumentProtocol,
+        identifier: String,
+        spaceType: SpaceType?
+    ) -> SubscriptionData {
+        let setSubData = SetSubscriptionData(
+            identifier: identifier,
+            document: setDocument,
+            groupFilter: nil,
+            currentPage: 0,
+            numberOfRowsPerPage: widgetInfo.fixedLimit,
+            collectionId: setDocument.isCollection() ? setDocument.objectId : nil,
+            objectOrderIds: setDocument.objectOrderIds(for: subscriptionId),
+            spaceType: spaceType
+        )
+        return set(setSubData)
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
@@ -2,14 +2,13 @@ import Foundation
 import SwiftUI
 import Services
 
-/// Pre-warmed dataview subscription bundle for Set/Type widgets.
-/// Populated by `HomeWidgetsViewModel.openWidgetObjects()` before flipping the section gate
-/// so the widget renders rows on first frame (no header-then-rows pop during transition).
-struct PrefetchedSetSubscription: @unchecked Sendable {
+/// Pre-warmed dataview subscription bundle for Set/Type widgets, populated by the loader
+/// before flipping the section gate so the widget renders rows on the first frame.
+struct PrefetchedSetSubscription: Sendable {
     let setDocument: any SetDocumentProtocol
     let subscriptionStorage: any SubscriptionStorageProtocol
-    /// Snapshot captured at pre-warm time. The widget VM seeds rows synchronously from this
-    /// in `init`; the live storage takes over on subsequent emits.
+    /// Snapshot captured at pre-warm time; the VM seeds rows synchronously from this in init,
+    /// then the live storage takes over on subsequent emits.
     let state: SubscriptionStorageState
 }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
@@ -2,6 +2,17 @@ import Foundation
 import SwiftUI
 import Services
 
+/// Pre-warmed dataview subscription bundle for Set/Type widgets.
+/// Populated by `HomeWidgetsViewModel.openWidgetObjects()` before flipping the section gate
+/// so the widget renders rows on first frame (no header-then-rows pop during transition).
+struct PrefetchedSetSubscription: @unchecked Sendable {
+    let setDocument: any SetDocumentProtocol
+    let subscriptionStorage: any SubscriptionStorageProtocol
+    /// Snapshot captured at pre-warm time. The widget VM seeds rows synchronously from this
+    /// in `init`; the live storage takes over on subsequent emits.
+    let state: SubscriptionStorageState
+}
+
 struct WidgetSubmoduleData {
     let widgetBlockId: String
     /// Shared channel widgets document (`info.widgetsId`) — holds pinned widgets
@@ -15,4 +26,6 @@ struct WidgetSubmoduleData {
     let output: (any CommonWidgetModuleOutput)?
     /// Pre-seeded object details for `.object`-source widgets, enabling synchronous first-render without an empty frame.
     let prefetchedDetails: ObjectDetails?
+    /// Pre-warmed set subscription bundle for Set/Type widgets — see `PrefetchedSetSubscription`.
+    let prefetchedSetSubscription: PrefetchedSetSubscription?
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
@@ -7,6 +7,7 @@ struct PinnedSectionView: View {
     let info: AccountInfo
     let channelWidgetsObject: any BaseDocumentProtocol
     let personalWidgetsObject: any BaseDocumentProtocol
+    let prefetchedSetSubscriptions: [String: PrefetchedSetSubscription]
     weak var output: (any CommonWidgetModuleOutput)?
 
     var body: some View {
@@ -14,6 +15,7 @@ struct PinnedSectionView: View {
             info: info,
             channelWidgetsObject: channelWidgetsObject,
             personalWidgetsObject: personalWidgetsObject,
+            prefetchedSetSubscriptions: prefetchedSetSubscriptions,
             output: output
         )
     }
@@ -26,16 +28,19 @@ private struct PinnedSectionViewInternal: View {
 
     let info: AccountInfo
     let personalWidgetsObject: any BaseDocumentProtocol
+    let prefetchedSetSubscriptions: [String: PrefetchedSetSubscription]
     weak var output: (any CommonWidgetModuleOutput)?
 
     init(
         info: AccountInfo,
         channelWidgetsObject: any BaseDocumentProtocol,
         personalWidgetsObject: any BaseDocumentProtocol,
+        prefetchedSetSubscriptions: [String: PrefetchedSetSubscription],
         output: (any CommonWidgetModuleOutput)?
     ) {
         self.info = info
         self.personalWidgetsObject = personalWidgetsObject
+        self.prefetchedSetSubscriptions = prefetchedSetSubscriptions
         self.output = output
         self._model = State(
             wrappedValue: PinnedSectionViewModel(
@@ -56,6 +61,7 @@ private struct PinnedSectionViewInternal: View {
                         personalWidgetsObject: personalWidgetsObject,
                         workspaceInfo: info,
                         homeState: $model.homeState,
+                        prefetchedSetSubscription: prefetchedSetSubscriptions[widgetInfo.id],
                         output: output
                     )
                 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
@@ -55,13 +55,9 @@ final class SetObjectWidgetInternalViewModel {
     private var unreadDiscussionsBySpace: [String: SpaceDiscussionsUnreadInfo] = [:]
     @ObservationIgnored
     private var dataviewUpdateTask: Task<Void, Never>?
-    /// `widgetTargetDetailsPublisher` emits both the initial replay (channelWidgets'
-    /// syncPublisher fires `[.general]` on subscribe) AND subsequent change events.
-    /// The initial replay is redundant — `setDocument` was just opened (pre-warm or
-    /// our own `newSetDocument.open()`) so its data is already fresh. Subsequent
-    /// emissions are real change events from other devices; `.preview` mode docs
-    /// don't get live events, so `setDocument.update()` is the only path that picks
-    /// up remote dataView edits (filter/sort/view changes).
+    /// Skip the very first `setDocument.update()` after a fresh open: that emission
+    /// is the publisher's initial replay, not a real change event. Subsequent emissions
+    /// are remote edits — `.preview` mode docs need explicit `update()` to refresh.
     @ObservationIgnored
     private var setDocumentJustOpened = false
 
@@ -82,9 +78,8 @@ final class SetObjectWidgetInternalViewModel {
         self.output = data.output
 
         if let prefetched = data.prefetchedSetSubscription {
-            // Reuse the loader's storage so subsequent `updateViewSubscription` calls with
-            // matching data short-circuit at `SubscriptionStorage.startOrUpdateSubscription`'s
-            // `self.data != data` guard — no duplicate ObjectSearchSubscribe.
+            // Reuse the loader's storage so the VM's later `startOrUpdateSubscription`
+            // with matching data short-circuits — no duplicate ObjectSearchSubscribe.
             self.subscriptionStorage = prefetched.subscriptionStorage
             self.subscriptionId = prefetched.subscriptionStorage.subId
             self.setDocument = prefetched.setDocument
@@ -103,8 +98,6 @@ final class SetObjectWidgetInternalViewModel {
             self.icon = details.objectIconImage
         }
 
-        // Synchronous first-frame seed: render rows from the pre-warmed subscription state.
-        // Requires setDocument + activeViewId, both already assigned above when prefetched.
         if let prefetched = data.prefetchedSetSubscription {
             updateRowDetails(data: prefetched.state)
         }
@@ -309,12 +302,6 @@ final class SetObjectWidgetInternalViewModel {
     
     private func updateSetDocument(objectId: String, spaceId: String) async {
         guard objectId != setDocument?.objectId, spaceId != setDocument?.spaceId else {
-            // Same target re-emitted. The first emission after a fresh open is the
-            // publisher's initial replay — skip `update()` then (the doc is already
-            // fresh, an ObjectShow would be wasted). Subsequent emissions are real
-            // remote change events; `.preview` mode docs don't subscribe to live
-            // events, so `update()` is the only way to pick up dataView edits
-            // (filter / sort / view changes) made on another device.
             if setDocumentJustOpened {
                 setDocumentJustOpened = false
             } else {
@@ -329,7 +316,6 @@ final class SetObjectWidgetInternalViewModel {
         let newSetDocument = documentsProvider.setDocument(objectId: objectId, spaceId: spaceId, mode: .preview)
         setDocument = newSetDocument
         try? await newSetDocument.open()
-        // Doc is fresh — next same-target emission is the redundant replay; skip `update()` then.
         setDocumentJustOpened = true
 
         // dataView blocks and permissions sync after open(); re-pull on emit.

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
@@ -270,18 +270,12 @@ final class SetObjectWidgetInternalViewModel {
         // SetSubscriptionData falls back to createdDate.
         guard setDocument.dataView.views.isNotEmpty else { return }
 
-        let spaceType = spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.spaceType
-        let setSubData = SetSubscriptionData(
+        let subscriptionData = setSubscriptionDataBuilder.widgetSubscriptionData(
+            widgetInfo: widgetInfo,
+            setDocument: setDocument,
             identifier: subscriptionId,
-            document: setDocument,
-            groupFilter: nil,
-            currentPage: 0,
-            numberOfRowsPerPage: widgetInfo.fixedLimit,
-            collectionId: setDocument.isCollection() ? setDocument.objectId : nil,
-            objectOrderIds: setDocument.objectOrderIds(for: setSubscriptionDataBuilder.subscriptionId),
-            spaceType: spaceType
+            spaceType: spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.spaceType
         )
-        let subscriptionData = setSubscriptionDataBuilder.set(setSubData)
 
         try? await subscriptionStorage.startOrUpdateSubscription(data: subscriptionData) { [weak self] data in
             await self?.updateRowDetails(data: data)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
@@ -19,8 +19,8 @@ final class SetObjectWidgetInternalViewModel {
     private let subscriptionStorage: any SubscriptionStorageProtocol
     @ObservationIgnored
     private weak var output: (any CommonWidgetModuleOutput)?
-    private let subscriptionId = "SetWidget-\(UUID().uuidString)"
-    
+    private let subscriptionId: String
+
     @Injected(\.documentsProvider) @ObservationIgnored
     private var documentsProvider: any DocumentsProviderProtocol
     @Injected(\.blockWidgetService) @ObservationIgnored
@@ -55,7 +55,16 @@ final class SetObjectWidgetInternalViewModel {
     private var unreadDiscussionsBySpace: [String: SpaceDiscussionsUnreadInfo] = [:]
     @ObservationIgnored
     private var dataviewUpdateTask: Task<Void, Never>?
-    
+    /// `widgetTargetDetailsPublisher` emits both the initial replay (channelWidgets'
+    /// syncPublisher fires `[.general]` on subscribe) AND subsequent change events.
+    /// The initial replay is redundant — `setDocument` was just opened (pre-warm or
+    /// our own `newSetDocument.open()`) so its data is already fresh. Subsequent
+    /// emissions are real change events from other devices; `.preview` mode docs
+    /// don't get live events, so `setDocument.update()` is the only path that picks
+    /// up remote dataView edits (filter/sort/view changes).
+    @ObservationIgnored
+    private var setDocumentJustOpened = false
+
     var dragId: String? { widgetBlockId }
     
     var name: String = ""
@@ -72,13 +81,32 @@ final class SetObjectWidgetInternalViewModel {
         self.widgetObject = data.channelWidgetsObject
         self.output = data.output
 
-        let storageProvider = Container.shared.subscriptionStorageProvider.resolve()
-        self.subscriptionStorage = storageProvider.createSubscriptionStorage(subId: subscriptionId)
+        if let prefetched = data.prefetchedSetSubscription {
+            // Reuse the loader's storage so subsequent `updateViewSubscription` calls with
+            // matching data short-circuit at `SubscriptionStorage.startOrUpdateSubscription`'s
+            // `self.data != data` guard — no duplicate ObjectSearchSubscribe.
+            self.subscriptionStorage = prefetched.subscriptionStorage
+            self.subscriptionId = prefetched.subscriptionStorage.subId
+            self.setDocument = prefetched.setDocument
+            self.activeViewId = prefetched.setDocument.activeView.id
+            self.setDocumentJustOpened = true
+        } else {
+            let id = "SetWidget-\(UUID().uuidString)"
+            self.subscriptionId = id
+            let storageProvider = Container.shared.subscriptionStorageProvider.resolve()
+            self.subscriptionStorage = storageProvider.createSubscriptionStorage(subId: id)
+        }
 
         // Avoid a frame of empty row before `targetDetailsPublisher` first ticks.
         if let details = data.prefetchedDetails {
             self.name = details.pluralTitle
             self.icon = details.objectIconImage
+        }
+
+        // Synchronous first-frame seed: render rows from the pre-warmed subscription state.
+        // Requires setDocument + activeViewId, both already assigned above when prefetched.
+        if let prefetched = data.prefetchedSetSubscription {
+            updateRowDetails(data: prefetched.state)
         }
     }
     
@@ -261,7 +289,7 @@ final class SetObjectWidgetInternalViewModel {
             spaceType: spaceType
         )
         let subscriptionData = setSubscriptionDataBuilder.set(setSubData)
-        
+
         try? await subscriptionStorage.startOrUpdateSubscription(data: subscriptionData) { [weak self] data in
             await self?.updateRowDetails(data: data)
         }
@@ -281,7 +309,17 @@ final class SetObjectWidgetInternalViewModel {
     
     private func updateSetDocument(objectId: String, spaceId: String) async {
         guard objectId != setDocument?.objectId, spaceId != setDocument?.spaceId else {
-            try? await setDocument?.update()
+            // Same target re-emitted. The first emission after a fresh open is the
+            // publisher's initial replay — skip `update()` then (the doc is already
+            // fresh, an ObjectShow would be wasted). Subsequent emissions are real
+            // remote change events; `.preview` mode docs don't subscribe to live
+            // events, so `update()` is the only way to pick up dataView edits
+            // (filter / sort / view changes) made on another device.
+            if setDocumentJustOpened {
+                setDocumentJustOpened = false
+            } else {
+                try? await setDocument?.update()
+            }
             await updateModelState()
             return
         }
@@ -291,6 +329,8 @@ final class SetObjectWidgetInternalViewModel {
         let newSetDocument = documentsProvider.setDocument(objectId: objectId, spaceId: spaceId, mode: .preview)
         setDocument = newSetDocument
         try? await newSetDocument.open()
+        // Doc is fresh — next same-target emission is the redundant replay; skip `update()` then.
+        setDocumentJustOpened = true
 
         // dataView blocks and permissions sync after open(); re-pull on emit.
         dataviewUpdateTask = Task { [weak self] in

--- a/Anytype/Sources/ServiceLayer/SubscriptionsToggler/Internals/SubscriptionStorage.swift
+++ b/Anytype/Sources/ServiceLayer/SubscriptionsToggler/Internals/SubscriptionStorage.swift
@@ -59,9 +59,8 @@ actor SubscriptionStorage: SubscriptionStorageProtocol {
         }
         
         guard self.data != data else {
-            // Always refresh the update callback so a later caller's closure replaces
-            // an earlier one (e.g. loader pre-warms with a no-op, VM mounts and wants
-            // real updates) — otherwise live state changes go to the stale closure.
+            // Always replace the callback so a later caller's closure wins
+            // (e.g. loader pre-warms with no-op, VM mounts with real handler).
             self.update = update
             await update(state)
             stateSubject.send(state)

--- a/Anytype/Sources/ServiceLayer/SubscriptionsToggler/Internals/SubscriptionStorage.swift
+++ b/Anytype/Sources/ServiceLayer/SubscriptionsToggler/Internals/SubscriptionStorage.swift
@@ -59,6 +59,10 @@ actor SubscriptionStorage: SubscriptionStorageProtocol {
         }
         
         guard self.data != data else {
+            // Always refresh the update callback so a later caller's closure replaces
+            // an earlier one (e.g. loader pre-warms with a no-op, VM mounts and wants
+            // real updates) — otherwise live state changes go to the stale closure.
+            self.update = update
             await update(state)
             stateSubject.send(state)
             return

--- a/Anytype/Sources/ServiceLayer/SubscriptionsToggler/Internals/SubscriptionStorageState.swift
+++ b/Anytype/Sources/ServiceLayer/SubscriptionsToggler/Internals/SubscriptionStorageState.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Services
 
-struct  SubscriptionStorageState: Equatable {
+struct SubscriptionStorageState: Equatable, Sendable {
     var total: Int
     var nextCount: Int
     var prevCount: Int


### PR DESCRIPTION
## Summary

- Pre-warm Set/Type widget subscriptions in `HomeWidgetsViewModel.openWidgetObjects()` before flipping the section gate, so widget rows render on the first frame (no mid-transition row-pop jump).
- Each pre-warm runs in parallel with a per-widget 600 ms timeout — slow widgets fall back to today's mount-time open instead of stalling the gate.
- Personal widgets doc opens overlap with channel open AND pre-warm work via `async let`, removing a sequential wait.
- Restore real-time dataView updates from remote devices: `setDocument.update()` is called on subsequent `widgetTargetDetailsPublisher` emissions, but a `setDocumentJustOpened` flag absorbs the redundant initial replay (no duplicate `ObjectShow`).
- `SubscriptionStorage.startOrUpdateSubscription` now always refreshes the update closure on its short-circuit path so a later caller (VM) wins over an earlier one (pre-warm).
- `SubscriptionStorageState` is now properly `Sendable`.