### PR TITLE
IOS-5812 Sync-seed Object Tree widget header to drop first-frame title flash

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetView.swift
@@ -17,6 +17,7 @@ struct TreeWidgetView: View {
                 widgetBlockId: data.widgetBlockId,
                 widgetObject: data.channelWidgetsObject,
                 internalModel: internalModel,
+                prefetchedDetails: data.prefetchedDetails,
                 prefetchedFirstLevel: data.prefetchedTreeChildren?.childDetails,
                 output: data.output
             )

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetViewModel.swift
@@ -50,6 +50,7 @@ final class TreeWidgetViewModel: ObservableObject {
         widgetBlockId: String,
         widgetObject: any BaseDocumentProtocol,
         internalModel: any WidgetInternalViewModelProtocol,
+        prefetchedDetails: ObjectDetails?,
         prefetchedFirstLevel: [ObjectDetails]?,
         output: (any CommonWidgetModuleOutput)?
     ) {
@@ -57,6 +58,13 @@ final class TreeWidgetViewModel: ObservableObject {
         self.widgetObject = widgetObject
         self.internalModel = internalModel
         self.output = output
+        // Inner VM seeds name/icon in its own init, but `setupAllSubscriptions`
+        // re-publishes them through `receiveOnMain()` — the @Published initial replay
+        // lands one main-tick late. Seed here too so the header renders on frame 0.
+        if let prefetchedDetails {
+            self.name = prefetchedDetails.title
+            self.icon = prefetchedDetails.objectIconImage
+        }
         // Seed rows synchronously when available — `internalModel.detailsPublisher`
         // is delivered via `receiveOnMain()`, so even an init-time seed in the inner
         // VM reaches the sink one main-tick later. Without this, the content area


### PR DESCRIPTION
## Summary
- Pre-seed `TreeWidgetViewModel.name`/`icon` from `data.prefetchedDetails` in `init`, mirroring the existing `prefetchedFirstLevel` sync-seed pattern in the same constructor.
- Fixes the one-frame empty-title flash on pinned Object Tree widgets — caused by `internalModel.namePublisher.receiveOnMain().assign(to: &$name)` deferring the inner VM's seeded value by one main-tick.
- Pinned/Recent paths pass `nil` for `prefetchedDetails` and remain unchanged.