### PR TITLE
IOS-6203 HomeWidgets: high-priority widget-doc open + LazyVStack for ObjectTypes

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -53,7 +53,7 @@ private struct HomeWidgetsInternalView: View {
                 )
             }
         }
-        .task {
+        .task(priority: .high) {
             await model.openWidgetObjects()
         }
         .task {
@@ -87,7 +87,7 @@ private struct HomeWidgetsInternalView: View {
     
     private var widgets: some View {
         ScrollView {
-            VStack(spacing: 0) {
+            LazyVStack(spacing: 0) {
                 SpaceInfoView(spaceId: model.spaceId)
                 InviteMembersStubWidgetView(spaceId: model.spaceId, output: model.output)
                 if let channelWidgetsObject = model.channelWidgetsObject,

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -87,7 +87,7 @@ private struct HomeWidgetsInternalView: View {
     
     private var widgets: some View {
         ScrollView {
-            LazyVStack(spacing: 0) {
+            VStack(spacing: 0) {
                 SpaceInfoView(spaceId: model.spaceId)
                 InviteMembersStubWidgetView(spaceId: model.spaceId, output: model.output)
                 if let channelWidgetsObject = model.channelWidgetsObject,

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesUnifiedWidgetView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/ObjectTypesUnified/ObjectTypesUnifiedWidgetView.swift
@@ -8,7 +8,7 @@ struct ObjectTypesUnifiedWidgetView: View {
     let onCreate: (ObjectTypeWidgetInfo) async throws -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
+        LazyVStack(spacing: 0) {
             ForEach(Array(typeInfos.enumerated()), id: \.element.id) { index, info in
                 ObjectTypesUnifiedRowView(
                     info: info,


### PR DESCRIPTION
## Summary

- Bump `.task` priority to `.high` for `openWidgetObjects()` (opens channel + personal widgets docs and pre-warms set-widget subscriptions — first paint depends on this).
- Convert `VStack` → `LazyVStack` in `ObjectTypesUnifiedWidgetView`, the only unbounded-count list in HomeWidgets.

The outer screen-level `LazyVStack` from the issue description was investigated and rejected: it would break the `shouldHideChatBadges` contract (UnreadSectionView's `.task` wouldn't fire when offscreen, leaving Pinned-section chat badges hidden indefinitely on spaces with many pinned widgets — i.e. the IOS-5812 target scenario). Scope refined to the one inner list where it's actually a win.