### PR TITLE
IOS-5994 [Temp] Add internal-debug buttons to manually fire Sentry profile events

### DIFF
--- a/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
@@ -6,6 +6,7 @@ import Logger
 protocol MemoryPressureProfilerTriggerProtocol: AnyObject, Sendable {
     func startSubscription() async
     func stopSubscriptionAndClean() async
+    func triggerManually(severity: DebugProfilerReason.MemorySeverity) async
 }
 
 actor MemoryPressureProfilerTrigger: MemoryPressureProfilerTriggerProtocol {
@@ -43,6 +44,11 @@ actor MemoryPressureProfilerTrigger: MemoryPressureProfilerTriggerProtocol {
         source?.cancel()
         source = nil
         lastTrigger = nil
+    }
+
+    func triggerManually(severity: DebugProfilerReason.MemorySeverity) async {
+        lastTrigger = nil
+        await trigger(reason: .memoryPressure(severity))
     }
 
     private func handleEventFire() async {

--- a/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
@@ -6,6 +6,7 @@ import Logger
 protocol ThermalProfilerTriggerProtocol: AnyObject, Sendable {
     func startSubscription() async
     func stopSubscriptionAndClean() async
+    func triggerManually(severity: DebugProfilerReason.ThermalSeverity) async
 }
 
 actor ThermalProfilerTrigger: ThermalProfilerTriggerProtocol {
@@ -40,6 +41,11 @@ actor ThermalProfilerTrigger: ThermalProfilerTriggerProtocol {
     func stopSubscriptionAndClean() async {
         observer = nil
         lastTrigger = nil
+    }
+
+    func triggerManually(severity: DebugProfilerReason.ThermalSeverity) async {
+        lastTrigger = nil
+        await trigger(reason: .thermalState(severity))
     }
 
     private func handleThermalChange() async {

--- a/Anytype/Sources/PresentationLayer/Debug/Flows/InternalDebug/DebugMenuView.swift
+++ b/Anytype/Sources/PresentationLayer/Debug/Flows/InternalDebug/DebugMenuView.swift
@@ -116,6 +116,16 @@ struct DebugMenuView: View {
                 }
             }
             
+            AsyncStandardButton("[Temp] Send Sentry: thermal critical 🌡️", style: .secondaryLarge) {
+                UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+                await model.triggerThermalProfile()
+            }
+
+            AsyncStandardButton("[Temp] Send Sentry: memory critical 🧠", style: .secondaryLarge) {
+                UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+                await model.triggerMemoryPressureProfile()
+            }
+
             StandardButton("Homepage Picker Preview 🏠", style: .secondaryLarge) {
                 showHomepagePicker = true
             }

--- a/Anytype/Sources/PresentationLayer/Debug/Flows/InternalDebug/DebugMenuViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Debug/Flows/InternalDebug/DebugMenuViewModel.swift
@@ -39,6 +39,10 @@ final class DebugMenuViewModel: ObservableObject {
     private var applePushNotificationService: any ApplePushNotificationServiceProtocol
     @Injected(\.chatService)
     private var chatService: any ChatServiceProtocol
+    @Injected(\.thermalProfilerTrigger)
+    private var thermalProfilerTrigger: any ThermalProfilerTriggerProtocol
+    @Injected(\.memoryPressureProfilerTrigger)
+    private var memoryPressureProfilerTrigger: any MemoryPressureProfilerTriggerProtocol
     
     var shouldRunDebugProfilerOnNextStartup: Bool {
         get {
@@ -111,6 +115,14 @@ final class DebugMenuViewModel: ObservableObject {
     
     func onDebugRunProfiler() {
         debugService.startDebugRunProfiler()
+    }
+
+    func triggerThermalProfile() async {
+        await thermalProfilerTrigger.triggerManually(severity: .critical)
+    }
+
+    func triggerMemoryPressureProfile() async {
+        await memoryPressureProfilerTrigger.triggerManually(severity: .critical)
     }
     
     func shareUrlContent(url: URL) {


### PR DESCRIPTION
## Summary
- Adds two temporary buttons to the Internal Debug menu that exercise the thermal and memory-pressure profile triggers directly, bypassing the cooldown so each tap reliably produces a Sentry envelope.
- Diagnostic only: PR #4942 shipped the production wiring but no `MW_*` events have appeared in Sentry from nightly testing. These buttons let us pinpoint whether the gap is the system observers (never firing), DSN injection, or the reporter itself.
- Buttons fire `severity: .critical` (most prominent Sentry fingerprint), labeled `[Temp]` in the UI, and live in `DebugMenuView` only — not the public release menu.

## Removal
Drop / revert this commit once `MW_thermal_critical` and `MW_memory_pressure_critical` events are confirmed in Sentry.