### PR TITLE
IOS-6200 Restore search button and center comment capsule on bar

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -38,14 +38,14 @@ private struct HomeBottomNavigationPanelViewInternal: View {
         VStack(spacing: 0) {
             GlassEffectContainerIOS26(spacing: 20) {
                 HStack {
+                    searchButton
+                        .glassEffectIDIOS26("search", in: glassNamespace)
+                    Spacer()
                     if model.showDiscussButton {
                         discussIsland
                             .glassEffectIDIOS26("discussIsland", in: glassNamespace)
-                    } else {
-                        searchButton
-                            .glassEffectIDIOS26("search", in: glassNamespace)
+                        Spacer()
                     }
-                    Spacer()
                     if model.canCreateObject {
                         createButton
                             .glassEffectIDIOS26("create", in: glassNamespace)
@@ -98,15 +98,15 @@ private struct HomeBottomNavigationPanelViewInternal: View {
         return Button {
             model.onTapDiscuss()
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: 6) {
                 Image(systemName: model.discussButtonHasUnread ? "message.badge" : "message")
                     .symbolRenderingMode(.palette)
                     .foregroundStyle(
                         model.discussButtonHasUnread ? Color.Control.accent100 : Color.Control.primary,
                         Color.Control.primary
                     )
-                    .font(.system(size: 20))
-                    .frame(width: 32, height: 32)
+                    .font(.system(size: 17))
+                    .frame(width: 24, height: 24)
                 if hasCount {
                     AnytypeText("\(model.commentsCount)", style: .previewTitle2Medium)
                         .foregroundStyle(Color.Text.primary)
@@ -114,9 +114,8 @@ private struct HomeBottomNavigationPanelViewInternal: View {
                         .transition(.opacity.combined(with: .scale(scale: 0.5, anchor: .leading)))
                 }
             }
-            .padding(.leading, 8)
-            .padding(.vertical, 8)
-            .padding(.trailing, hasCount ? 12 : 8)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
         }
         .glassEffectInteractiveIOS26(in: Capsule())
         .animation(.snappy(duration: 0.35), value: hasCount)


### PR DESCRIPTION
## Summary
- Restore the search button at the leading slot of the home bottom navigation bar; it no longer gets replaced by the discuss capsule on discussion screens.
- Move the discuss/comment capsule to the center (between two `Spacer()`s when `showDiscussButton` is true) and shrink it for a lighter look: SF Symbol 20 → 17pt, icon frame 32 → 24, capsule paddings unified to 16 horizontal / 12 vertical, icon↔count spacing 4 → 6.
- Non-discussion screens are unchanged: `[search] — Spacer — [create]`.

Figma: [node 11441:3665](https://www.figma.com/design/AmcNix4nhUIKx02POalQ3T/-M--Discussions?node-id=11441-3665)