### PR TITLE
IOS-6129 Rotate fastlane Apple ID to iosdevops@anytype.io

### DIFF
--- a/fastlane/.env
+++ b/fastlane/.env
@@ -20,4 +20,4 @@ APP_SHARE_EXTENSION_ID_RELEASE_ANYTYPE = "io.anytype.app.AnytypeShareExtension"
 APP_NOTIFICATION_EXTENSION_ID_DEVELOP = "io.anytype.app.dev.AnytypeNotificationExtension"
 APP_NOTIFICATION_EXTENSION_ID_RELEASE_ANYTYPE = "io.anytype.app.AnytypeNotificationExtension"
 
-APPLE_ID = "iosteam@anytype.io"
+APPLE_ID = "iosdevops@anytype.io"


### PR DESCRIPTION
## Summary
- Replace `iosteam@anytype.io` with `iosdevops@anytype.io` in `fastlane/.env` ahead of the May 29 distribution certificate expiry.
- The new Apple ID is a dedicated service account added as Admin on App Store Connect (team `J3NXTX3T5S`); it owns only the signing identity and is not used as a TestFlight tester.
- Match (`Matchfile`) and `Appfile` read `ENV["APPLE_ID"]`, so this single change propagates everywhere fastlane needs it. Certificate regeneration will be performed locally after this lands.