### PR TITLE
IOS-6207 Move pre-warm logic to dedicated components

### DIFF
--- a/AnyTypeTests/PresentationLayer/HomeWidgets/HomeWidgetsViewModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/HomeWidgets/HomeWidgetsViewModelTests.swift
@@ -118,20 +118,14 @@ private final class TestDocumentsProvider: DocumentsProviderProtocol, @unchecked
 
 @MainActor
 private final class TestSetWidgetsPrewarmer: SetWidgetsPrewarmerProtocol {
-    func prewarm(
-        channelDoc: any BaseDocumentProtocol,
-        spaceId: String
-    ) async -> [String: PrefetchedSetSubscription] {
+    func prewarm(channelDoc: any BaseDocumentProtocol) async -> [String: PrefetchedSetSubscription] {
         [:]
     }
 }
 
 @MainActor
 private final class TestTreeWidgetsPrewarmer: TreeWidgetsPrewarmerProtocol {
-    func prewarm(
-        channelDoc: any BaseDocumentProtocol,
-        spaceId: String
-    ) async -> [String: PrefetchedTreeChildren] {
+    func prewarm(channelDoc: any BaseDocumentProtocol) async -> [String: PrefetchedTreeChildren] {
         [:]
     }
 }

--- a/AnyTypeTests/PresentationLayer/HomeWidgets/HomeWidgetsViewModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/HomeWidgets/HomeWidgetsViewModelTests.swift
@@ -16,29 +16,32 @@ struct HomeWidgetsViewModelTests {
         // VM still injects documentsProvider for set/homepage docs; provide a no-op stub
         // so test resolution doesn't pick up a stale registration from another suite.
         Container.shared.documentsProvider.register { TestDocumentsProvider() }
+        Container.shared.setWidgetsPrewarmer.register { TestSetWidgetsPrewarmer() }
+        Container.shared.treeWidgetsPrewarmer.register { TestTreeWidgetsPrewarmer() }
+        Container.shared.unreadSectionPrewarmer.register { TestUnreadSectionPrewarmer() }
         self.widgetsStorage = widgetsStorage
     }
 
-    // MARK: - openWidgetObjects
+    // MARK: - awaitPrewarm
 
-    @Test func openWidgetObjects_storageHasBothDocs_setsBothObjects() async {
+    @Test func awaitPrewarm_storageHasBothDocs_setsBothObjects() async {
         let info = makeAccountInfo(widgetsId: "channel-id", spaceId: "space-id")
         let channel = MockBaseDocument(objectId: info.widgetsId)
         let personal = MockBaseDocument(objectId: info.personalWidgetsId)
         widgetsStorage.preload(spaceId: info.accountSpaceId, channel: channel, personal: personal)
         let model = HomeWidgetsViewModel(info: info, output: nil)
 
-        await model.openWidgetObjects()
+        await model.awaitPrewarm()
 
         #expect(model.channelWidgetsObject?.objectId == info.widgetsId)
         #expect(model.personalWidgetsObject?.objectId == info.personalWidgetsId)
     }
 
-    @Test func openWidgetObjects_storageNotPreloaded_leavesObjectsNil() async {
+    @Test func awaitPrewarm_storageNotPreloaded_leavesObjectsNil() async {
         let info = makeAccountInfo(widgetsId: "channel-id", spaceId: "space-id")
         let model = HomeWidgetsViewModel(info: info, output: nil)
 
-        await model.openWidgetObjects()
+        await model.awaitPrewarm()
 
         #expect(model.channelWidgetsObject == nil)
         #expect(model.personalWidgetsObject == nil)
@@ -110,5 +113,32 @@ private final class TestDocumentsProvider: DocumentsProviderProtocol, @unchecked
         inlineParameters: EditorInlineSetObject?
     ) -> any SetDocumentProtocol {
         fatalError("setDocument not used by HomeWidgetsViewModelTests")
+    }
+}
+
+@MainActor
+private final class TestSetWidgetsPrewarmer: SetWidgetsPrewarmerProtocol {
+    func prewarm(
+        channelDoc: any BaseDocumentProtocol,
+        spaceId: String
+    ) async -> [String: PrefetchedSetSubscription] {
+        [:]
+    }
+}
+
+@MainActor
+private final class TestTreeWidgetsPrewarmer: TreeWidgetsPrewarmerProtocol {
+    func prewarm(
+        channelDoc: any BaseDocumentProtocol,
+        spaceId: String
+    ) async -> [String: PrefetchedTreeChildren] {
+        [:]
+    }
+}
+
+@MainActor
+private final class TestUnreadSectionPrewarmer: UnreadSectionPrewarmerProtocol {
+    func prewarm(spaceId: String) async -> PrefetchedUnreadSection? {
+        nil
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsView.swift
@@ -53,9 +53,6 @@ private struct HomeWidgetsInternalView: View {
                 )
             }
         }
-        .task(priority: .high) {
-            await model.openWidgetObjects()
-        }
         .task {
             await model.startSubscriptions()
         }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -68,9 +68,8 @@ final class HomeWidgetsViewModel {
     ) {
         self.info = info
         self.output = output
-        // Spawn pre-warm in init so it overlaps the space-transition animation,
-        // not from `.task` on view appear. Observation propagates the Prefetched*
-        // results to the view once `runPrewarm` populates state.
+        // Spawn pre-warm in init so it overlaps the space-transition animation
+        // instead of waiting for view appear.
         prewarmTask = Task(priority: .high) { [weak self] in
             await self?.runPrewarm()
         }
@@ -80,8 +79,7 @@ final class HomeWidgetsViewModel {
         prewarmTask?.cancel()
     }
 
-    /// Test synchronization hook — awaits the init-spawned pre-warm Task.
-    /// Not called from production code; the view reads state via Observation.
+    /// Test-only synchronization hook for the init-spawned pre-warm Task.
     func awaitPrewarm() async {
         await prewarmTask?.value
     }
@@ -117,18 +115,16 @@ final class HomeWidgetsViewModel {
     // MARK: - Private
 
     private func runPrewarm() async {
-        // Docs may still be opening (kicked off upstream in ActiveSpaceManager);
-        // wait so prewarm sees a live channel doc.
+        // Channel doc may still be opening; wait for it before reading children.
         await widgetsObjectsStorage.waitForReady(spaceId: info.accountSpaceId)
         guard !Task.isCancelled,
               let (channel, personal) = widgetsObjectsStorage.widgetsObjects(spaceId: info.accountSpaceId)
         else { return }
 
-        // Pre-warm before flipping the section gate so Set/Type and expanded Tree
-        // widgets render rows on the first frame. The view body guards on
-        // `channelWidgetsObject != nil`; Observation re-renders once we assign below.
-        async let prefetchedSet = setWidgetsPrewarmer.prewarm(channelDoc: channel, spaceId: info.accountSpaceId)
-        async let prefetchedTree = treeWidgetsPrewarmer.prewarm(channelDoc: channel, spaceId: info.accountSpaceId)
+        // Pre-warm before flipping the `channelWidgetsObject` gate so Set/Type and
+        // expanded Tree widgets render rows on the first frame.
+        async let prefetchedSet = setWidgetsPrewarmer.prewarm(channelDoc: channel)
+        async let prefetchedTree = treeWidgetsPrewarmer.prewarm(channelDoc: channel)
         async let prefetchedUnread = unreadSectionPrewarmer.prewarm(spaceId: info.accountSpaceId)
         let (setMap, treeMap, unread) = await (prefetchedSet, prefetchedTree, prefetchedUnread)
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/HomeWidgetsViewModel.swift
@@ -22,20 +22,12 @@ final class HomeWidgetsViewModel {
     private var homeSectionsStorage: any HomeSectionsStorageProtocol
     @Injected(\.participantsStorage) @ObservationIgnored
     private var accountParticipantStorage: any ParticipantsStorageProtocol
-    @Injected(\.expandedService) @ObservationIgnored
-    private var expandedService: any ExpandedServiceProtocol
-    @Injected(\.setSubscriptionDataBuilder) @ObservationIgnored
-    private var setSubscriptionDataBuilder: any SetSubscriptionDataBuilderProtocol
-    @Injected(\.subscriptionStorageProvider) @ObservationIgnored
-    private var subscriptionStorageProvider: any SubscriptionStorageProviderProtocol
-    @Injected(\.spaceViewsStorage) @ObservationIgnored
-    private var spaceViewsStorage: any SpaceViewsStorageProtocol
-    @Injected(\.chatMessagesPreviewsStorage) @ObservationIgnored
-    private var chatMessagesPreviewsStorage: any ChatMessagesPreviewsStorageProtocol
-    @Injected(\.chatDetailsStorage) @ObservationIgnored
-    private var chatDetailsStorage: any ChatDetailsStorageProtocol
-    @Injected(\.objectsWithUnreadDiscussionsSubscription) @ObservationIgnored
-    private var unreadDiscussionsSubscription: any ObjectsWithUnreadDiscussionsSubscriptionProtocol
+    @Injected(\.setWidgetsPrewarmer) @ObservationIgnored
+    private var setWidgetsPrewarmer: any SetWidgetsPrewarmerProtocol
+    @Injected(\.treeWidgetsPrewarmer) @ObservationIgnored
+    private var treeWidgetsPrewarmer: any TreeWidgetsPrewarmerProtocol
+    @Injected(\.unreadSectionPrewarmer) @ObservationIgnored
+    private var unreadSectionPrewarmer: any UnreadSectionPrewarmerProtocol
 
     @ObservationIgnored
     weak var output: (any HomeWidgetsModuleOutput)?
@@ -55,6 +47,9 @@ final class HomeWidgetsViewModel {
     // matches pre-refactor `homeState = .readonly` default and `PinnedSectionViewModel`.
     private var canEdit: Bool = false
 
+    @ObservationIgnored
+    private var prewarmTask: Task<Void, Never>?
+
     var spaceId: String { info.accountSpaceId }
 
     var visibleSections: [HomeSection] {
@@ -73,31 +68,22 @@ final class HomeWidgetsViewModel {
     ) {
         self.info = info
         self.output = output
+        // Spawn pre-warm in init so it overlaps the space-transition animation,
+        // not from `.task` on view appear. Observation propagates the Prefetched*
+        // results to the view once `runPrewarm` populates state.
+        prewarmTask = Task(priority: .high) { [weak self] in
+            await self?.runPrewarm()
+        }
     }
 
-    func openWidgetObjects() async {
-        // Docs may still be opening (kicked off upstream in SpaceLoadingContainerViewModel);
-        // wait so prewarm sees a live channel doc.
-        await widgetsObjectsStorage.waitForReady(spaceId: info.accountSpaceId)
-        guard !Task.isCancelled,
-              let (channel, personal) = widgetsObjectsStorage.widgetsObjects(spaceId: info.accountSpaceId)
-        else { return }
+    deinit {
+        prewarmTask?.cancel()
+    }
 
-        // Pre-warm before flipping the section gate so Set/Type and expanded Tree
-        // widgets render rows on the first frame. We accept the loader extension in
-        // every context — a visible row-pop is worse than a small delay regardless
-        // of presentation.
-        async let prefetchedSet = prewarmSetWidgetSubscriptions(channelWidgetsObject: channel)
-        async let prefetchedTree = prewarmTreeWidgetChildren(channelWidgetsObject: channel)
-        async let prefetchedUnread = prewarmUnreadSection()
-        let (setMap, treeMap, unread) = await (prefetchedSet, prefetchedTree, prefetchedUnread)
-
-        guard !Task.isCancelled else { return }
-        channelWidgetsObject = channel
-        personalWidgetsObject = personal
-        prefetchedSetSubscriptions = setMap
-        prefetchedTreeChildren = treeMap
-        prefetchedUnreadSection = unread
+    /// Test synchronization hook — awaits the init-spawned pre-warm Task.
+    /// Not called from production code; the view reads state via Observation.
+    func awaitPrewarm() async {
+        await prewarmTask?.value
     }
 
     func startSubscriptions() async {
@@ -129,6 +115,30 @@ final class HomeWidgetsViewModel {
     }
 
     // MARK: - Private
+
+    private func runPrewarm() async {
+        // Docs may still be opening (kicked off upstream in ActiveSpaceManager);
+        // wait so prewarm sees a live channel doc.
+        await widgetsObjectsStorage.waitForReady(spaceId: info.accountSpaceId)
+        guard !Task.isCancelled,
+              let (channel, personal) = widgetsObjectsStorage.widgetsObjects(spaceId: info.accountSpaceId)
+        else { return }
+
+        // Pre-warm before flipping the section gate so Set/Type and expanded Tree
+        // widgets render rows on the first frame. The view body guards on
+        // `channelWidgetsObject != nil`; Observation re-renders once we assign below.
+        async let prefetchedSet = setWidgetsPrewarmer.prewarm(channelDoc: channel, spaceId: info.accountSpaceId)
+        async let prefetchedTree = treeWidgetsPrewarmer.prewarm(channelDoc: channel, spaceId: info.accountSpaceId)
+        async let prefetchedUnread = unreadSectionPrewarmer.prewarm(spaceId: info.accountSpaceId)
+        let (setMap, treeMap, unread) = await (prefetchedSet, prefetchedTree, prefetchedUnread)
+
+        guard !Task.isCancelled else { return }
+        channelWidgetsObject = channel
+        personalWidgetsObject = personal
+        prefetchedSetSubscriptions = setMap
+        prefetchedTreeChildren = treeMap
+        prefetchedUnreadSection = unread
+    }
 
     private func startSectionsConfigurationTask() async {
         for await configuration in homeSectionsStorage.configurationPublisher(spaceId: info.accountSpaceId).values {
@@ -188,231 +198,6 @@ final class HomeWidgetsViewModel {
             homepageTask = Task { [weak self] in
                 await self?.observeHomepageObject(objectId: next.objectId, canSetHomepage: next.canSetHomepage)
             }
-        }
-    }
-
-    // MARK: - Widget pre-warm
-
-    /// Per-widget budget. A slow widget falls back to its own mount-time open
-    /// (header first, rows later) instead of stalling the whole gate.
-    private static let prewarmTimeout: TimeInterval = 0.6
-
-    private func prewarmSetWidgetSubscriptions(
-        channelWidgetsObject: any BaseDocumentProtocol
-    ) async -> [String: PrefetchedSetSubscription] {
-        let setWidgets = channelWidgetsObject.children.compactMap { child -> BlockWidgetInfo? in
-            guard child.isWidget,
-                  let info = channelWidgetsObject.widgetInfo(block: child),
-                  info.isSetTypeWidget,
-                  expandedService.isExpanded(id: info.id, defaultValue: true)
-            else { return nil }
-            return info
-        }
-
-        guard setWidgets.isNotEmpty else { return [:] }
-
-        return await withTaskGroup(of: (String, PrefetchedSetSubscription)?.self) { group in
-            for widgetInfo in setWidgets {
-                group.addTask { [weak self] in
-                    guard let self else { return nil }
-                    guard let prefetched = await prewarmSingleSetWidget(widgetInfo: widgetInfo) else { return nil }
-                    return (widgetInfo.id, prefetched)
-                }
-            }
-
-            var result: [String: PrefetchedSetSubscription] = [:]
-            for await pair in group {
-                if let (id, prefetched) = pair {
-                    result[id] = prefetched
-                }
-            }
-            return result
-        }
-    }
-
-    /// In-memory snapshots — no timeout; cold-start aggregator returns `[:]` and the live subscription fills gaps.
-    private func prewarmUnreadSection() async -> PrefetchedUnreadSection? {
-        let spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)
-        let supportsMultiChats = !(spaceView?.isOneToOne ?? false)
-        guard supportsMultiChats else { return nil }
-
-        async let previews = chatMessagesPreviewsStorage.previews()
-        async let chats = chatDetailsStorage.allChats()
-        async let unreadBySpace = unreadDiscussionsSubscription.snapshot
-
-        let (p, c, u) = await (previews, chats, unreadBySpace)
-        guard let spaceView else { return PrefetchedUnreadSection(rows: [], supportsMultiChats: true) }
-
-        let rows = UnreadSectionViewModel.mergeUnreadRows(
-            previews: p,
-            chatDetails: c,
-            spaceView: spaceView,
-            unreadBySpace: u,
-            spaceId: spaceId
-        )
-        return PrefetchedUnreadSection(rows: rows, supportsMultiChats: true)
-    }
-
-    private func prewarmTreeWidgetChildren(
-        channelWidgetsObject: any BaseDocumentProtocol
-    ) async -> [String: PrefetchedTreeChildren] {
-        let treeWidgets = channelWidgetsObject.children.compactMap { child -> BlockWidgetInfo? in
-            guard child.isWidget,
-                  let info = channelWidgetsObject.widgetInfo(block: child),
-                  info.isTreeObjectWidget,
-                  expandedService.isExpanded(id: info.id, defaultValue: true)
-            else { return nil }
-            return info
-        }
-
-        guard treeWidgets.isNotEmpty else { return [:] }
-
-        return await withTaskGroup(of: (String, PrefetchedTreeChildren)?.self) { group in
-            for widgetInfo in treeWidgets {
-                group.addTask { [weak self] in
-                    guard let self else { return nil }
-                    guard let prefetched = await prewarmSingleTreeWidget(widgetInfo: widgetInfo) else { return nil }
-                    return (widgetInfo.id, prefetched)
-                }
-            }
-
-            var result: [String: PrefetchedTreeChildren] = [:]
-            for await pair in group {
-                if let (id, prefetched) = pair {
-                    result[id] = prefetched
-                }
-            }
-            return result
-        }
-    }
-
-    private func prewarmSingleTreeWidget(widgetInfo: BlockWidgetInfo) async -> PrefetchedTreeChildren? {
-        guard case let .object(linkedObjectDetails) = widgetInfo.source else { return nil }
-
-        // Target has no children — seed an empty list so the widget renders `.empty`
-        // synchronously on first frame instead of flashing `.loading` → `.empty`
-        // when the live subscription emits its first (empty) result.
-        guard linkedObjectDetails.links.isNotEmpty else {
-            return PrefetchedTreeChildren(childDetails: [])
-        }
-
-        return await withTimeout(seconds: Self.prewarmTimeout) { [self] in
-            // Fresh builder per widget — its `subscriptionId` is the storage's `subId`,
-            // and we need a unique pair so disposable storages don't collide.
-            let builder = TreeSubscriptionDataBuilder()
-            let storage = subscriptionStorageProvider.createSubscriptionStorage(
-                subId: builder.subscriptionId
-            )
-            let subscriptionData = builder.build(
-                spaceId: info.accountSpaceId,
-                objectIds: linkedObjectDetails.links
-            )
-
-            do {
-                try await storage.startOrUpdateSubscription(data: subscriptionData)
-            } catch {
-                return nil
-            }
-
-            // `statePublisher` is backed by CurrentValueSubject, so subscribing after
-            // `startOrUpdateSubscription` returns replays the current state immediately.
-            var snapshot: [ObjectDetails]?
-            for await state in storage.statePublisher.values {
-                snapshot = state.items
-                break
-            }
-            try? await storage.stopSubscription()
-
-            guard let items = snapshot else { return nil }
-
-            // Mirror `TreeSubscriptionManager`'s publisher composition: filter to
-            // openable objects, sort by parent `.links` order, then apply the limit.
-            let sorted = items
-                .filter(\.isNotDeletedAndSupportedForOpening)
-                .reordered(by: linkedObjectDetails.links, transform: { $0.id })
-            return PrefetchedTreeChildren(childDetails: Array(sorted.prefix(widgetInfo.fixedLimit)))
-        }
-    }
-
-    private func prewarmSingleSetWidget(widgetInfo: BlockWidgetInfo) async -> PrefetchedSetSubscription? {
-        guard case let .object(setDetails) = widgetInfo.source else { return nil }
-
-        return await withTimeout(seconds: Self.prewarmTimeout) { [self] in
-            let setDocument = documentsProvider.setDocument(
-                objectId: setDetails.id,
-                spaceId: info.accountSpaceId,
-                mode: .preview
-            )
-
-            do { try await setDocument.open() } catch { return nil }
-
-            // `setDocument.updateData()` runs on the next main-queue tick after open()
-            // returns (syncPublisher replays via `receiveOnMain`). Check the actual
-            // state on every emission — `setUpdatePublisher` can emit `.syncStatus`
-            // before `.dataviewUpdated`, and we'd loop without progress if we only
-            // matched on the event variant.
-            if !setDocument.dataView.views.isNotEmpty {
-                for await _ in setDocument.setUpdatePublisher.values {
-                    if setDocument.dataView.views.isNotEmpty { break }
-                }
-            }
-
-            guard setDocument.canStartSubscription(), setDocument.dataView.views.isNotEmpty else {
-                return nil
-            }
-
-            let subscriptionData = buildSubscriptionData(
-                widgetInfo: widgetInfo,
-                setDocument: setDocument
-            )
-
-            let storage = subscriptionStorageProvider.createSubscriptionStorage(
-                subId: subscriptionData.identifier
-            )
-            do {
-                try await storage.startOrUpdateSubscription(data: subscriptionData)
-            } catch {
-                return nil
-            }
-
-            // `statePublisher` is backed by CurrentValueSubject, so subscribing after
-            // `startOrUpdateSubscription` returns replays the current state immediately.
-            for await state in storage.statePublisher.values {
-                return PrefetchedSetSubscription(
-                    setDocument: setDocument,
-                    subscriptionStorage: storage,
-                    state: state
-                )
-            }
-            return nil
-        }
-    }
-
-    private func buildSubscriptionData(
-        widgetInfo: BlockWidgetInfo,
-        setDocument: any SetDocumentProtocol
-    ) -> SubscriptionData {
-        setSubscriptionDataBuilder.widgetSubscriptionData(
-            widgetInfo: widgetInfo,
-            setDocument: setDocument,
-            identifier: "SetWidget-\(UUID().uuidString)",
-            spaceType: spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.spaceType
-        )
-    }
-
-    private func withTimeout<T: Sendable>(
-        seconds: TimeInterval,
-        operation: @escaping @MainActor () async -> T?
-    ) async -> T? {
-        await withTaskGroup(of: T?.self) { group in
-            group.addTask { @MainActor in await operation() }
-            group.addTask {
-                try? await Task.sleep(for: .seconds(seconds))
-                return nil
-            }
-            defer { group.cancelAll() }
-            // `next()` returns Element? = T??; the `?? nil` flattens to T?.
-            return await group.next() ?? nil
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/Internal/PrewarmTimeout.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/Internal/PrewarmTimeout.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Race `operation` against a sleep so a slow widget falls back to its own mount-time open
+/// (header first, rows later) instead of stalling the whole pre-warm gate.
+@MainActor
+func withPrewarmTimeout<T: Sendable>(
+    seconds: TimeInterval,
+    operation: @escaping @MainActor () async -> T?
+) async -> T? {
+    await withTaskGroup(of: T?.self) { group in
+        group.addTask { @MainActor in await operation() }
+        group.addTask {
+            try? await Task.sleep(for: .seconds(seconds))
+            return nil
+        }
+        defer { group.cancelAll() }
+        // `next()` returns Element? = T??; the `?? nil` flattens to T?.
+        return await group.next() ?? nil
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/SetWidgetsPrewarmer.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/SetWidgetsPrewarmer.swift
@@ -4,10 +4,7 @@ import AnytypeCore
 
 @MainActor
 protocol SetWidgetsPrewarmerProtocol: AnyObject, Sendable {
-    func prewarm(
-        channelDoc: any BaseDocumentProtocol,
-        spaceId: String
-    ) async -> [String: PrefetchedSetSubscription]
+    func prewarm(channelDoc: any BaseDocumentProtocol) async -> [String: PrefetchedSetSubscription]
 }
 
 @MainActor
@@ -30,10 +27,8 @@ final class SetWidgetsPrewarmer: SetWidgetsPrewarmerProtocol {
 
     nonisolated init() {}
 
-    func prewarm(
-        channelDoc: any BaseDocumentProtocol,
-        spaceId: String
-    ) async -> [String: PrefetchedSetSubscription] {
+    func prewarm(channelDoc: any BaseDocumentProtocol) async -> [String: PrefetchedSetSubscription] {
+        let spaceId = channelDoc.spaceId
         let setWidgets = channelDoc.children.compactMap { child -> BlockWidgetInfo? in
             guard child.isWidget,
                   let info = channelDoc.widgetInfo(block: child),

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/SetWidgetsPrewarmer.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/SetWidgetsPrewarmer.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Services
+import AnytypeCore
+
+@MainActor
+protocol SetWidgetsPrewarmerProtocol: AnyObject, Sendable {
+    func prewarm(
+        channelDoc: any BaseDocumentProtocol,
+        spaceId: String
+    ) async -> [String: PrefetchedSetSubscription]
+}
+
+@MainActor
+final class SetWidgetsPrewarmer: SetWidgetsPrewarmerProtocol {
+
+    @Injected(\.documentsProvider)
+    private var documentsProvider: any DocumentsProviderProtocol
+    @Injected(\.setSubscriptionDataBuilder)
+    private var setSubscriptionDataBuilder: any SetSubscriptionDataBuilderProtocol
+    @Injected(\.subscriptionStorageProvider)
+    private var subscriptionStorageProvider: any SubscriptionStorageProviderProtocol
+    @Injected(\.spaceViewsStorage)
+    private var spaceViewsStorage: any SpaceViewsStorageProtocol
+    @Injected(\.expandedService)
+    private var expandedService: any ExpandedServiceProtocol
+
+    /// Per-widget budget. A slow widget falls back to its own mount-time open
+    /// (header first, rows later) instead of stalling the whole gate.
+    private static let prewarmTimeout: TimeInterval = 0.6
+
+    nonisolated init() {}
+
+    func prewarm(
+        channelDoc: any BaseDocumentProtocol,
+        spaceId: String
+    ) async -> [String: PrefetchedSetSubscription] {
+        let setWidgets = channelDoc.children.compactMap { child -> BlockWidgetInfo? in
+            guard child.isWidget,
+                  let info = channelDoc.widgetInfo(block: child),
+                  info.isSetTypeWidget,
+                  expandedService.isExpanded(id: info.id, defaultValue: true)
+            else { return nil }
+            return info
+        }
+
+        guard setWidgets.isNotEmpty else { return [:] }
+
+        return await withTaskGroup(of: (String, PrefetchedSetSubscription)?.self) { group in
+            for widgetInfo in setWidgets {
+                group.addTask { [weak self] in
+                    guard let self else { return nil }
+                    guard let prefetched = await prewarmSingleSetWidget(
+                        widgetInfo: widgetInfo,
+                        spaceId: spaceId
+                    ) else { return nil }
+                    return (widgetInfo.id, prefetched)
+                }
+            }
+
+            var result: [String: PrefetchedSetSubscription] = [:]
+            for await pair in group {
+                if let (id, prefetched) = pair {
+                    result[id] = prefetched
+                }
+            }
+            return result
+        }
+    }
+
+    private func prewarmSingleSetWidget(
+        widgetInfo: BlockWidgetInfo,
+        spaceId: String
+    ) async -> PrefetchedSetSubscription? {
+        guard case let .object(setDetails) = widgetInfo.source else { return nil }
+
+        return await withPrewarmTimeout(seconds: Self.prewarmTimeout) { [self] in
+            let setDocument = documentsProvider.setDocument(
+                objectId: setDetails.id,
+                spaceId: spaceId,
+                mode: .preview
+            )
+
+            do { try await setDocument.open() } catch { return nil }
+
+            // `setDocument.updateData()` runs on the next main-queue tick after open()
+            // returns (syncPublisher replays via `receiveOnMain`). Check the actual
+            // state on every emission — `setUpdatePublisher` can emit `.syncStatus`
+            // before `.dataviewUpdated`, and we'd loop without progress if we only
+            // matched on the event variant.
+            if !setDocument.dataView.views.isNotEmpty {
+                for await _ in setDocument.setUpdatePublisher.values {
+                    if setDocument.dataView.views.isNotEmpty { break }
+                }
+            }
+
+            guard setDocument.canStartSubscription(), setDocument.dataView.views.isNotEmpty else {
+                return nil
+            }
+
+            let subscriptionData = buildSubscriptionData(
+                widgetInfo: widgetInfo,
+                setDocument: setDocument
+            )
+
+            let storage = subscriptionStorageProvider.createSubscriptionStorage(
+                subId: subscriptionData.identifier
+            )
+            do {
+                try await storage.startOrUpdateSubscription(data: subscriptionData)
+            } catch {
+                return nil
+            }
+
+            // `statePublisher` is backed by CurrentValueSubject, so subscribing after
+            // `startOrUpdateSubscription` returns replays the current state immediately.
+            for await state in storage.statePublisher.values {
+                return PrefetchedSetSubscription(
+                    setDocument: setDocument,
+                    subscriptionStorage: storage,
+                    state: state
+                )
+            }
+            return nil
+        }
+    }
+
+    private func buildSubscriptionData(
+        widgetInfo: BlockWidgetInfo,
+        setDocument: any SetDocumentProtocol
+    ) -> SubscriptionData {
+        setSubscriptionDataBuilder.widgetSubscriptionData(
+            widgetInfo: widgetInfo,
+            setDocument: setDocument,
+            identifier: "SetWidget-\(UUID().uuidString)",
+            spaceType: spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)?.spaceType
+        )
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/TreeWidgetsPrewarmer.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/TreeWidgetsPrewarmer.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Services
+import AnytypeCore
+
+@MainActor
+protocol TreeWidgetsPrewarmerProtocol: AnyObject, Sendable {
+    func prewarm(
+        channelDoc: any BaseDocumentProtocol,
+        spaceId: String
+    ) async -> [String: PrefetchedTreeChildren]
+}
+
+@MainActor
+final class TreeWidgetsPrewarmer: TreeWidgetsPrewarmerProtocol {
+
+    @Injected(\.subscriptionStorageProvider)
+    private var subscriptionStorageProvider: any SubscriptionStorageProviderProtocol
+    @Injected(\.expandedService)
+    private var expandedService: any ExpandedServiceProtocol
+
+    /// Per-widget budget. A slow widget falls back to its own mount-time open
+    /// (header first, rows later) instead of stalling the whole gate.
+    private static let prewarmTimeout: TimeInterval = 0.6
+
+    nonisolated init() {}
+
+    func prewarm(
+        channelDoc: any BaseDocumentProtocol,
+        spaceId: String
+    ) async -> [String: PrefetchedTreeChildren] {
+        let treeWidgets = channelDoc.children.compactMap { child -> BlockWidgetInfo? in
+            guard child.isWidget,
+                  let info = channelDoc.widgetInfo(block: child),
+                  info.isTreeObjectWidget,
+                  expandedService.isExpanded(id: info.id, defaultValue: true)
+            else { return nil }
+            return info
+        }
+
+        guard treeWidgets.isNotEmpty else { return [:] }
+
+        return await withTaskGroup(of: (String, PrefetchedTreeChildren)?.self) { group in
+            for widgetInfo in treeWidgets {
+                group.addTask { [weak self] in
+                    guard let self else { return nil }
+                    guard let prefetched = await prewarmSingleTreeWidget(
+                        widgetInfo: widgetInfo,
+                        spaceId: spaceId
+                    ) else { return nil }
+                    return (widgetInfo.id, prefetched)
+                }
+            }
+
+            var result: [String: PrefetchedTreeChildren] = [:]
+            for await pair in group {
+                if let (id, prefetched) = pair {
+                    result[id] = prefetched
+                }
+            }
+            return result
+        }
+    }
+
+    private func prewarmSingleTreeWidget(
+        widgetInfo: BlockWidgetInfo,
+        spaceId: String
+    ) async -> PrefetchedTreeChildren? {
+        guard case let .object(linkedObjectDetails) = widgetInfo.source else { return nil }
+
+        // Target has no children — seed an empty list so the widget renders `.empty`
+        // synchronously on first frame instead of flashing `.loading` → `.empty`
+        // when the live subscription emits its first (empty) result.
+        guard linkedObjectDetails.links.isNotEmpty else {
+            return PrefetchedTreeChildren(childDetails: [])
+        }
+
+        return await withPrewarmTimeout(seconds: Self.prewarmTimeout) { [self] in
+            // Fresh builder per widget — its `subscriptionId` is the storage's `subId`,
+            // and we need a unique pair so disposable storages don't collide.
+            let builder = TreeSubscriptionDataBuilder()
+            let storage = subscriptionStorageProvider.createSubscriptionStorage(
+                subId: builder.subscriptionId
+            )
+            let subscriptionData = builder.build(
+                spaceId: spaceId,
+                objectIds: linkedObjectDetails.links
+            )
+
+            do {
+                try await storage.startOrUpdateSubscription(data: subscriptionData)
+            } catch {
+                return nil
+            }
+
+            // `statePublisher` is backed by CurrentValueSubject, so subscribing after
+            // `startOrUpdateSubscription` returns replays the current state immediately.
+            var snapshot: [ObjectDetails]?
+            for await state in storage.statePublisher.values {
+                snapshot = state.items
+                break
+            }
+            try? await storage.stopSubscription()
+
+            guard let items = snapshot else { return nil }
+
+            // Mirror `TreeSubscriptionManager`'s publisher composition: filter to
+            // openable objects, sort by parent `.links` order, then apply the limit.
+            let sorted = items
+                .filter(\.isNotDeletedAndSupportedForOpening)
+                .reordered(by: linkedObjectDetails.links, transform: { $0.id })
+            return PrefetchedTreeChildren(childDetails: Array(sorted.prefix(widgetInfo.fixedLimit)))
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/TreeWidgetsPrewarmer.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/TreeWidgetsPrewarmer.swift
@@ -4,10 +4,7 @@ import AnytypeCore
 
 @MainActor
 protocol TreeWidgetsPrewarmerProtocol: AnyObject, Sendable {
-    func prewarm(
-        channelDoc: any BaseDocumentProtocol,
-        spaceId: String
-    ) async -> [String: PrefetchedTreeChildren]
+    func prewarm(channelDoc: any BaseDocumentProtocol) async -> [String: PrefetchedTreeChildren]
 }
 
 @MainActor
@@ -24,10 +21,8 @@ final class TreeWidgetsPrewarmer: TreeWidgetsPrewarmerProtocol {
 
     nonisolated init() {}
 
-    func prewarm(
-        channelDoc: any BaseDocumentProtocol,
-        spaceId: String
-    ) async -> [String: PrefetchedTreeChildren] {
+    func prewarm(channelDoc: any BaseDocumentProtocol) async -> [String: PrefetchedTreeChildren] {
+        let spaceId = channelDoc.spaceId
         let treeWidgets = channelDoc.children.compactMap { child -> BlockWidgetInfo? in
             guard child.isWidget,
                   let info = channelDoc.widgetInfo(block: child),

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/UnreadSectionPrewarmer.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Prewarm/UnreadSectionPrewarmer.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Services
+import AnytypeCore
+
+@MainActor
+protocol UnreadSectionPrewarmerProtocol: AnyObject, Sendable {
+    func prewarm(spaceId: String) async -> PrefetchedUnreadSection?
+}
+
+@MainActor
+final class UnreadSectionPrewarmer: UnreadSectionPrewarmerProtocol {
+
+    @Injected(\.chatMessagesPreviewsStorage)
+    private var chatMessagesPreviewsStorage: any ChatMessagesPreviewsStorageProtocol
+    @Injected(\.chatDetailsStorage)
+    private var chatDetailsStorage: any ChatDetailsStorageProtocol
+    @Injected(\.objectsWithUnreadDiscussionsSubscription)
+    private var unreadDiscussionsSubscription: any ObjectsWithUnreadDiscussionsSubscriptionProtocol
+    @Injected(\.spaceViewsStorage)
+    private var spaceViewsStorage: any SpaceViewsStorageProtocol
+
+    nonisolated init() {}
+
+    /// In-memory snapshots — no timeout; cold-start aggregator returns `[:]` and the live subscription fills gaps.
+    func prewarm(spaceId: String) async -> PrefetchedUnreadSection? {
+        let spaceView = spaceViewsStorage.spaceView(spaceId: spaceId)
+        let supportsMultiChats = !(spaceView?.isOneToOne ?? false)
+        guard supportsMultiChats else { return nil }
+
+        async let previews = chatMessagesPreviewsStorage.previews()
+        async let chats = chatDetailsStorage.allChats()
+        async let unreadBySpace = unreadDiscussionsSubscription.snapshot
+
+        let (p, c, u) = await (previews, chats, unreadBySpace)
+        guard let spaceView else { return PrefetchedUnreadSection(rows: [], supportsMultiChats: true) }
+
+        let rows = UnreadSectionViewModel.mergeUnreadRows(
+            previews: p,
+            chatDetails: c,
+            spaceView: spaceView,
+            unreadBySpace: u,
+            spaceId: spaceId
+        )
+        return PrefetchedUnreadSection(rows: rows, supportsMultiChats: true)
+    }
+}

--- a/Anytype/Sources/ServiceLayer/ServicesDI.swift
+++ b/Anytype/Sources/ServiceLayer/ServicesDI.swift
@@ -192,6 +192,18 @@ extension Container {
         self { WidgetsObjectsStorage() }.singleton
     }
 
+    var setWidgetsPrewarmer: Factory<any SetWidgetsPrewarmerProtocol> {
+        self { SetWidgetsPrewarmer() }.singleton
+    }
+
+    var treeWidgetsPrewarmer: Factory<any TreeWidgetsPrewarmerProtocol> {
+        self { TreeWidgetsPrewarmer() }.singleton
+    }
+
+    var unreadSectionPrewarmer: Factory<any UnreadSectionPrewarmerProtocol> {
+        self { UnreadSectionPrewarmer() }.singleton
+    }
+
     var expandedService: Factory<any ExpandedServiceProtocol> {
         self { ExpandedService() }.shared
     }


### PR DESCRIPTION
## Summary

- Extracted three pre-warm operations from `HomeWidgetsViewModel` into dedicated `@MainActor` components (`SetWidgetsPrewarmer`, `TreeWidgetsPrewarmer`, `UnreadSectionPrewarmer`) injected via Factory.
- Moved the pre-warm trigger from view `.task(priority: .high)` (on appear) to VM `init`, so it overlaps the space-transition animation. `deinit` cancels the in-flight Task on rapid space switch.
- VM shrunk from 446 → ~220 lines; `openWidgetObjects()` and the corresponding view modifier are gone — the existing `channelWidgetsObject != nil` gate is driven purely by Observation.