### PR TITLE
IOS-6205 Pre-warm Unread section

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -128,6 +128,7 @@ private struct HomeWidgetsInternalView: View {
         case .unread:
             UnreadSectionView(
                 spaceId: model.spaceId,
+                prefetched: model.prefetchedUnreadSection,
                 output: model.output,
                 onShouldHideBadgesChange: { shouldHideChatBadges = $0 }
             )

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -28,6 +28,12 @@ final class HomeWidgetsViewModel {
     private var subscriptionStorageProvider: any SubscriptionStorageProviderProtocol
     @Injected(\.spaceViewsStorage) @ObservationIgnored
     private var spaceViewsStorage: any SpaceViewsStorageProtocol
+    @Injected(\.chatMessagesPreviewsStorage) @ObservationIgnored
+    private var chatMessagesPreviewsStorage: any ChatMessagesPreviewsStorageProtocol
+    @Injected(\.chatDetailsStorage) @ObservationIgnored
+    private var chatDetailsStorage: any ChatDetailsStorageProtocol
+    @Injected(\.objectsWithUnreadDiscussionsSubscription) @ObservationIgnored
+    private var unreadDiscussionsSubscription: any ObjectsWithUnreadDiscussionsSubscriptionProtocol
 
     @ObservationIgnored
     weak var output: (any HomeWidgetsModuleOutput)?
@@ -40,6 +46,7 @@ final class HomeWidgetsViewModel {
     private(set) var personalWidgetsObject: (any BaseDocumentProtocol)?
     private(set) var prefetchedSetSubscriptions: [String: PrefetchedSetSubscription] = [:]
     private(set) var prefetchedTreeChildren: [String: PrefetchedTreeChildren] = [:]
+    private(set) var prefetchedUnreadSection: PrefetchedUnreadSection?
 
     // Default false so readonly users never see (and can never tap) the Bin's empty-bin
     // action before `canEdit` resolves. Editors briefly see no Bin section until then —
@@ -92,14 +99,16 @@ final class HomeWidgetsViewModel {
         // of presentation.
         async let prefetchedSet = prewarmSetWidgetSubscriptions(channelWidgetsObject: channel)
         async let prefetchedTree = prewarmTreeWidgetChildren(channelWidgetsObject: channel)
+        async let prefetchedUnread = prewarmUnreadSection()
         _ = await personalOpen
-        let (setMap, treeMap) = await (prefetchedSet, prefetchedTree)
+        let (setMap, treeMap, unread) = await (prefetchedSet, prefetchedTree, prefetchedUnread)
 
         guard !Task.isCancelled else { return }
         channelWidgetsObject = channel
         personalWidgetsObject = personal
         prefetchedSetSubscriptions = setMap
         prefetchedTreeChildren = treeMap
+        prefetchedUnreadSection = unread
     }
 
     func startSubscriptions() async {
@@ -230,6 +239,34 @@ final class HomeWidgetsViewModel {
             }
             return result
         }
+    }
+
+    /// Snapshot the four sources backing the Unread section and run the same merge the live
+    /// subscription would run, so `UnreadSectionViewModel` can seed `unreadItems` on first
+    /// frame and the section header + rows render without the one-frame pop-in. No timeout —
+    /// all three storages are global `.shared` actors started by login time, so reads are
+    /// in-memory snapshots; cold-start aggregator returns `[:]` and the live subscription
+    /// fills parent rows in on the next tick.
+    private func prewarmUnreadSection() async -> PrefetchedUnreadSection? {
+        let spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)
+        let supportsMultiChats = !(spaceView?.isOneToOne ?? false)
+        guard supportsMultiChats else { return nil }
+
+        async let previews = chatMessagesPreviewsStorage.previews()
+        async let chats = chatDetailsStorage.allChats()
+        async let unreadBySpace = unreadDiscussionsSubscription.snapshot
+
+        let (p, c, u) = await (previews, chats, unreadBySpace)
+        guard let spaceView else { return PrefetchedUnreadSection(rows: [], supportsMultiChats: true) }
+
+        let rows = UnreadSectionViewModel.mergeUnreadRows(
+            previews: p,
+            chatDetails: c,
+            spaceView: spaceView,
+            unreadBySpace: u,
+            spaceId: spaceId
+        )
+        return PrefetchedUnreadSection(rows: rows, supportsMultiChats: true)
     }
 
     private func prewarmTreeWidgetChildren(

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -241,9 +241,7 @@ final class HomeWidgetsViewModel {
         }
     }
 
-    /// No timeout — the three backing storages are global `.shared` actors started by login,
-    /// so reads are in-memory snapshots. Cold-start aggregator returns `[:]` and the live
-    /// subscription fills parent rows in on the next tick.
+    /// In-memory snapshots — no timeout; cold-start aggregator returns `[:]` and the live subscription fills gaps.
     private func prewarmUnreadSection() async -> PrefetchedUnreadSection? {
         let spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)
         let supportsMultiChats = !(spaceView?.isOneToOne ?? false)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -241,12 +241,9 @@ final class HomeWidgetsViewModel {
         }
     }
 
-    /// Snapshot the four sources backing the Unread section and run the same merge the live
-    /// subscription would run, so `UnreadSectionViewModel` can seed `unreadItems` on first
-    /// frame and the section header + rows render without the one-frame pop-in. No timeout —
-    /// all three storages are global `.shared` actors started by login time, so reads are
-    /// in-memory snapshots; cold-start aggregator returns `[:]` and the live subscription
-    /// fills parent rows in on the next tick.
+    /// No timeout — the three backing storages are global `.shared` actors started by login,
+    /// so reads are in-memory snapshots. Cold-start aggregator returns `[:]` and the live
+    /// subscription fills parent rows in on the next tick.
     private func prewarmUnreadSection() async -> PrefetchedUnreadSection? {
         let spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)
         let supportsMultiChats = !(spaceView?.isOneToOne ?? false)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
@@ -20,10 +20,7 @@ struct PrefetchedTreeChildren: Sendable {
     let childDetails: [ObjectDetails]
 }
 
-/// Pre-warmed merge of the Unread section so the section header + rows render on the first
-/// frame of the widget surface, instead of popping in after `combineLatest` produces its
-/// first emission. The VM seeds `unreadItems` from `rows` and treats `didLoadInitial = true`,
-/// then its own live subscription takes over on subsequent emits.
+/// Pre-warmed Unread rows; seeds `unreadItems` + `didLoadInitial` before live subscription takes over.
 struct PrefetchedUnreadSection: Sendable {
     let rows: [UnreadSectionRowData]
     let supportsMultiChats: Bool

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Common/WidgetSubmoduleData.swift
@@ -20,6 +20,15 @@ struct PrefetchedTreeChildren: Sendable {
     let childDetails: [ObjectDetails]
 }
 
+/// Pre-warmed merge of the Unread section so the section header + rows render on the first
+/// frame of the widget surface, instead of popping in after `combineLatest` produces its
+/// first emission. The VM seeds `unreadItems` from `rows` and treats `didLoadInitial = true`,
+/// then its own live subscription takes over on subsequent emits.
+struct PrefetchedUnreadSection: Sendable {
+    let rows: [UnreadSectionRowData]
+    let supportsMultiChats: Bool
+}
+
 struct WidgetSubmoduleData {
     let widgetBlockId: String
     /// Shared channel widgets document (`info.widgetsId`) — holds pinned widgets

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionRowData.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionRowData.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Services
 
-struct UnreadSectionRowData: Identifiable, Equatable {
+struct UnreadSectionRowData: Identifiable, Equatable, Sendable {
     let id: String
     let details: ObjectDetails
     let notificationMode: SpacePushNotificationsMode

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionView.swift
@@ -5,12 +5,14 @@ import Services
 struct UnreadSectionView: View {
 
     let spaceId: String
+    let prefetched: PrefetchedUnreadSection?
     weak var output: (any CommonWidgetModuleOutput)?
     let onShouldHideBadgesChange: (Bool) -> Void
 
     var body: some View {
         UnreadSectionViewInternal(
             spaceId: spaceId,
+            prefetched: prefetched,
             output: output,
             onShouldHideBadgesChange: onShouldHideBadgesChange
         )
@@ -24,11 +26,12 @@ private struct UnreadSectionViewInternal: View {
 
     init(
         spaceId: String,
+        prefetched: PrefetchedUnreadSection?,
         output: (any CommonWidgetModuleOutput)?,
         onShouldHideBadgesChange: @escaping (Bool) -> Void
     ) {
         self.onShouldHideBadgesChange = onShouldHideBadgesChange
-        self._model = State(wrappedValue: UnreadSectionViewModel(spaceId: spaceId, output: output))
+        self._model = State(wrappedValue: UnreadSectionViewModel(spaceId: spaceId, prefetched: prefetched, output: output))
     }
 
     var body: some View {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -53,8 +53,7 @@ final class UnreadSectionViewModel {
         if let prefetched {
             self.unreadItems = prefetched.rows
             self.supportsMultiChats = prefetched.supportsMultiChats
-            // Releases `shouldHideChatBadges` from its pessimistic `true` default so first-frame
-            // pinned chat badges render with their real visibility instead of flashing hidden→visible.
+            // Release `shouldHideChatBadges` from its pessimistic `true` default.
             self.didLoadInitial = true
         } else {
             // Default to multi-chat when spaceView isn't loaded yet — the section is also gated

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -51,11 +51,10 @@ final class UnreadSectionViewModel {
         self.unreadSectionIsExpanded = expandedService.isExpanded(section: .unread, defaultValue: true)
 
         if let prefetched {
-            // Seed first-frame state: rows already merged, multi-chat decided, aggregator
-            // treated as having ticked so `shouldHideChatBadges` reports its real value
-            // immediately instead of the pessimistic `true` default.
             self.unreadItems = prefetched.rows
             self.supportsMultiChats = prefetched.supportsMultiChats
+            // Releases `shouldHideChatBadges` from its pessimistic `true` default so first-frame
+            // pinned chat badges render with their real visibility instead of flashing hidden→visible.
             self.didLoadInitial = true
         } else {
             // Default to multi-chat when spaceView isn't loaded yet — the section is also gated

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Unread/UnreadSectionViewModel.swift
@@ -45,13 +45,23 @@ final class UnreadSectionViewModel {
         return shouldShowUnreadSection && unreadSectionIsExpanded
     }
 
-    init(spaceId: String, output: (any CommonWidgetModuleOutput)?) {
+    init(spaceId: String, prefetched: PrefetchedUnreadSection?, output: (any CommonWidgetModuleOutput)?) {
         self.spaceId = spaceId
         self.output = output
         self.unreadSectionIsExpanded = expandedService.isExpanded(section: .unread, defaultValue: true)
-        // Default to multi-chat when spaceView isn't loaded yet — the section is also gated
-        // by `unreadItems.isNotEmpty`, so multi-chat-but-empty stays invisible.
-        self.supportsMultiChats = !(workspaceStorage.spaceView(spaceId: spaceId)?.isOneToOne ?? false)
+
+        if let prefetched {
+            // Seed first-frame state: rows already merged, multi-chat decided, aggregator
+            // treated as having ticked so `shouldHideChatBadges` reports its real value
+            // immediately instead of the pessimistic `true` default.
+            self.unreadItems = prefetched.rows
+            self.supportsMultiChats = prefetched.supportsMultiChats
+            self.didLoadInitial = true
+        } else {
+            // Default to multi-chat when spaceView isn't loaded yet — the section is also gated
+            // by `unreadItems.isNotEmpty`, so multi-chat-but-empty stays invisible.
+            self.supportsMultiChats = !(workspaceStorage.spaceView(spaceId: spaceId)?.isOneToOne ?? false)
+        }
     }
 
     // MARK: - Subscriptions
@@ -96,55 +106,71 @@ final class UnreadSectionViewModel {
             let nextSupportsMultiChats = !currentSpaceView.isOneToOne
             if supportsMultiChats != nextSupportsMultiChats { supportsMultiChats = nextSupportsMultiChats }
 
-            let chatItems: [UnreadSectionRowData] = previews.compactMap { preview in
-                guard preview.spaceId == spaceId else { return nil }
-
-                let mode = currentSpaceView.effectiveNotificationMode(for: preview.chatId)
-                if FeatureFlags.muteAndHide && mode == .nothing {
-                    guard preview.mentionCounter > 0 || preview.hasUnreadReactions else { return nil }
-                }
-
-                guard preview.hasCounters else { return nil }
-                guard let chatDetail = chatDetails.first(where: { $0.id == preview.chatId }), !chatDetail.isArchivedOrDeleted else {
-                    return nil
-                }
-                return UnreadSectionRowData(
-                    id: chatDetail.id,
-                    details: chatDetail,
-                    notificationMode: mode,
-                    unreadMessageCount: preview.unreadCounter,
-                    unreadMentionCount: preview.mentionCounter,
-                    hasUnreadReactions: preview.hasUnreadReactions,
-                    isSubscribed: true,
-                    lastMessageDate: preview.lastMessage?.createdAt
-                )
-            }
-
-            let parentSource = FeatureFlags.discussionButton ? (unreadBySpace[spaceId]?.parents ?? []) : []
-            let parentMode = currentSpaceView.pushNotificationMode
-            let parentItems: [UnreadSectionRowData] = parentSource.compactMap { parent in
-                if FeatureFlags.muteAndHide && parentMode == .nothing {
-                    guard parent.hasUnreadMention else { return nil }
-                }
-                // Aggregator admits any subscribed parent; drop fully-caught-up rows here so the section
-                // never shows a name with no badge. Mirrors the chat path's `hasCounters` guard.
-                guard parent.unreadMessageCount > 0 || parent.hasUnreadMention else { return nil }
-                return UnreadSectionRowData(
-                    id: parent.id,
-                    details: parent.details,
-                    notificationMode: parentMode,
-                    unreadMessageCount: parent.unreadMessageCount,
-                    unreadMentionCount: parent.unreadMentionCount,
-                    hasUnreadReactions: false,
-                    isSubscribed: parent.isSubscribed,
-                    lastMessageDate: parent.lastMessageDate
-                )
-            }
-
-            let merged = (chatItems + parentItems)
-                .sorted { ($0.lastMessageDate ?? .distantPast) > ($1.lastMessageDate ?? .distantPast) }
+            let merged = Self.mergeUnreadRows(
+                previews: previews,
+                chatDetails: chatDetails,
+                spaceView: currentSpaceView,
+                unreadBySpace: unreadBySpace,
+                spaceId: spaceId
+            )
             guard unreadItems != merged else { continue }
             unreadItems = merged
         }
+    }
+
+    static func mergeUnreadRows(
+        previews: [ChatMessagePreview],
+        chatDetails: [ObjectDetails],
+        spaceView: SpaceView,
+        unreadBySpace: [String: SpaceDiscussionsUnreadInfo],
+        spaceId: String
+    ) -> [UnreadSectionRowData] {
+        let chatItems: [UnreadSectionRowData] = previews.compactMap { preview in
+            guard preview.spaceId == spaceId else { return nil }
+
+            let mode = spaceView.effectiveNotificationMode(for: preview.chatId)
+            if FeatureFlags.muteAndHide && mode == .nothing {
+                guard preview.mentionCounter > 0 || preview.hasUnreadReactions else { return nil }
+            }
+
+            guard preview.hasCounters else { return nil }
+            guard let chatDetail = chatDetails.first(where: { $0.id == preview.chatId }), !chatDetail.isArchivedOrDeleted else {
+                return nil
+            }
+            return UnreadSectionRowData(
+                id: chatDetail.id,
+                details: chatDetail,
+                notificationMode: mode,
+                unreadMessageCount: preview.unreadCounter,
+                unreadMentionCount: preview.mentionCounter,
+                hasUnreadReactions: preview.hasUnreadReactions,
+                isSubscribed: true,
+                lastMessageDate: preview.lastMessage?.createdAt
+            )
+        }
+
+        let parentSource = FeatureFlags.discussionButton ? (unreadBySpace[spaceId]?.parents ?? []) : []
+        let parentMode = spaceView.pushNotificationMode
+        let parentItems: [UnreadSectionRowData] = parentSource.compactMap { parent in
+            if FeatureFlags.muteAndHide && parentMode == .nothing {
+                guard parent.hasUnreadMention else { return nil }
+            }
+            // Aggregator admits any subscribed parent; drop fully-caught-up rows here so the section
+            // never shows a name with no badge. Mirrors the chat path's `hasCounters` guard.
+            guard parent.unreadMessageCount > 0 || parent.hasUnreadMention else { return nil }
+            return UnreadSectionRowData(
+                id: parent.id,
+                details: parent.details,
+                notificationMode: parentMode,
+                unreadMessageCount: parent.unreadMessageCount,
+                unreadMentionCount: parent.unreadMentionCount,
+                hasUnreadReactions: false,
+                isSubscribed: parent.isSubscribed,
+                lastMessageDate: parent.lastMessageDate
+            )
+        }
+
+        return (chatItems + parentItems)
+            .sorted { ($0.lastMessageDate ?? .distantPast) > ($1.lastMessageDate ?? .distantPast) }
     }
 }

--- a/Anytype/Sources/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsSubscription.swift
+++ b/Anytype/Sources/ServiceLayer/ObjectsUnread/ObjectsWithUnreadDiscussionsSubscription.swift
@@ -4,6 +4,7 @@ import AsyncTools
 
 protocol ObjectsWithUnreadDiscussionsSubscriptionProtocol: AnyObject, Sendable {
     var unreadBySpaceSequence: AnyAsyncSequence<[String: SpaceDiscussionsUnreadInfo]> { get async }
+    var snapshot: [String: SpaceDiscussionsUnreadInfo] { get async }
     func startSubscription() async
     func stopSubscription() async
 }
@@ -29,6 +30,10 @@ actor ObjectsWithUnreadDiscussionsSubscription: ObjectsWithUnreadDiscussionsSubs
 
     var unreadBySpaceSequence: AnyAsyncSequence<[String: SpaceDiscussionsUnreadInfo]> {
         unreadBySpaceStream.subscribe([:]).eraseToAnyAsyncSequence()
+    }
+
+    var snapshot: [String: SpaceDiscussionsUnreadInfo] {
+        lastEmittedAggregate ?? [:]
     }
 
     func startSubscription() async {


### PR DESCRIPTION
## Summary
- Snapshots chat previews, chat details, space view, and the unread-discussions aggregate inside `HomeWidgetsViewModel.openWidgetObjects()` (alongside the existing IOS-6198/IOS-6202 prewarms) and seeds `UnreadSectionViewModel` with the merged rows so the section header + rows render on the first frame, eliminating the visible "section jump" when opening a Space.
- Extracts the chat/parent merge from the live `combineLatest` loop into a static `UnreadSectionViewModel.mergeUnreadRows(...)` so both prewarm and live subscription share one code path.
- Adds a non-blocking `snapshot` accessor on `ObjectsWithUnreadDiscussionsSubscriptionProtocol` (returns `lastEmittedAggregate ?? [:]`); cold-start aggregator returns empty and the live subscription fills parent rows in on the next tick.
- Side benefit: seeding `didLoadInitial = true` releases pinned-chat-widget badges from their pessimistic-hidden default on the first frame.