### PR TITLE
IOS-6208 Animate Pinned widget add/remove

### DIFF
--- a/Anytype/Sources/Design system/Animations/AnimationExtension.swift
+++ b/Anytype/Sources/Design system/Animations/AnimationExtension.swift
@@ -6,4 +6,5 @@ extension Animation {
     static let slowIteractiveSpring = Animation.interactiveSpring(response: 0.3, dampingFraction: 1)
     static let disclosure = Animation.snappy(duration: 0.28, extraBounce: 0.05)
     static let disclosureSmall = Animation.snappy(duration: 0.22)
+    static let widgetTile = Animation.spring(response: 0.4, dampingFraction: 0.85)
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionView.swift
@@ -70,6 +70,7 @@ private struct PinnedSectionViewInternal: View {
                         prefetchedTreeChildren: prefetchedTreeChildren[widgetInfo.id],
                         output: output
                     )
+                    .transition(.scale(scale: 0.94, anchor: .center).combined(with: .opacity))
                 }
             }
         }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Pinned/PinnedSectionViewModel.swift
@@ -28,6 +28,7 @@ final class PinnedSectionViewModel {
 
     var widgetBlocks: [BlockWidgetInfo] = []
     var homeState: HomeWidgetsState = .readonly
+    private var didInitWidgets: Bool = false
 
     init(
         spaceId: String,
@@ -37,6 +38,7 @@ final class PinnedSectionViewModel {
         self.channelWidgetsObject = channelWidgetsObject
         self.widgetBlocks = buildWidgetBlocks()
         self.homeState = participantsStorage.canEdit(spaceId: spaceId) ? .readwrite : .readonly
+        self.didInitWidgets = true
     }
 
     // MARK: - Subscriptions
@@ -57,7 +59,9 @@ final class PinnedSectionViewModel {
         for await _ in channelWidgetsObject.syncPublisher.values {
             let next = buildWidgetBlocks()
             guard widgetBlocks != next else { continue }
-            widgetBlocks = next
+            withAnimation(didInitWidgets ? .widgetTile : nil) {
+                widgetBlocks = next
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Pinned widget tiles now animate with a scale+opacity spring on insert/remove (user adds via menu, deletes, or remote collaborator changes the pinned set).
- Guarded by a `didInitWidgets` flag on `PinnedSectionViewModel` so cold load and warm reload don't animate the seed assignment — only genuinely new structural changes after init.
- Curve: `.spring(response: 0.4, dampingFraction: 0.85)`, exposed as `Animation.widgetTile` in `AnimationExtension.swift`.

Continues IOS-6208 master plan (Tier 2.2). DnD reorder unchanged — still handled by SwiftUI's native machinery.