### PR TITLE
IOS-6221 Auto-link merged PR to Linear release

### DIFF
--- a/.github/WORKFLOWS_REFERENCE.md
+++ b/.github/WORKFLOWS_REFERENCE.md
@@ -29,6 +29,7 @@ This document provides an overview of GitHub workflows, custom actions, and auto
 | `branch_build.yaml` | Manual | Build and upload branch to TestFlight |
 | `dev_build.yaml` | Schedule (weekdays 05:00 UTC), manual | Daily dev build to TestFlight |
 | `claude-code-review.yml` | PR opened | AI-powered code review with Claude |
+| `link_issue_to_release.yaml` | PR merged to `develop` or `release` | Auto-assign Linear issue to the matching release |
 
 ## Workflows
 
@@ -102,6 +103,26 @@ This document provides an overview of GitHub workflows, custom actions, and auto
 - Auto-merge is handled automatically by `automerge.yaml` workflow (no manual intervention needed)
 - PR will merge automatically when all required checks pass
 - Linear issue is closed when PR is created (not when merged)
+
+---
+
+#### `link_issue_to_release.yaml` - Auto-link Linear Issue to Release
+**File:** `.github/workflows/link_issue_to_release.yaml`
+**Triggers:** Pull request `closed` on `develop` or `release` branch (gated by `merged == true`)
+**Purpose:** When a PR is merged, assigns the Linear issue referenced by its branch name (`ios-XXXX-...`) to the matching release in the "Anytype iOS" pipeline.
+
+**Mapping:**
+- PR → `release` branch → release with stage name `Beta`
+- PR → `develop` branch → release with stage name `In Progress` (preferred), else `Planned`
+
+**Behavior:**
+- Branch without `ios-XXXX` prefix → exits silently (covers bot branches, hotfixes)
+- Issue not found in Linear → exits silently
+- Issue already on any release → exits silently (idempotent re-runs)
+- Multiple matching releases → picks the lowest semver `name` (component-wise numeric compare)
+- No matching release → posts a comment on the Linear issue with PR URL, base branch, and expected stages; fails the workflow
+
+**Required secrets:** `LINEAR_TOKEN`
 
 ---
 

--- a/.github/workflows/link_issue_to_release.yaml
+++ b/.github/workflows/link_issue_to_release.yaml
@@ -1,0 +1,196 @@
+name: Link merged PR to Linear release
+
+# Automatically assigns the Linear issue referenced by a merged PR to the
+# appropriate release in the "Anytype iOS" pipeline.
+#
+# Mapping:
+#   PR merged to `release` → release with stage name "Beta"
+#   PR merged to `develop` → release with stage name "In Progress" (preferred), else "Planned"
+#
+# Behavior:
+#   - Branch name must start with `ios-XXXX`; otherwise the run exits silently.
+#   - If the issue already has any release assigned, the run exits silently.
+#   - If multiple releases share the target stage, the lowest semver name wins.
+#   - If no release matches the target stage(s), a comment is posted on the
+#     Linear issue and the workflow fails.
+#
+# Required secrets:
+#   - LINEAR_TOKEN: Linear API token with write access to issues and releases.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+      - release
+
+jobs:
+  link:
+    name: Link issue to release
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Linear issue identifier from branch
+        id: extract
+        shell: bash
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$HEAD_REF" =~ ^[Ii][Oo][Ss]-([0-9]+) ]]; then
+            IDENTIFIER="IOS-${BASH_REMATCH[1]}"
+            echo "Found Linear identifier: $IDENTIFIER"
+            echo "identifier=$IDENTIFIER" >> "$GITHUB_OUTPUT"
+          else
+            echo "Branch '$HEAD_REF' has no ios-XXXX prefix, nothing to link."
+            echo "identifier=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine target stage preference
+        id: stages
+        if: steps.extract.outputs.identifier != ''
+        shell: bash
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [[ "$BASE_REF" == "release" ]]; then
+            PREF='["Beta"]'
+          else
+            PREF='["In Progress","Planned"]'
+          fi
+          echo "Base branch '$BASE_REF' → stage preference: $PREF"
+          echo "preference=$PREF" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch Linear issue and check existing release
+        id: issue
+        if: steps.extract.outputs.identifier != ''
+        shell: bash
+        env:
+          LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
+          IDENTIFIER: ${{ steps.extract.outputs.identifier }}
+        run: |
+          QUERY='query($id: String!) { issue(id: $id) { id identifier releases { nodes { id name } } } }'
+          PAYLOAD=$(jq -n --arg q "$QUERY" --arg id "$IDENTIFIER" \
+            '{query: $q, variables: { id: $id }}')
+
+          RESP=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          UUID=$(echo "$RESP" | jq -r '.data.issue.id // empty')
+          if [[ -z "$UUID" ]]; then
+            echo "Issue $IDENTIFIER not found in Linear, skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          EXISTING=$(echo "$RESP" | jq -r '.data.issue.releases.nodes | length')
+          if [[ "$EXISTING" -gt 0 ]]; then
+            NAMES=$(echo "$RESP" | jq -r '[.data.issue.releases.nodes[].name] | join(", ")')
+            echo "Issue $IDENTIFIER already on release(s): $NAMES — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "issueUuid=$UUID" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Pick target release
+        id: pick
+        if: steps.issue.outputs.skip == 'false'
+        shell: bash
+        env:
+          LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
+          PREFERENCE: ${{ steps.stages.outputs.preference }}
+        run: |
+          QUERY='query($stages: [String!]!) { releases(filter: { pipeline: { name: { eq: "Anytype iOS" } }, stage: { name: { in: $stages } } }) { nodes { id name stage { name } } } }'
+          STAGES=$(echo "$PREFERENCE" | jq -c '.')
+          PAYLOAD=$(jq -n --arg q "$QUERY" --argjson stages "$STAGES" \
+            '{query: $q, variables: { stages: $stages }}')
+
+          RESP=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          echo "Releases response: $RESP"
+
+          # Walk preference order; first stage with any candidate wins.
+          # Among those, pick lowest semver by splitting name on '.' and comparing as ints.
+          PICKED=$(echo "$RESP" | jq -c --argjson pref "$PREFERENCE" '
+            .data.releases.nodes as $all
+            | ($pref | map(. as $s | $all | map(select(.stage.name == $s))) | map(select(length > 0)) | first // [])
+            | sort_by(.name | split(".") | map(tonumber? // 0))
+            | first
+          ')
+
+          if [[ "$PICKED" == "null" || -z "$PICKED" ]]; then
+            echo "No release found in stages $PREFERENCE."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          RELEASE_ID=$(echo "$PICKED" | jq -r '.id')
+          RELEASE_NAME=$(echo "$PICKED" | jq -r '.name')
+          RELEASE_STAGE=$(echo "$PICKED" | jq -r '.stage.name')
+          echo "Picked release: $RELEASE_NAME (stage: $RELEASE_STAGE, id: $RELEASE_ID)"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "releaseId=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+          echo "releaseName=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Assign issue to release
+        if: steps.pick.outputs.found == 'true'
+        shell: bash
+        env:
+          LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
+          ISSUE_UUID: ${{ steps.issue.outputs.issueUuid }}
+          IDENTIFIER: ${{ steps.extract.outputs.identifier }}
+          RELEASE_ID: ${{ steps.pick.outputs.releaseId }}
+          RELEASE_NAME: ${{ steps.pick.outputs.releaseName }}
+        run: |
+          MUTATION='mutation($input: IssueToReleaseCreateInput!) { issueToReleaseCreate(input: $input) { success } }'
+          PAYLOAD=$(jq -n --arg q "$MUTATION" --arg iid "$ISSUE_UUID" --arg rid "$RELEASE_ID" \
+            '{query: $q, variables: { input: { issueId: $iid, releaseId: $rid } }}')
+
+          RESP=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          echo "Mutation response: $RESP"
+
+          SUCCESS=$(echo "$RESP" | jq -r '.data.issueToReleaseCreate.success // false')
+          if [[ "$SUCCESS" != "true" ]]; then
+            echo "::error::Failed to assign $IDENTIFIER to release $RELEASE_NAME"
+            echo "$RESP" | jq -r '.errors // empty'
+            exit 1
+          fi
+
+          echo "::notice::Assigned $IDENTIFIER to release $RELEASE_NAME"
+
+      - name: Comment on issue when no release matched
+        if: steps.pick.outputs.found == 'false'
+        shell: bash
+        env:
+          LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
+          ISSUE_UUID: ${{ steps.issue.outputs.issueUuid }}
+          IDENTIFIER: ${{ steps.extract.outputs.identifier }}
+          PREFERENCE: ${{ steps.stages.outputs.preference }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          STAGE_LIST=$(echo "$PREFERENCE" | jq -r '. | join(" / ")')
+          BODY=$(printf 'Automation could not assign this issue to a release.\n\nPR %s was merged to `%s`, expected to find a release in the "Anytype iOS" pipeline with stage: **%s**, but none matched.\n\nPlease assign the release manually and verify the pipeline stages.' \
+            "$PR_URL" "$BASE_REF" "$STAGE_LIST")
+
+          MUTATION='mutation($input: CommentCreateInput!) { commentCreate(input: $input) { success } }'
+          PAYLOAD=$(jq -n --arg q "$MUTATION" --arg iid "$ISSUE_UUID" --arg body "$BODY" \
+            '{query: $q, variables: { input: { issueId: $iid, body: $body } }}')
+
+          curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" | jq .
+
+          echo "::error::No release found in stage(s) $STAGE_LIST for $IDENTIFIER (base=$BASE_REF); comment posted."
+          exit 1

--- a/.github/workflows/link_issue_to_release.yaml
+++ b/.github/workflows/link_issue_to_release.yaml
@@ -29,6 +29,8 @@ jobs:
     name: Link issue to release
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    env:
+      PIPELINE_NAME: Anytype iOS
     steps:
       - name: Extract Linear issue identifier from branch
         id: extract
@@ -36,7 +38,8 @@ jobs:
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [[ "$HEAD_REF" =~ ^[Ii][Oo][Ss]-([0-9]+) ]]; then
+          set -euo pipefail
+          if [[ "$HEAD_REF" =~ ^ios-([0-9]+) ]]; then
             IDENTIFIER="IOS-${BASH_REMATCH[1]}"
             echo "Found Linear identifier: $IDENTIFIER"
             echo "identifier=$IDENTIFIER" >> "$GITHUB_OUTPUT"
@@ -52,6 +55,7 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
+          set -euo pipefail
           if [[ "$BASE_REF" == "release" ]]; then
             PREF='["Beta"]'
           else
@@ -60,19 +64,30 @@ jobs:
           echo "Base branch '$BASE_REF' → stage preference: $PREF"
           echo "preference=$PREF" >> "$GITHUB_OUTPUT"
 
-      - name: Fetch Linear issue and check existing release
-        id: issue
+      - name: Fetch issue and candidate releases
+        id: fetch
         if: steps.extract.outputs.identifier != ''
         shell: bash
         env:
           LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
           IDENTIFIER: ${{ steps.extract.outputs.identifier }}
+          PREFERENCE: ${{ steps.stages.outputs.preference }}
         run: |
-          QUERY='query($id: String!) { issue(id: $id) { id identifier releases { nodes { id name } } } }'
-          PAYLOAD=$(jq -n --arg q "$QUERY" --arg id "$IDENTIFIER" \
-            '{query: $q, variables: { id: $id }}')
+          set -euo pipefail
+          QUERY='query($id: String!, $pipeline: String!, $stages: [String!]!) {
+            issue(id: $id) { id identifier releases { nodes { id name } } }
+            releases(filter: { pipeline: { name: { eq: $pipeline } }, stage: { name: { in: $stages } } }) {
+              nodes { id name stage { name } }
+            }
+          }'
+          PAYLOAD=$(jq -n \
+            --arg q "$QUERY" \
+            --arg id "$IDENTIFIER" \
+            --arg pipeline "$PIPELINE_NAME" \
+            --argjson stages "$PREFERENCE" \
+            '{query: $q, variables: { id: $id, pipeline: $pipeline, stages: $stages }}')
 
-          RESP=$(curl -s -X POST https://api.linear.app/graphql \
+          RESP=$(curl -fsS -X POST https://api.linear.app/graphql \
             -H "Authorization: $LINEAR_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")
@@ -92,33 +107,24 @@ jobs:
             exit 0
           fi
 
+          RELEASES=$(echo "$RESP" | jq -c '.data.releases.nodes')
           echo "issueUuid=$UUID" >> "$GITHUB_OUTPUT"
+          echo "releases=$RELEASES" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Pick target release
         id: pick
-        if: steps.issue.outputs.skip == 'false'
+        if: steps.fetch.outputs.skip == 'false'
         shell: bash
         env:
-          LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
+          RELEASES: ${{ steps.fetch.outputs.releases }}
           PREFERENCE: ${{ steps.stages.outputs.preference }}
         run: |
-          QUERY='query($stages: [String!]!) { releases(filter: { pipeline: { name: { eq: "Anytype iOS" } }, stage: { name: { in: $stages } } }) { nodes { id name stage { name } } } }'
-          STAGES=$(echo "$PREFERENCE" | jq -c '.')
-          PAYLOAD=$(jq -n --arg q "$QUERY" --argjson stages "$STAGES" \
-            '{query: $q, variables: { stages: $stages }}')
-
-          RESP=$(curl -s -X POST https://api.linear.app/graphql \
-            -H "Authorization: $LINEAR_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD")
-
-          echo "Releases response: $RESP"
-
+          set -euo pipefail
           # Walk preference order; first stage with any candidate wins.
-          # Among those, pick lowest semver by splitting name on '.' and comparing as ints.
-          PICKED=$(echo "$RESP" | jq -c --argjson pref "$PREFERENCE" '
-            .data.releases.nodes as $all
+          # Lowest semver by splitting name on '.' and comparing component-wise as ints.
+          PICKED=$(echo "$RELEASES" | jq -c --argjson pref "$PREFERENCE" '
+            . as $all
             | ($pref | map(. as $s | $all | map(select(.stage.name == $s))) | map(select(length > 0)) | first // [])
             | sort_by(.name | split(".") | map(tonumber? // 0))
             | first
@@ -143,21 +149,20 @@ jobs:
         shell: bash
         env:
           LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
-          ISSUE_UUID: ${{ steps.issue.outputs.issueUuid }}
+          ISSUE_UUID: ${{ steps.fetch.outputs.issueUuid }}
           IDENTIFIER: ${{ steps.extract.outputs.identifier }}
           RELEASE_ID: ${{ steps.pick.outputs.releaseId }}
           RELEASE_NAME: ${{ steps.pick.outputs.releaseName }}
         run: |
+          set -euo pipefail
           MUTATION='mutation($input: IssueToReleaseCreateInput!) { issueToReleaseCreate(input: $input) { success } }'
           PAYLOAD=$(jq -n --arg q "$MUTATION" --arg iid "$ISSUE_UUID" --arg rid "$RELEASE_ID" \
             '{query: $q, variables: { input: { issueId: $iid, releaseId: $rid } }}')
 
-          RESP=$(curl -s -X POST https://api.linear.app/graphql \
+          RESP=$(curl -fsS -X POST https://api.linear.app/graphql \
             -H "Authorization: $LINEAR_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")
-
-          echo "Mutation response: $RESP"
 
           SUCCESS=$(echo "$RESP" | jq -r '.data.issueToReleaseCreate.success // false')
           if [[ "$SUCCESS" != "true" ]]; then
@@ -173,21 +178,22 @@ jobs:
         shell: bash
         env:
           LINEAR_TOKEN: ${{ secrets.LINEAR_TOKEN }}
-          ISSUE_UUID: ${{ steps.issue.outputs.issueUuid }}
+          ISSUE_UUID: ${{ steps.fetch.outputs.issueUuid }}
           IDENTIFIER: ${{ steps.extract.outputs.identifier }}
           PREFERENCE: ${{ steps.stages.outputs.preference }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
+          set -euo pipefail
           STAGE_LIST=$(echo "$PREFERENCE" | jq -r '. | join(" / ")')
-          BODY=$(printf 'Automation could not assign this issue to a release.\n\nPR %s was merged to `%s`, expected to find a release in the "Anytype iOS" pipeline with stage: **%s**, but none matched.\n\nPlease assign the release manually and verify the pipeline stages.' \
-            "$PR_URL" "$BASE_REF" "$STAGE_LIST")
+          BODY=$(printf 'Automation could not assign this issue to a release.\n\nPR %s was merged to `%s`, expected to find a release in the "%s" pipeline with stage: **%s**, but none matched.\n\nPlease assign the release manually and verify the pipeline stages.' \
+            "$PR_URL" "$BASE_REF" "$PIPELINE_NAME" "$STAGE_LIST")
 
           MUTATION='mutation($input: CommentCreateInput!) { commentCreate(input: $input) { success } }'
           PAYLOAD=$(jq -n --arg q "$MUTATION" --arg iid "$ISSUE_UUID" --arg body "$BODY" \
             '{query: $q, variables: { input: { issueId: $iid, body: $body } }}')
 
-          curl -s -X POST https://api.linear.app/graphql \
+          curl -fsS -X POST https://api.linear.app/graphql \
             -H "Authorization: $LINEAR_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD" | jq .


### PR DESCRIPTION
## Summary
- New workflow `link_issue_to_release.yaml` runs on PR merge to `develop` or `release` and assigns the Linear issue (parsed from `ios-XXXX` branch prefix) to a release in the "Anytype iOS" pipeline.
- Mapping: `release` → release with stage `Beta`; `develop` → stage `In Progress` (preferred) else `Planned`. Lowest-semver tiebreak if multiple match.
- Skip-silently rules: branch without `ios-XXXX` prefix, issue not found, issue already assigned to any release. Failure path posts a comment on the Linear issue and fails the workflow.
- One combined GraphQL request (issue + candidate releases) per run; `set -euo pipefail` + `curl -fsS` on every step.