### PR TITLE
IOS-6201 Fix home widget appearing before other widgets in overlay

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -90,9 +90,9 @@ private struct HomeWidgetsInternalView: View {
             VStack(spacing: 0) {
                 SpaceInfoView(spaceId: model.spaceId)
                 InviteMembersStubWidgetView(spaceId: model.spaceId, output: model.output)
-                homeWidget
                 if let channelWidgetsObject = model.channelWidgetsObject,
                    let personalWidgetsObject = model.personalWidgetsObject {
+                    homeWidget
                     ForEach(model.visibleSections, id: \.self) { section in
                         manageableSection(
                             section,
@@ -159,7 +159,7 @@ private struct HomeWidgetsInternalView: View {
         if context == .overlay, let data = model.homeWidgetData {
             HomeWidgetView(data: data)
                 .id("\(data.objectId)-\(data.canSetHomepage)")
-                .padding(.bottom, 8)
+                .padding(.bottom, 12)
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/HomeWidget/HomeWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/HomeWidget/HomeWidgetViewModel.swift
@@ -34,12 +34,10 @@ final class HomeWidgetViewModel {
 
     init(data: HomepageWidgetViewData) {
         self.data = data
-        // Parent gates `homeWidgetData` on `document.details != nil`, so the header can
-        // render fully formed on the first frame instead of flashing empty until the
-        // child's `.task` subscription replays.
+        // Parent gates `homeWidgetData` on `document.details != nil`, so seed from it
+        // to avoid an empty-header first frame and a dead tap before the subscription replays.
         if let details = data.document.details {
-            self.title = details.pluralTitle
-            self.icon = details.objectIconImage
+            apply(details: details)
         }
     }
 
@@ -72,10 +70,14 @@ final class HomeWidgetViewModel {
         let document = data.document
         for await _ in document.syncPublisher.values {
             guard let details = document.details else { continue }
-            self.details = details
-            self.title = details.pluralTitle
-            self.icon = details.objectIconImage
+            apply(details: details)
         }
+    }
+
+    private func apply(details: ObjectDetails) {
+        self.details = details
+        self.title = details.pluralTitle
+        self.icon = details.objectIconImage
     }
 
     private func startCountersSubscription() async {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/HomeWidget/HomeWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/HomeWidget/HomeWidgetViewModel.swift
@@ -34,6 +34,13 @@ final class HomeWidgetViewModel {
 
     init(data: HomepageWidgetViewData) {
         self.data = data
+        // Parent gates `homeWidgetData` on `document.details != nil`, so the header can
+        // render fully formed on the first frame instead of flashing empty until the
+        // child's `.task` subscription replays.
+        if let details = data.document.details {
+            self.title = details.pluralTitle
+            self.icon = details.objectIconImage
+        }
     }
 
     func onHeaderTap() {


### PR DESCRIPTION
## Summary
- Move the overlay `homeWidget` inside the existing `channelWidgetsObject` + `personalWidgetsObject` gate so it appears in the same frame as the pinned section instead of popping in first.
- Pre-seed `title`/`icon`/`details` in `HomeWidgetViewModel.init` from `data.document.details` (parent already guarantees it's non-nil) to avoid an empty-header first frame and a dead tap before the subscription replays. Shared `apply(details:)` helper used by both init and the `syncPublisher` loop.
- Bump home widget bottom padding `8 → 12` to match `PinnedSectionView`'s `VStack(spacing: 12)`.