### PR TITLE
IOS-6129 Authenticate cert management lanes via App Store Connect API key

### DIFF
--- a/fastlane/FastfileProfiles
+++ b/fastlane/FastfileProfiles
@@ -15,28 +15,34 @@ platform :ios do
   # Generate Debug
 
   lane :generate_dev_debug_profiles do
+    set_api_key
     match(force_for_new_devices: true)
   end
 
   lane :generate_anytype_debug_profiles do
+    set_api_key
     match(force_for_new_devices: true)
   end
 
   # Generate Release
 
   lane :generate_appstore_profiles_for_nightly do
+    set_api_key
     match(force: true)
   end
 
   lane :generate_appstore_profiles_for_anytype do
+    set_api_key
     match(force: true)
   end
 
   lane :delete_dev_certs do
+    set_api_key
     match_nuke()
   end
 
   lane :delete_appstore_certs do
+    set_api_key
     match_nuke()
   end
 end


### PR DESCRIPTION
## Summary
- Add `set_api_key` to all four `generate_*` lanes and both `delete_*` lanes in `FastfileProfiles` so local cert/profile management uses the App Store Connect API key (matching the deploy lane's pattern).
- Without this, `match` and `match_nuke` fall back to interactive Apple ID + password authentication when run locally, which doesn't play well with rotation work and is inconsistent with CI.
- No CI impact: the affected lanes are invoked manually for cert management; the deploy/branch_build lanes already set the API key correctly.