### PR TITLE
IOS-6202 Pre-warm Object Tree widget children

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/BlockWidgetInfo+WidgetKind.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/BlockWidgetInfo+WidgetKind.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Services
+
+extension BlockWidgetInfo {
+
+    /// Set/Type source rendered as `.view` / `.list` / `.compactList`.
+    /// Routing mirrors `HomeWidgetSubmoduleView.viewForObject`.
+    var isSetTypeWidget: Bool {
+        guard case let .object(details) = source else { return false }
+        let validViewType = details.editorViewType == .list || details.editorViewType == .type
+        let validLayout: [BlockWidget.Layout] = [.view, .list, .compactList]
+        return validViewType && validLayout.contains(fixedLayout)
+    }
+
+    /// Object source with `.page` editor type rendered as `.tree`.
+    /// Routing mirrors `HomeWidgetSubmoduleView.viewForObject`.
+    var isTreeObjectWidget: Bool {
+        guard case let .object(details) = source else { return false }
+        return details.editorViewType == .page && fixedLayout == .tree
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetSubmoduleView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetSubmoduleView.swift
@@ -11,6 +11,7 @@ struct HomeWidgetSubmoduleView: View {
     let workspaceInfo: AccountInfo
     @Binding var homeState: HomeWidgetsState
     let prefetchedSetSubscription: PrefetchedSetSubscription?
+    let prefetchedTreeChildren: PrefetchedTreeChildren?
     let output: (any CommonWidgetModuleOutput)?
 
     var body: some View {
@@ -81,7 +82,8 @@ struct HomeWidgetSubmoduleView: View {
             spaceInfo: workspaceInfo,
             output: output,
             prefetchedDetails: prefetchedDetails,
-            prefetchedSetSubscription: prefetchedSetSubscription
+            prefetchedSetSubscription: prefetchedSetSubscription,
+            prefetchedTreeChildren: prefetchedTreeChildren
         )
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -122,6 +122,7 @@ private struct HomeWidgetsInternalView: View {
                 channelWidgetsObject: channelWidgetsObject,
                 personalWidgetsObject: personalWidgetsObject,
                 prefetchedSetSubscriptions: model.prefetchedSetSubscriptions,
+                prefetchedTreeChildren: model.prefetchedTreeChildren,
                 output: model.output
             )
         case .unread:

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -39,6 +39,7 @@ final class HomeWidgetsViewModel {
     private(set) var channelWidgetsObject: (any BaseDocumentProtocol)?
     private(set) var personalWidgetsObject: (any BaseDocumentProtocol)?
     private(set) var prefetchedSetSubscriptions: [String: PrefetchedSetSubscription] = [:]
+    private(set) var prefetchedTreeChildren: [String: PrefetchedTreeChildren] = [:]
 
     // Default false so readonly users never see (and can never tap) the Bin's empty-bin
     // action before `canEdit` resolves. Editors briefly see no Bin section until then —
@@ -85,17 +86,20 @@ final class HomeWidgetsViewModel {
 
         guard !Task.isCancelled else { return }
 
-        // Pre-warm before flipping the section gate so Set/Type widgets render rows
-        // on the first frame. We accept the loader extension in every context — a
-        // visible row-pop is worse than a small delay regardless of presentation.
-        async let prefetched = prewarmSetWidgetSubscriptions(channelWidgetsObject: channel)
+        // Pre-warm before flipping the section gate so Set/Type and expanded Tree
+        // widgets render rows on the first frame. We accept the loader extension in
+        // every context — a visible row-pop is worse than a small delay regardless
+        // of presentation.
+        async let prefetchedSet = prewarmSetWidgetSubscriptions(channelWidgetsObject: channel)
+        async let prefetchedTree = prewarmTreeWidgetChildren(channelWidgetsObject: channel)
         _ = await personalOpen
-        let result = await prefetched
+        let (setMap, treeMap) = await (prefetchedSet, prefetchedTree)
 
         guard !Task.isCancelled else { return }
         channelWidgetsObject = channel
         personalWidgetsObject = personal
-        prefetchedSetSubscriptions = result
+        prefetchedSetSubscriptions = setMap
+        prefetchedTreeChildren = treeMap
     }
 
     func startSubscriptions() async {
@@ -189,7 +193,7 @@ final class HomeWidgetsViewModel {
         }
     }
 
-    // MARK: - Set/Type widget pre-warm
+    // MARK: - Widget pre-warm
 
     /// Per-widget budget. A slow widget falls back to its own mount-time open
     /// (header first, rows later) instead of stalling the whole gate.
@@ -201,7 +205,7 @@ final class HomeWidgetsViewModel {
         let setWidgets = channelWidgetsObject.children.compactMap { child -> BlockWidgetInfo? in
             guard child.isWidget,
                   let info = channelWidgetsObject.widgetInfo(block: child),
-                  Self.isSetTypeWidget(widgetInfo: info),
+                  info.isSetTypeWidget,
                   expandedService.isExpanded(id: info.id, defaultValue: true)
             else { return nil }
             return info
@@ -228,13 +232,87 @@ final class HomeWidgetsViewModel {
         }
     }
 
-    /// Matches `HomeWidgetSubmoduleView`'s Set/Type routing — Tree widgets aren't
-    /// pre-warmed because their `ObjectSubscribeIds` settles in single-digit ms.
-    private static func isSetTypeWidget(widgetInfo: BlockWidgetInfo) -> Bool {
-        guard case let .object(details) = widgetInfo.source else { return false }
-        let validViewType = details.editorViewType == .list || details.editorViewType == .type
-        let validLayout: [BlockWidget.Layout] = [.view, .list, .compactList]
-        return validViewType && validLayout.contains(widgetInfo.fixedLayout)
+    private func prewarmTreeWidgetChildren(
+        channelWidgetsObject: any BaseDocumentProtocol
+    ) async -> [String: PrefetchedTreeChildren] {
+        let treeWidgets = channelWidgetsObject.children.compactMap { child -> BlockWidgetInfo? in
+            guard child.isWidget,
+                  let info = channelWidgetsObject.widgetInfo(block: child),
+                  info.isTreeObjectWidget,
+                  expandedService.isExpanded(id: info.id, defaultValue: true)
+            else { return nil }
+            return info
+        }
+
+        guard treeWidgets.isNotEmpty else { return [:] }
+
+        return await withTaskGroup(of: (String, PrefetchedTreeChildren)?.self) { group in
+            for widgetInfo in treeWidgets {
+                group.addTask { [weak self] in
+                    guard let self else { return nil }
+                    guard let prefetched = await prewarmSingleTreeWidget(widgetInfo: widgetInfo) else { return nil }
+                    return (widgetInfo.id, prefetched)
+                }
+            }
+
+            var result: [String: PrefetchedTreeChildren] = [:]
+            for await pair in group {
+                if let (id, prefetched) = pair {
+                    result[id] = prefetched
+                }
+            }
+            return result
+        }
+    }
+
+    private func prewarmSingleTreeWidget(widgetInfo: BlockWidgetInfo) async -> PrefetchedTreeChildren? {
+        guard case let .object(linkedObjectDetails) = widgetInfo.source else { return nil }
+
+        // Target has no children — seed an empty list so the widget renders `.empty`
+        // synchronously on first frame instead of flashing `.loading` → `.empty`
+        // when the live subscription emits its first (empty) result.
+        guard linkedObjectDetails.links.isNotEmpty else {
+            return PrefetchedTreeChildren(childDetails: [])
+        }
+
+        return await withTimeout(seconds: Self.prewarmTimeout) { [self] in
+            // Fresh builder per widget — its `subscriptionId` is the storage's `subId`,
+            // and we need a unique pair so disposable storages don't collide.
+            let builder = TreeSubscriptionDataBuilder()
+            let storage = subscriptionStorageProvider.createSubscriptionStorage(
+                subId: builder.subscriptionId
+            )
+            let subscriptionData = builder.build(
+                spaceId: info.accountSpaceId,
+                objectIds: linkedObjectDetails.links
+            )
+
+            do {
+                try await storage.startOrUpdateSubscription(data: subscriptionData)
+            } catch {
+                return nil
+            }
+
+            // `statePublisher` is backed by CurrentValueSubject, so subscribing after
+            // `startOrUpdateSubscription` returns replays the current state immediately.
+            var snapshot: [ObjectDetails]?
+            for await state in storage.statePublisher.values {
+                snapshot = state.items
+                break
+            }
+            try? await storage.stopSubscription()
+
+            guard let items = snapshot else { return nil }
+
+            // Mirror `TreeSubscriptionManager`'s publisher composition: filter to
+            // openable objects, sort by parent `.links` order, then apply the limit.
+            let filtered = items.filter(\.isNotDeletedAndSupportedForOpening)
+            let sorted = filtered.sorted { a, b in
+                (linkedObjectDetails.links.firstIndex(of: a.id) ?? 0)
+                    < (linkedObjectDetails.links.firstIndex(of: b.id) ?? 0)
+            }
+            return PrefetchedTreeChildren(childDetails: Array(sorted.prefix(widgetInfo.fixedLimit)))
+        }
     }
 
     private func prewarmSingleSetWidget(widgetInfo: BlockWidgetInfo) async -> PrefetchedSetSubscription? {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -306,11 +306,9 @@ final class HomeWidgetsViewModel {
 
             // Mirror `TreeSubscriptionManager`'s publisher composition: filter to
             // openable objects, sort by parent `.links` order, then apply the limit.
-            let filtered = items.filter(\.isNotDeletedAndSupportedForOpening)
-            let sorted = filtered.sorted { a, b in
-                (linkedObjectDetails.links.firstIndex(of: a.id) ?? 0)
-                    < (linkedObjectDetails.links.firstIndex(of: b.id) ?? 0)
-            }
+            let sorted = items
+                .filter(\.isNotDeletedAndSupportedForOpening)
+                .reordered(by: linkedObjectDetails.links, transform: { $0.id })
             return PrefetchedTreeChildren(childDetails: Array(sorted.prefix(widgetInfo.fixedLimit)))
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
@@ -12,6 +12,14 @@ struct PrefetchedSetSubscription: Sendable {
     let state: SubscriptionStorageState
 }
 
+/// Pre-warmed first-level child rows for expanded `(.tree, .page)` Object Tree widgets.
+/// Pure data — no live storage handoff. The VM seeds `details` synchronously in `init`,
+/// then its own `treeSubscriptionManager` starts a fresh live subscription on mount.
+struct PrefetchedTreeChildren: Sendable {
+    /// First-level children, sorted by parent `.links` order, already limited to `widgetInfo.fixedLimit`.
+    let childDetails: [ObjectDetails]
+}
+
 struct WidgetSubmoduleData {
     let widgetBlockId: String
     /// Shared channel widgets document (`info.widgetsId`) — holds pinned widgets
@@ -27,4 +35,6 @@ struct WidgetSubmoduleData {
     let prefetchedDetails: ObjectDetails?
     /// Pre-warmed set subscription bundle for Set/Type widgets — see `PrefetchedSetSubscription`.
     let prefetchedSetSubscription: PrefetchedSetSubscription?
+    /// Pre-warmed first-level children for Object Tree widgets — see `PrefetchedTreeChildren`.
+    let prefetchedTreeChildren: PrefetchedTreeChildren?
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
@@ -8,6 +8,7 @@ struct PinnedSectionView: View {
     let channelWidgetsObject: any BaseDocumentProtocol
     let personalWidgetsObject: any BaseDocumentProtocol
     let prefetchedSetSubscriptions: [String: PrefetchedSetSubscription]
+    let prefetchedTreeChildren: [String: PrefetchedTreeChildren]
     weak var output: (any CommonWidgetModuleOutput)?
 
     var body: some View {
@@ -16,6 +17,7 @@ struct PinnedSectionView: View {
             channelWidgetsObject: channelWidgetsObject,
             personalWidgetsObject: personalWidgetsObject,
             prefetchedSetSubscriptions: prefetchedSetSubscriptions,
+            prefetchedTreeChildren: prefetchedTreeChildren,
             output: output
         )
     }
@@ -29,6 +31,7 @@ private struct PinnedSectionViewInternal: View {
     let info: AccountInfo
     let personalWidgetsObject: any BaseDocumentProtocol
     let prefetchedSetSubscriptions: [String: PrefetchedSetSubscription]
+    let prefetchedTreeChildren: [String: PrefetchedTreeChildren]
     weak var output: (any CommonWidgetModuleOutput)?
 
     init(
@@ -36,11 +39,13 @@ private struct PinnedSectionViewInternal: View {
         channelWidgetsObject: any BaseDocumentProtocol,
         personalWidgetsObject: any BaseDocumentProtocol,
         prefetchedSetSubscriptions: [String: PrefetchedSetSubscription],
+        prefetchedTreeChildren: [String: PrefetchedTreeChildren],
         output: (any CommonWidgetModuleOutput)?
     ) {
         self.info = info
         self.personalWidgetsObject = personalWidgetsObject
         self.prefetchedSetSubscriptions = prefetchedSetSubscriptions
+        self.prefetchedTreeChildren = prefetchedTreeChildren
         self.output = output
         self._model = State(
             wrappedValue: PinnedSectionViewModel(
@@ -62,6 +67,7 @@ private struct PinnedSectionViewInternal: View {
                         workspaceInfo: info,
                         homeState: $model.homeState,
                         prefetchedSetSubscription: prefetchedSetSubscriptions[widgetInfo.id],
+                        prefetchedTreeChildren: prefetchedTreeChildren[widgetInfo.id],
                         output: output
                     )
                 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/ObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/ObjectWidgetInternalViewModel.swift
@@ -48,6 +48,15 @@ final class ObjectWidgetInternalViewModel: ObservableObject, WidgetInternalViewM
             self.icon = details.objectIconImage
             self.allowCreateObject = details.permissions(participantCanEdit: true).canEditBlocks
         }
+        // Seed limit early: without it, the first emission of `startTreeSubscription`
+        // runs `limitDetails()` against limit=0 and blanks rows until `startInfoSubscription`
+        // races in. Cold path benefits too.
+        self.limit = widgetObject.widgetInfo(blockId: widgetBlockId)?.fixedLimit ?? 0
+
+        if let prefetched = data.prefetchedTreeChildren {
+            self.details = prefetched.childDetails
+            self.availableMore = (linkedObjectDetails?.links.count ?? 0) > self.limit
+        }
     }
     
     func startHeaderSubscription() {}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/ObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/ObjectWidgetInternalViewModel.swift
@@ -49,14 +49,10 @@ final class ObjectWidgetInternalViewModel: ObservableObject, WidgetInternalViewM
             self.allowCreateObject = details.permissions(participantCanEdit: true).canEditBlocks
         }
         // Seed limit early: without it, the first emission of `startTreeSubscription`
-        // runs `limitDetails()` against limit=0 and blanks rows until `startInfoSubscription`
-        // races in. Cold path benefits too.
+        // runs `limitDetails()` against limit=0, emits `details = []` via `detailsPublisher`,
+        // and clobbers `TreeWidgetViewModel.firstLevelSubscriptionData` until
+        // `startInfoSubscription` races in. Cold path benefits too.
         self.limit = widgetObject.widgetInfo(blockId: widgetBlockId)?.fixedLimit ?? 0
-
-        if let prefetched = data.prefetchedTreeChildren {
-            self.details = prefetched.childDetails
-            self.availableMore = (linkedObjectDetails?.links.count ?? 0) > self.limit
-        }
     }
     
     func startHeaderSubscription() {}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetView.swift
@@ -17,6 +17,7 @@ struct TreeWidgetView: View {
                 widgetBlockId: data.widgetBlockId,
                 widgetObject: data.channelWidgetsObject,
                 internalModel: internalModel,
+                prefetchedFirstLevel: data.prefetchedTreeChildren?.childDetails,
                 output: data.output
             )
         )

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetViewModel.swift
@@ -50,12 +50,21 @@ final class TreeWidgetViewModel: ObservableObject {
         widgetBlockId: String,
         widgetObject: any BaseDocumentProtocol,
         internalModel: any WidgetInternalViewModelProtocol,
+        prefetchedFirstLevel: [ObjectDetails]?,
         output: (any CommonWidgetModuleOutput)?
     ) {
         self.widgetBlockId = widgetBlockId
         self.widgetObject = widgetObject
         self.internalModel = internalModel
         self.output = output
+        // Seed rows synchronously when available — `internalModel.detailsPublisher`
+        // is delivered via `receiveOnMain()`, so even an init-time seed in the inner
+        // VM reaches the sink one main-tick later. Without this, the content area
+        // animates from 0pt (rows == nil) to the empty-state placeholder (rows == []).
+        if let prefetchedFirstLevel {
+            self.firstLevelSubscriptionData = prefetchedFirstLevel
+            updateTree()
+        }
         startHeaderSubscription()
         startContentSubscription()
     }


### PR DESCRIPTION
## Summary

- Pre-warms first-level children for expanded `(.tree, .page)` Object Tree widgets during `HomeWidgetsViewModel.openWidgetObjects()`, mirroring the IOS-6198 Set/Type prewarm so rows render on the first frame instead of popping in mid-Space-transition.
- `TreeWidgetViewModel` seeds `firstLevelSubscriptionData` synchronously from the prefetched DTO so the content area doesn't animate from 0pt → empty-state placeholder when target has no children.
- Seeds `ObjectWidgetInternalViewModel.limit` early to prevent a `limitDetails()` race that otherwise emits `details = []` through `detailsPublisher` and clobbers the seeded rows.
- Adds `BlockWidgetInfo+WidgetKind.swift` hosting `isSetTypeWidget` (moved from a private static) and the new `isTreeObjectWidget`.