### PR TITLE
IOS-6204 Open and save widget objects regardless of space-root view

### DIFF
--- a/AnyTypeTests/PresentationLayer/HomeWidgets/HomeWidgetsViewModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/HomeWidgets/HomeWidgetsViewModelTests.swift
@@ -90,6 +90,7 @@ private final class TestWidgetsObjectsStorage: WidgetsObjectsStorageProtocol {
 
     func prepare(info: AccountInfo) {}
     func waitForReady(spaceId: String) async {}
+    func clear() {}
 
     func widgetsObjects(spaceId: String) -> (channel: any BaseDocumentProtocol, personal: any BaseDocumentProtocol)? {
         guard self.spaceId == spaceId, let channel, let personal else { return nil }

--- a/AnyTypeTests/PresentationLayer/HomeWidgets/HomeWidgetsViewModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/HomeWidgets/HomeWidgetsViewModelTests.swift
@@ -8,43 +8,40 @@ import Factory
 @MainActor
 struct HomeWidgetsViewModelTests {
 
-    private let documentsProvider: TestDocumentsProvider
+    private let widgetsStorage: TestWidgetsObjectsStorage
 
     init() {
-        let documentsProvider = TestDocumentsProvider()
-        Container.shared.documentsProvider.register { documentsProvider }
-        self.documentsProvider = documentsProvider
+        let widgetsStorage = TestWidgetsObjectsStorage()
+        Container.shared.widgetsObjectsStorage.register { widgetsStorage }
+        // VM still injects documentsProvider for set/homepage docs; provide a no-op stub
+        // so test resolution doesn't pick up a stale registration from another suite.
+        Container.shared.documentsProvider.register { TestDocumentsProvider() }
+        self.widgetsStorage = widgetsStorage
     }
 
     // MARK: - openWidgetObjects
 
-    @Test func openWidgetObjects_bothSucceed_setsBothObjects() async {
+    @Test func openWidgetObjects_storageHasBothDocs_setsBothObjects() async {
         let info = makeAccountInfo(widgetsId: "channel-id", spaceId: "space-id")
-        documentsProvider.register(objectId: info.widgetsId, doc: MockBaseDocument(objectId: info.widgetsId))
-        documentsProvider.register(objectId: info.personalWidgetsId, doc: MockBaseDocument(objectId: info.personalWidgetsId))
+        let channel = MockBaseDocument(objectId: info.widgetsId)
+        let personal = MockBaseDocument(objectId: info.personalWidgetsId)
+        widgetsStorage.preload(spaceId: info.accountSpaceId, channel: channel, personal: personal)
         let model = HomeWidgetsViewModel(info: info, output: nil)
 
         await model.openWidgetObjects()
 
         #expect(model.channelWidgetsObject?.objectId == info.widgetsId)
         #expect(model.personalWidgetsObject?.objectId == info.personalWidgetsId)
-        #expect(documentsProvider.requestedObjectIds.contains(info.widgetsId))
-        #expect(documentsProvider.requestedObjectIds.contains(info.personalWidgetsId))
     }
 
-    @Test func openWidgetObjects_oneOpenThrows_stillSetsBothObjects() async {
+    @Test func openWidgetObjects_storageReturnsNil_leavesObjectsNil() async {
         let info = makeAccountInfo(widgetsId: "channel-id", spaceId: "space-id")
-        let channelDoc = MockBaseDocument(objectId: info.widgetsId)
-        channelDoc.openHandler = { throw TestError.openFailed }
-        let personalDoc = MockBaseDocument(objectId: info.personalWidgetsId)
-        documentsProvider.register(objectId: info.widgetsId, doc: channelDoc)
-        documentsProvider.register(objectId: info.personalWidgetsId, doc: personalDoc)
         let model = HomeWidgetsViewModel(info: info, output: nil)
 
         await model.openWidgetObjects()
 
-        #expect(model.channelWidgetsObject?.objectId == info.widgetsId)
-        #expect(model.personalWidgetsObject?.objectId == info.personalWidgetsId)
+        #expect(model.channelWidgetsObject == nil)
+        #expect(model.personalWidgetsObject == nil)
     }
 
     @Test func widgetObjects_areNilBeforeOpenWidgetObjectsResolves() {
@@ -79,26 +76,35 @@ struct HomeWidgetsViewModelTests {
 
 // MARK: - Inline test mocks
 
-private enum TestError: Error {
-    case openFailed
+@MainActor
+private final class TestWidgetsObjectsStorage: WidgetsObjectsStorageProtocol {
+    private var spaceId: String?
+    private var channel: (any BaseDocumentProtocol)?
+    private var personal: (any BaseDocumentProtocol)?
+
+    func preload(spaceId: String, channel: any BaseDocumentProtocol, personal: any BaseDocumentProtocol) {
+        self.spaceId = spaceId
+        self.channel = channel
+        self.personal = personal
+    }
+
+    func prepare(info: AccountInfo) {}
+    func waitForReady(spaceId: String) async {}
+
+    func channelWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)? {
+        guard self.spaceId == spaceId else { return nil }
+        return channel
+    }
+
+    func personalWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)? {
+        guard self.spaceId == spaceId else { return nil }
+        return personal
+    }
 }
 
 private final class TestDocumentsProvider: DocumentsProviderProtocol, @unchecked Sendable {
-    private var documentsByObjectId: [String: any BaseDocumentProtocol] = [:]
-    private(set) var requestedObjectIds: [String] = []
-
-    func register(objectId: String, doc: any BaseDocumentProtocol) {
-        documentsByObjectId[objectId] = doc
-    }
-
     func document(objectId: String, spaceId: String, mode: DocumentMode) -> any BaseDocumentProtocol {
-        requestedObjectIds.append(objectId)
-        if let doc = documentsByObjectId[objectId] {
-            return doc
-        }
-        let fallback = MockBaseDocument(objectId: objectId)
-        documentsByObjectId[objectId] = fallback
-        return fallback
+        MockBaseDocument(objectId: objectId)
     }
 
     func setDocument(
@@ -107,6 +113,6 @@ private final class TestDocumentsProvider: DocumentsProviderProtocol, @unchecked
         mode: DocumentMode,
         inlineParameters: EditorInlineSetObject?
     ) -> any SetDocumentProtocol {
-        fatalError("setDocument not used by HomeWidgetsViewModel")
+        fatalError("setDocument not used by HomeWidgetsViewModelTests")
     }
 }

--- a/AnyTypeTests/PresentationLayer/HomeWidgets/HomeWidgetsViewModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/HomeWidgets/HomeWidgetsViewModelTests.swift
@@ -34,7 +34,7 @@ struct HomeWidgetsViewModelTests {
         #expect(model.personalWidgetsObject?.objectId == info.personalWidgetsId)
     }
 
-    @Test func openWidgetObjects_storageReturnsNil_leavesObjectsNil() async {
+    @Test func openWidgetObjects_storageNotPreloaded_leavesObjectsNil() async {
         let info = makeAccountInfo(widgetsId: "channel-id", spaceId: "space-id")
         let model = HomeWidgetsViewModel(info: info, output: nil)
 
@@ -44,7 +44,7 @@ struct HomeWidgetsViewModelTests {
         #expect(model.personalWidgetsObject == nil)
     }
 
-    @Test func widgetObjects_areNilBeforeOpenWidgetObjectsResolves() {
+    @Test func widgetObjects_areNilOnInit() {
         let info = makeAccountInfo(widgetsId: "channel-id", spaceId: "space-id")
         let model = HomeWidgetsViewModel(info: info, output: nil)
 
@@ -91,14 +91,9 @@ private final class TestWidgetsObjectsStorage: WidgetsObjectsStorageProtocol {
     func prepare(info: AccountInfo) {}
     func waitForReady(spaceId: String) async {}
 
-    func channelWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)? {
-        guard self.spaceId == spaceId else { return nil }
-        return channel
-    }
-
-    func personalWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)? {
-        guard self.spaceId == spaceId else { return nil }
-        return personal
+    func widgetsObjects(spaceId: String) -> (channel: any BaseDocumentProtocol, personal: any BaseDocumentProtocol)? {
+        guard self.spaceId == spaceId, let channel, let personal else { return nil }
+        return (channel, personal)
     }
 }
 

--- a/AnyTypeTests/Services/WidgetsObjectsStorageTests.swift
+++ b/AnyTypeTests/Services/WidgetsObjectsStorageTests.swift
@@ -82,6 +82,23 @@ struct WidgetsObjectsStorageTests {
         #expect(sut.widgetsObjects(spaceId: "never-prepared") == nil)
     }
 
+    @Test func clear_dropsCurrentStateAndAllowsReopen() async {
+        let info = makeInfo(spaceId: "A")
+        documentsProvider.register(objectId: info.widgetsId, doc: MockBaseDocument(objectId: info.widgetsId))
+        documentsProvider.register(objectId: info.personalWidgetsId, doc: MockBaseDocument(objectId: info.personalWidgetsId))
+
+        sut.prepare(info: info)
+        await sut.waitForReady(spaceId: info.accountSpaceId)
+        let firstChannelCount = documentsProvider.callCount(objectId: info.widgetsId)
+        sut.clear()
+
+        #expect(sut.widgetsObjects(spaceId: info.accountSpaceId) == nil)
+
+        sut.prepare(info: info)
+        await sut.waitForReady(spaceId: info.accountSpaceId)
+        #expect(documentsProvider.callCount(objectId: info.widgetsId) == firstChannelCount + 1)
+    }
+
     @Test func prepare_openThrows_stillExposesDocs() async {
         let info = makeInfo(spaceId: "A")
         let channel = MockBaseDocument(objectId: info.widgetsId)

--- a/AnyTypeTests/Services/WidgetsObjectsStorageTests.swift
+++ b/AnyTypeTests/Services/WidgetsObjectsStorageTests.swift
@@ -1,0 +1,155 @@
+import Testing
+import Foundation
+@testable import Anytype
+import Services
+import Factory
+
+@Suite(.serialized)
+@MainActor
+struct WidgetsObjectsStorageTests {
+
+    private let documentsProvider: TestDocumentsProvider
+    private let sut: WidgetsObjectsStorage
+
+    init() {
+        let documentsProvider = TestDocumentsProvider()
+        Container.shared.documentsProvider.register { documentsProvider }
+        self.documentsProvider = documentsProvider
+        self.sut = WidgetsObjectsStorage()
+    }
+
+    @Test func prepare_opensBothDocsForSpace() async {
+        let info = makeInfo(spaceId: "A")
+        let channel = MockBaseDocument(objectId: info.widgetsId)
+        let personal = MockBaseDocument(objectId: info.personalWidgetsId)
+        documentsProvider.register(objectId: info.widgetsId, doc: channel)
+        documentsProvider.register(objectId: info.personalWidgetsId, doc: personal)
+        var channelOpened = false
+        var personalOpened = false
+        channel.openHandler = { channelOpened = true }
+        personal.openHandler = { personalOpened = true }
+
+        sut.prepare(info: info)
+        await sut.waitForReady(spaceId: info.accountSpaceId)
+
+        #expect(channelOpened)
+        #expect(personalOpened)
+        #expect(sut.channelWidgetsObject(spaceId: info.accountSpaceId)?.objectId == info.widgetsId)
+        #expect(sut.personalWidgetsObject(spaceId: info.accountSpaceId)?.objectId == info.personalWidgetsId)
+    }
+
+    @Test func prepare_sameSpaceTwice_doesNotReopen() async {
+        let info = makeInfo(spaceId: "A")
+        let channel = MockBaseDocument(objectId: info.widgetsId)
+        let personal = MockBaseDocument(objectId: info.personalWidgetsId)
+        documentsProvider.register(objectId: info.widgetsId, doc: channel)
+        documentsProvider.register(objectId: info.personalWidgetsId, doc: personal)
+
+        sut.prepare(info: info)
+        await sut.waitForReady(spaceId: info.accountSpaceId)
+        let firstCallCount = documentsProvider.callCount(objectId: info.widgetsId)
+
+        sut.prepare(info: info)
+        await sut.waitForReady(spaceId: info.accountSpaceId)
+
+        #expect(documentsProvider.callCount(objectId: info.widgetsId) == firstCallCount)
+    }
+
+    @Test func prepare_differentSpace_dropsPreviousAndOpensNew() async {
+        let infoA = makeInfo(spaceId: "A")
+        let infoB = makeInfo(spaceId: "B")
+        documentsProvider.register(objectId: infoA.widgetsId, doc: MockBaseDocument(objectId: infoA.widgetsId))
+        documentsProvider.register(objectId: infoA.personalWidgetsId, doc: MockBaseDocument(objectId: infoA.personalWidgetsId))
+        documentsProvider.register(objectId: infoB.widgetsId, doc: MockBaseDocument(objectId: infoB.widgetsId))
+        documentsProvider.register(objectId: infoB.personalWidgetsId, doc: MockBaseDocument(objectId: infoB.personalWidgetsId))
+
+        sut.prepare(info: infoA)
+        await sut.waitForReady(spaceId: infoA.accountSpaceId)
+        sut.prepare(info: infoB)
+        await sut.waitForReady(spaceId: infoB.accountSpaceId)
+
+        #expect(sut.channelWidgetsObject(spaceId: infoA.accountSpaceId) == nil)
+        #expect(sut.personalWidgetsObject(spaceId: infoA.accountSpaceId) == nil)
+        #expect(sut.channelWidgetsObject(spaceId: infoB.accountSpaceId)?.objectId == infoB.widgetsId)
+        #expect(sut.personalWidgetsObject(spaceId: infoB.accountSpaceId)?.objectId == infoB.personalWidgetsId)
+    }
+
+    @Test func waitForReady_unknownSpace_returnsImmediately() async {
+        await sut.waitForReady(spaceId: "never-prepared")
+        #expect(sut.channelWidgetsObject(spaceId: "never-prepared") == nil)
+    }
+
+    @Test func prepare_openThrows_stillExposesDocs() async {
+        let info = makeInfo(spaceId: "A")
+        let channel = MockBaseDocument(objectId: info.widgetsId)
+        channel.openHandler = { throw TestError.openFailed }
+        let personal = MockBaseDocument(objectId: info.personalWidgetsId)
+        documentsProvider.register(objectId: info.widgetsId, doc: channel)
+        documentsProvider.register(objectId: info.personalWidgetsId, doc: personal)
+
+        sut.prepare(info: info)
+        await sut.waitForReady(spaceId: info.accountSpaceId)
+
+        #expect(sut.channelWidgetsObject(spaceId: info.accountSpaceId) != nil)
+        #expect(sut.personalWidgetsObject(spaceId: info.accountSpaceId) != nil)
+    }
+
+    // MARK: - Helpers
+
+    private func makeInfo(spaceId: String) -> AccountInfo {
+        AccountInfo(
+            homeObjectID: "",
+            archiveObjectID: "",
+            profileObjectID: "",
+            gatewayURL: "",
+            accountSpaceId: spaceId,
+            spaceViewId: "",
+            widgetsId: "\(spaceId)-channel",
+            analyticsId: "",
+            deviceId: "",
+            networkId: "",
+            techSpaceId: "",
+            ethereumAddress: "",
+            spaceChatId: "",
+            metadataKey: ""
+        )
+    }
+}
+
+// MARK: - Inline test mocks
+
+private enum TestError: Error {
+    case openFailed
+}
+
+private final class TestDocumentsProvider: DocumentsProviderProtocol, @unchecked Sendable {
+    private var documentsByObjectId: [String: any BaseDocumentProtocol] = [:]
+    private var callCounts: [String: Int] = [:]
+
+    func register(objectId: String, doc: any BaseDocumentProtocol) {
+        documentsByObjectId[objectId] = doc
+    }
+
+    func callCount(objectId: String) -> Int {
+        callCounts[objectId] ?? 0
+    }
+
+    func document(objectId: String, spaceId: String, mode: DocumentMode) -> any BaseDocumentProtocol {
+        callCounts[objectId, default: 0] += 1
+        if let doc = documentsByObjectId[objectId] {
+            return doc
+        }
+        let fallback = MockBaseDocument(objectId: objectId)
+        documentsByObjectId[objectId] = fallback
+        return fallback
+    }
+
+    func setDocument(
+        objectId: String,
+        spaceId: String,
+        mode: DocumentMode,
+        inlineParameters: EditorInlineSetObject?
+    ) -> any SetDocumentProtocol {
+        fatalError("setDocument not used by WidgetsObjectsStorageTests")
+    }
+}

--- a/AnyTypeTests/Services/WidgetsObjectsStorageTests.swift
+++ b/AnyTypeTests/Services/WidgetsObjectsStorageTests.swift
@@ -48,12 +48,14 @@ struct WidgetsObjectsStorageTests {
 
         sut.prepare(info: info)
         await sut.waitForReady(spaceId: info.accountSpaceId)
-        let firstCallCount = documentsProvider.callCount(objectId: info.widgetsId)
+        let firstChannelCount = documentsProvider.callCount(objectId: info.widgetsId)
+        let firstPersonalCount = documentsProvider.callCount(objectId: info.personalWidgetsId)
 
         sut.prepare(info: info)
         await sut.waitForReady(spaceId: info.accountSpaceId)
 
-        #expect(documentsProvider.callCount(objectId: info.widgetsId) == firstCallCount)
+        #expect(documentsProvider.callCount(objectId: info.widgetsId) == firstChannelCount)
+        #expect(documentsProvider.callCount(objectId: info.personalWidgetsId) == firstPersonalCount)
     }
 
     @Test func prepare_differentSpace_dropsPreviousAndOpensNew() async {

--- a/AnyTypeTests/Services/WidgetsObjectsStorageTests.swift
+++ b/AnyTypeTests/Services/WidgetsObjectsStorageTests.swift
@@ -34,8 +34,9 @@ struct WidgetsObjectsStorageTests {
 
         #expect(channelOpened)
         #expect(personalOpened)
-        #expect(sut.channelWidgetsObject(spaceId: info.accountSpaceId)?.objectId == info.widgetsId)
-        #expect(sut.personalWidgetsObject(spaceId: info.accountSpaceId)?.objectId == info.personalWidgetsId)
+        let docs = sut.widgetsObjects(spaceId: info.accountSpaceId)
+        #expect(docs?.channel.objectId == info.widgetsId)
+        #expect(docs?.personal.objectId == info.personalWidgetsId)
     }
 
     @Test func prepare_sameSpaceTwice_doesNotReopen() async {
@@ -68,15 +69,15 @@ struct WidgetsObjectsStorageTests {
         sut.prepare(info: infoB)
         await sut.waitForReady(spaceId: infoB.accountSpaceId)
 
-        #expect(sut.channelWidgetsObject(spaceId: infoA.accountSpaceId) == nil)
-        #expect(sut.personalWidgetsObject(spaceId: infoA.accountSpaceId) == nil)
-        #expect(sut.channelWidgetsObject(spaceId: infoB.accountSpaceId)?.objectId == infoB.widgetsId)
-        #expect(sut.personalWidgetsObject(spaceId: infoB.accountSpaceId)?.objectId == infoB.personalWidgetsId)
+        #expect(sut.widgetsObjects(spaceId: infoA.accountSpaceId) == nil)
+        let docsB = sut.widgetsObjects(spaceId: infoB.accountSpaceId)
+        #expect(docsB?.channel.objectId == infoB.widgetsId)
+        #expect(docsB?.personal.objectId == infoB.personalWidgetsId)
     }
 
     @Test func waitForReady_unknownSpace_returnsImmediately() async {
         await sut.waitForReady(spaceId: "never-prepared")
-        #expect(sut.channelWidgetsObject(spaceId: "never-prepared") == nil)
+        #expect(sut.widgetsObjects(spaceId: "never-prepared") == nil)
     }
 
     @Test func prepare_openThrows_stillExposesDocs() async {
@@ -90,8 +91,7 @@ struct WidgetsObjectsStorageTests {
         sut.prepare(info: info)
         await sut.waitForReady(spaceId: info.accountSpaceId)
 
-        #expect(sut.channelWidgetsObject(spaceId: info.accountSpaceId) != nil)
-        #expect(sut.personalWidgetsObject(spaceId: info.accountSpaceId) != nil)
+        #expect(sut.widgetsObjects(spaceId: info.accountSpaceId) != nil)
     }
 
     // MARK: - Helpers

--- a/AnyTypeTests/Services/WidgetsObjectsStorageTests.swift
+++ b/AnyTypeTests/Services/WidgetsObjectsStorageTests.swift
@@ -90,6 +90,7 @@ struct WidgetsObjectsStorageTests {
         sut.prepare(info: info)
         await sut.waitForReady(spaceId: info.accountSpaceId)
         let firstChannelCount = documentsProvider.callCount(objectId: info.widgetsId)
+        let firstPersonalCount = documentsProvider.callCount(objectId: info.personalWidgetsId)
         sut.clear()
 
         #expect(sut.widgetsObjects(spaceId: info.accountSpaceId) == nil)
@@ -97,6 +98,7 @@ struct WidgetsObjectsStorageTests {
         sut.prepare(info: info)
         await sut.waitForReady(spaceId: info.accountSpaceId)
         #expect(documentsProvider.callCount(objectId: info.widgetsId) == firstChannelCount + 1)
+        #expect(documentsProvider.callCount(objectId: info.personalWidgetsId) == firstPersonalCount + 1)
     }
 
     @Test func prepare_openThrows_stillExposesDocs() async {

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceLoadingContainer/SpaceLoadingContainerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceLoadingContainer/SpaceLoadingContainerViewModel.swift
@@ -9,9 +9,6 @@ final class SpaceLoadingContainerViewModel {
     @Injected(\.activeSpaceManager)
     private var activeSpaceManager: any ActiveSpaceManagerProtocol
     @ObservationIgnored
-    @Injected(\.widgetsObjectsStorage)
-    private var widgetsObjectsStorage: any WidgetsObjectsStorageProtocol
-    @ObservationIgnored
     private let workspacesStorage: any SpaceViewsStorageProtocol = Container.shared.spaceViewsStorage()
 
     let spaceId: String
@@ -31,7 +28,9 @@ final class SpaceLoadingContainerViewModel {
         let activeSpaceInfo = activeSpaceManager.workspaceInfo
         if let activeSpaceInfo, activeSpaceInfo.accountSpaceId == spaceId {
             info = activeSpaceInfo
-            widgetsObjectsStorage.prepare(info: activeSpaceInfo)
+            Task { [activeSpaceManager] in
+                await activeSpaceManager.prepareWidgets(info: activeSpaceInfo)
+            }
         } else {
             // Open space as fast as possible
             openSpace()

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceLoadingContainer/SpaceLoadingContainerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceLoadingContainer/SpaceLoadingContainerViewModel.swift
@@ -28,7 +28,7 @@ final class SpaceLoadingContainerViewModel {
         let activeSpaceInfo = activeSpaceManager.workspaceInfo
         if let activeSpaceInfo, activeSpaceInfo.accountSpaceId == spaceId {
             info = activeSpaceInfo
-            Task { [activeSpaceManager] in
+            Task(priority: .high) { [activeSpaceManager] in
                 await activeSpaceManager.prepareWidgets(info: activeSpaceInfo)
             }
         } else {

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceLoadingContainer/SpaceLoadingContainerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceLoadingContainer/SpaceLoadingContainerViewModel.swift
@@ -9,6 +9,9 @@ final class SpaceLoadingContainerViewModel {
     @Injected(\.activeSpaceManager)
     private var activeSpaceManager: any ActiveSpaceManagerProtocol
     @ObservationIgnored
+    @Injected(\.widgetsObjectsStorage)
+    private var widgetsObjectsStorage: any WidgetsObjectsStorageProtocol
+    @ObservationIgnored
     private let workspacesStorage: any SpaceViewsStorageProtocol = Container.shared.spaceViewsStorage()
 
     let spaceId: String
@@ -26,8 +29,9 @@ final class SpaceLoadingContainerViewModel {
         self.spaceId = spaceId
         self.showBackground = showBackground
         let activeSpaceInfo = activeSpaceManager.workspaceInfo
-        if activeSpaceInfo?.accountSpaceId == spaceId {
+        if let activeSpaceInfo, activeSpaceInfo.accountSpaceId == spaceId {
             info = activeSpaceInfo
+            widgetsObjectsStorage.prepare(info: activeSpaceInfo)
         } else {
             // Open space as fast as possible
             openSpace()
@@ -46,11 +50,15 @@ final class SpaceLoadingContainerViewModel {
     }
     
     private func openSpace() {
-        task = Task { [activeSpaceManager, weak self, spaceId] in
+        task = Task(priority: .high) { [activeSpaceManager, weak self, spaceId] in
             self?.errorText = nil
             self?.info = nil
             do {
-                self?.info = try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
+                let info = try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
+                self?.info = info
+                if let info {
+                    self?.widgetsObjectsStorage.prepare(info: info)
+                }
             } catch {
                 self?.errorText = error.localizedDescription
             }

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceLoadingContainer/SpaceLoadingContainerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceLoadingContainer/SpaceLoadingContainerViewModel.swift
@@ -54,11 +54,7 @@ final class SpaceLoadingContainerViewModel {
             self?.errorText = nil
             self?.info = nil
             do {
-                let info = try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
-                self?.info = info
-                if let info {
-                    self?.widgetsObjectsStorage.prepare(info: info)
-                }
+                self?.info = try await activeSpaceManager.setActiveSpace(spaceId: spaceId)
             } catch {
                 self?.errorText = error.localizedDescription
             }

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceLoadingContainer/SpaceLoadingContainerViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceLoadingContainer/SpaceLoadingContainerViewModel.swift
@@ -28,8 +28,8 @@ final class SpaceLoadingContainerViewModel {
         let activeSpaceInfo = activeSpaceManager.workspaceInfo
         if let activeSpaceInfo, activeSpaceInfo.accountSpaceId == spaceId {
             info = activeSpaceInfo
-            Task(priority: .high) { [activeSpaceManager] in
-                await activeSpaceManager.prepareWidgets(info: activeSpaceInfo)
+            task = Task(priority: .high) { [activeSpaceManager] in
+                await activeSpaceManager.prepareWidgets()
             }
         } else {
             // Open space as fast as possible

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -14,6 +14,8 @@ final class HomeWidgetsViewModel {
 
     @Injected(\.documentsProvider) @ObservationIgnored
     private var documentsProvider: any DocumentsProviderProtocol
+    @Injected(\.widgetsObjectsStorage) @ObservationIgnored
+    private var widgetsObjectsStorage: any WidgetsObjectsStorageProtocol
     @Injected(\.participantSpacesStorage) @ObservationIgnored
     private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
     @Injected(\.homeSectionsStorage) @ObservationIgnored
@@ -74,24 +76,12 @@ final class HomeWidgetsViewModel {
     }
 
     func openWidgetObjects() async {
-        let channel = documentsProvider.document(
-            objectId: info.widgetsId,
-            spaceId: info.accountSpaceId,
-            mode: .handling
-        )
-        let personal = documentsProvider.document(
-            objectId: info.personalWidgetsId,
-            spaceId: info.accountSpaceId,
-            mode: .handling
-        )
-
-        // Personal opens independently of pre-warm (set widgets live in channel only),
-        // so we start it now and only await it before the final gate flip — letting it
-        // overlap with both channel.open() and the per-widget pre-warm work.
-        async let personalOpen: Void? = try? await personal.open()
-        try? await channel.open()
-
-        guard !Task.isCancelled else { return }
+        // Widget container docs are opened upstream in SpaceLoadingContainerViewModel.
+        await widgetsObjectsStorage.waitForReady(spaceId: info.accountSpaceId)
+        guard !Task.isCancelled,
+              let channel = widgetsObjectsStorage.channelWidgetsObject(spaceId: info.accountSpaceId),
+              let personal = widgetsObjectsStorage.personalWidgetsObject(spaceId: info.accountSpaceId)
+        else { return }
 
         // Pre-warm before flipping the section gate so Set/Type and expanded Tree
         // widgets render rows on the first frame. We accept the loader extension in
@@ -100,7 +90,6 @@ final class HomeWidgetsViewModel {
         async let prefetchedSet = prewarmSetWidgetSubscriptions(channelWidgetsObject: channel)
         async let prefetchedTree = prewarmTreeWidgetChildren(channelWidgetsObject: channel)
         async let prefetchedUnread = prewarmUnreadSection()
-        _ = await personalOpen
         let (setMap, treeMap, unread) = await (prefetchedSet, prefetchedTree, prefetchedUnread)
 
         guard !Task.isCancelled else { return }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -76,11 +76,11 @@ final class HomeWidgetsViewModel {
     }
 
     func openWidgetObjects() async {
-        // Widget container docs are opened upstream in SpaceLoadingContainerViewModel.
+        // Docs may still be opening (kicked off upstream in SpaceLoadingContainerViewModel);
+        // wait so prewarm sees a live channel doc.
         await widgetsObjectsStorage.waitForReady(spaceId: info.accountSpaceId)
         guard !Task.isCancelled,
-              let channel = widgetsObjectsStorage.channelWidgetsObject(spaceId: info.accountSpaceId),
-              let personal = widgetsObjectsStorage.personalWidgetsObject(spaceId: info.accountSpaceId)
+              let (channel, personal) = widgetsObjectsStorage.widgetsObjects(spaceId: info.accountSpaceId)
         else { return }
 
         // Pre-warm before flipping the section gate so Set/Type and expanded Tree

--- a/Anytype/Sources/ServiceLayer/ActiveSpaceManager/ActiveSpaceManager.swift
+++ b/Anytype/Sources/ServiceLayer/ActiveSpaceManager/ActiveSpaceManager.swift
@@ -9,6 +9,7 @@ protocol ActiveSpaceManagerProtocol: AnyObject, Sendable {
     @discardableResult
     func setActiveSpace(spaceId: String?) async throws -> AccountInfo?
     func prepareSpaceForPreview(spaceId: String) async
+    func prepareWidgets(info: AccountInfo) async
     func startSubscription() async
     func stopSubscription() async
 }
@@ -106,6 +107,10 @@ actor ActiveSpaceManager: ActiveSpaceManagerProtocol, Sendable {
     func prepareSpaceForPreview(spaceId: String) async {
         await objectTypeProvider.prepareData(spaceId: spaceId)
         await propertyDetailsStorage.prepareData(spaceId: spaceId)
+    }
+
+    func prepareWidgets(info: AccountInfo) async {
+        await widgetsObjectsStorage.prepare(info: info)
     }
     
     // MARK: - Private

--- a/Anytype/Sources/ServiceLayer/ActiveSpaceManager/ActiveSpaceManager.swift
+++ b/Anytype/Sources/ServiceLayer/ActiveSpaceManager/ActiveSpaceManager.swift
@@ -34,6 +34,8 @@ actor ActiveSpaceManager: ActiveSpaceManagerProtocol, Sendable {
     private var objectTypeProvider: any ObjectTypeProviderProtocol
     @Injected(\.propertyDetailsStorage)
     private var propertyDetailsStorage: any PropertyDetailsStorageProtocol
+    @Injected(\.widgetsObjectsStorage)
+    private var widgetsObjectsStorage: any WidgetsObjectsStorageProtocol
     
     init() {}
     
@@ -61,6 +63,8 @@ actor ActiveSpaceManager: ActiveSpaceManagerProtocol, Sendable {
                 do {
                     let info = try await workspaceService.workspaceOpen(spaceId: spaceId, withChat: true)
                     workspaceStorage.addSpaceInfo(spaceId: spaceId, info: info)
+                    // Kick off widget-doc open in parallel with the two subscription startups.
+                    await widgetsObjectsStorage.prepare(info: info)
                     await objectTypeProvider.startSubscription(spaceId: spaceId)
                     await propertyDetailsStorage.startSubscription(spaceId: spaceId)
                     
@@ -133,6 +137,7 @@ actor ActiveSpaceManager: ActiveSpaceManagerProtocol, Sendable {
         workspaceInfoStreamInternal.send(nil)
         workspaceInfoStorage.value = nil
         activeSpaceId = nil
+        await widgetsObjectsStorage.clear()
         await objectTypeProvider.stopSubscription()
         await propertyDetailsStorage.stopSubscription()
     }

--- a/Anytype/Sources/ServiceLayer/ActiveSpaceManager/ActiveSpaceManager.swift
+++ b/Anytype/Sources/ServiceLayer/ActiveSpaceManager/ActiveSpaceManager.swift
@@ -9,7 +9,7 @@ protocol ActiveSpaceManagerProtocol: AnyObject, Sendable {
     @discardableResult
     func setActiveSpace(spaceId: String?) async throws -> AccountInfo?
     func prepareSpaceForPreview(spaceId: String) async
-    func prepareWidgets(info: AccountInfo) async
+    func prepareWidgets() async
     func startSubscription() async
     func stopSubscription() async
 }
@@ -64,7 +64,8 @@ actor ActiveSpaceManager: ActiveSpaceManagerProtocol, Sendable {
                 do {
                     let info = try await workspaceService.workspaceOpen(spaceId: spaceId, withChat: true)
                     workspaceStorage.addSpaceInfo(spaceId: spaceId, info: info)
-                    // Kick off widget-doc open in parallel with the two subscription startups.
+                    // prepare spawns its own Task — placing it here lets the widget-doc
+                    // open race with the two subscription startups below.
                     await widgetsObjectsStorage.prepare(info: info)
                     await objectTypeProvider.startSubscription(spaceId: spaceId)
                     await propertyDetailsStorage.startSubscription(spaceId: spaceId)
@@ -109,7 +110,8 @@ actor ActiveSpaceManager: ActiveSpaceManagerProtocol, Sendable {
         await propertyDetailsStorage.prepareData(spaceId: spaceId)
     }
 
-    func prepareWidgets(info: AccountInfo) async {
+    func prepareWidgets() async {
+        guard let info = workspaceInfoStorage.value else { return }
         await widgetsObjectsStorage.prepare(info: info)
     }
     

--- a/Anytype/Sources/ServiceLayer/ServicesDI.swift
+++ b/Anytype/Sources/ServiceLayer/ServicesDI.swift
@@ -187,7 +187,11 @@ extension Container {
     var documentsProvider: Factory<any DocumentsProviderProtocol> {
         self { DocumentsProvider() }.singleton
     }
-    
+
+    var widgetsObjectsStorage: Factory<any WidgetsObjectsStorageProtocol> {
+        self { WidgetsObjectsStorage() }.singleton
+    }
+
     var expandedService: Factory<any ExpandedServiceProtocol> {
         self { ExpandedService() }.shared
     }

--- a/Anytype/Sources/ServiceLayer/WidgetsObjectsStorage/WidgetsObjectsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/WidgetsObjectsStorage/WidgetsObjectsStorage.swift
@@ -5,8 +5,7 @@ import Services
 protocol WidgetsObjectsStorageProtocol: Sendable {
     func prepare(info: AccountInfo)
     func waitForReady(spaceId: String) async
-    func channelWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)?
-    func personalWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)?
+    func widgetsObjects(spaceId: String) -> (channel: any BaseDocumentProtocol, personal: any BaseDocumentProtocol)?
 }
 
 @MainActor
@@ -23,8 +22,7 @@ final class WidgetsObjectsStorage: WidgetsObjectsStorageProtocol {
     nonisolated init() {}
 
     func prepare(info: AccountInfo) {
-        if info.accountSpaceId == currentSpaceId,
-           openTask != nil || (channelDoc != nil && personalDoc != nil) {
+        if info.accountSpaceId == currentSpaceId, openTask != nil {
             return
         }
 
@@ -64,13 +62,8 @@ final class WidgetsObjectsStorage: WidgetsObjectsStorageProtocol {
         await task.value
     }
 
-    func channelWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)? {
-        guard currentSpaceId == spaceId else { return nil }
-        return channelDoc
-    }
-
-    func personalWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)? {
-        guard currentSpaceId == spaceId else { return nil }
-        return personalDoc
+    func widgetsObjects(spaceId: String) -> (channel: any BaseDocumentProtocol, personal: any BaseDocumentProtocol)? {
+        guard currentSpaceId == spaceId, let channelDoc, let personalDoc else { return nil }
+        return (channelDoc, personalDoc)
     }
 }

--- a/Anytype/Sources/ServiceLayer/WidgetsObjectsStorage/WidgetsObjectsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/WidgetsObjectsStorage/WidgetsObjectsStorage.swift
@@ -6,6 +6,7 @@ protocol WidgetsObjectsStorageProtocol: AnyObject, Sendable {
     func prepare(info: AccountInfo)
     func waitForReady(spaceId: String) async
     func widgetsObjects(spaceId: String) -> (channel: any BaseDocumentProtocol, personal: any BaseDocumentProtocol)?
+    func clear()
 }
 
 @MainActor
@@ -65,5 +66,13 @@ final class WidgetsObjectsStorage: WidgetsObjectsStorageProtocol {
     func widgetsObjects(spaceId: String) -> (channel: any BaseDocumentProtocol, personal: any BaseDocumentProtocol)? {
         guard currentSpaceId == spaceId, let channelDoc, let personalDoc else { return nil }
         return (channelDoc, personalDoc)
+    }
+
+    func clear() {
+        openTask?.cancel()
+        openTask = nil
+        currentSpaceId = nil
+        channelDoc = nil
+        personalDoc = nil
     }
 }

--- a/Anytype/Sources/ServiceLayer/WidgetsObjectsStorage/WidgetsObjectsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/WidgetsObjectsStorage/WidgetsObjectsStorage.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Services
+
+@MainActor
+protocol WidgetsObjectsStorageProtocol: Sendable {
+    func prepare(info: AccountInfo)
+    func waitForReady(spaceId: String) async
+    func channelWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)?
+    func personalWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)?
+}
+
+@MainActor
+final class WidgetsObjectsStorage: WidgetsObjectsStorageProtocol {
+
+    @Injected(\.documentsProvider)
+    private var documentsProvider: any DocumentsProviderProtocol
+
+    private var currentSpaceId: String?
+    private var channelDoc: (any BaseDocumentProtocol)?
+    private var personalDoc: (any BaseDocumentProtocol)?
+    private var openTask: Task<Void, Never>?
+
+    nonisolated init() {}
+
+    func prepare(info: AccountInfo) {
+        if info.accountSpaceId == currentSpaceId,
+           openTask != nil || (channelDoc != nil && personalDoc != nil) {
+            return
+        }
+
+        // Releasing strong refs to old docs is what lets BaseDocument.deinit fire and
+        // call middleware close(): DocumentsProvider.documentCache is strongToWeakObjects().
+        openTask?.cancel()
+        currentSpaceId = info.accountSpaceId
+
+        let channel = documentsProvider.document(
+            objectId: info.widgetsId,
+            spaceId: info.accountSpaceId,
+            mode: .handling
+        )
+        let personal = documentsProvider.document(
+            objectId: info.personalWidgetsId,
+            spaceId: info.accountSpaceId,
+            mode: .handling
+        )
+        channelDoc = channel
+        personalDoc = personal
+
+        // Don't reset openTask in the body — a switch A→B that races with A's tail
+        // would clobber B's task. A completed Task still resolves waitForReady via .value.
+        openTask = Task {
+            // `async let` starts personal.open() concurrently with channel.open() so the
+            // two opens overlap instead of running sequentially. The trailing await on
+            // `personalOpen` keeps the Task body alive until personal also finishes, so
+            // waitForReady doesn't unblock callers while personal is still mid-open.
+            async let personalOpen: Void? = try? await personal.open()
+            try? await channel.open()
+            _ = await personalOpen
+        }
+    }
+
+    func waitForReady(spaceId: String) async {
+        guard currentSpaceId == spaceId, let task = openTask else { return }
+        await task.value
+    }
+
+    func channelWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)? {
+        guard currentSpaceId == spaceId else { return nil }
+        return channelDoc
+    }
+
+    func personalWidgetsObject(spaceId: String) -> (any BaseDocumentProtocol)? {
+        guard currentSpaceId == spaceId else { return nil }
+        return personalDoc
+    }
+}

--- a/Anytype/Sources/ServiceLayer/WidgetsObjectsStorage/WidgetsObjectsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/WidgetsObjectsStorage/WidgetsObjectsStorage.swift
@@ -46,7 +46,7 @@ final class WidgetsObjectsStorage: WidgetsObjectsStorageProtocol {
 
         // Don't reset openTask in the body — a switch A→B that races with A's tail
         // would clobber B's task. A completed Task still resolves waitForReady via .value.
-        openTask = Task {
+        openTask = Task(priority: .high) {
             // `async let` starts personal.open() concurrently with channel.open() so the
             // two opens overlap instead of running sequentially. The trailing await on
             // `personalOpen` keeps the Task body alive until personal also finishes, so

--- a/Anytype/Sources/ServiceLayer/WidgetsObjectsStorage/WidgetsObjectsStorage.swift
+++ b/Anytype/Sources/ServiceLayer/WidgetsObjectsStorage/WidgetsObjectsStorage.swift
@@ -2,7 +2,7 @@ import Foundation
 import Services
 
 @MainActor
-protocol WidgetsObjectsStorageProtocol: Sendable {
+protocol WidgetsObjectsStorageProtocol: AnyObject, Sendable {
     func prepare(info: AccountInfo)
     func waitForReady(spaceId: String) async
     func widgetsObjects(spaceId: String) -> (channel: any BaseDocumentProtocol, personal: any BaseDocumentProtocol)?


### PR DESCRIPTION
## Summary
- New `WidgetsObjectsStorage` DI singleton owns `channelWidgetsObject` + `personalWidgetsObject` per active space. `SpaceLoadingContainerViewModel` calls `prepare(info:)` as soon as `AccountInfo` resolves, so docs are open for every space-entry route — Editor, Chat, SpaceChat, Discussion, SpaceSettings — not only HomeWidgets.
- `HomeWidgetsViewModel.openWidgetObjects()` now awaits the storage instead of opening the docs itself; prewarm pipeline (Set/Tree/Unread) is unchanged.
- Bumped `SpaceLoadingContainerViewModel.openSpace()`'s task to `.high` priority so the whole space-open chain runs at the same priority as the existing widget-mount work.

## Test plan
- [ ] Space homed on Chat → tap bottom-bar widgets overlay: pinned widgets render warm, no progressive section pop-in during present.
- [ ] Space homed on Editor object → same expectation.
- [ ] 1-on-1 space (chat root) → same expectation.
- [ ] Regression: HomeWidgets-rooted space still loads identically; Set/Tree/Unread rows render on first frame.
- [ ] Cold launch via deeplink into chat-rooted space → overlay opens warm a few seconds later.
- [ ] Space switch A → B: previous space's widget docs deinit (middleware `close()`) once A's view tree tears down.
- [ ] Unit tests: `WidgetsObjectsStorageTests`, refactored `HomeWidgetsViewModelTests`.