### PR TITLE
IOS-6224 Move synchronous middleware calls to GCD and add per-call QoS

### DIFF
--- a/Anytype/Sources/ServiceLayer/Object/TypesService/TypesService.swift
+++ b/Anytype/Sources/ServiceLayer/Object/TypesService/TypesService.swift
@@ -31,7 +31,7 @@ final class TypesService: TypesServiceProtocol, Sendable {
         let result = try await ClientCommands.objectCreateObjectType(.with {
             $0.details = details
             $0.spaceID = spaceId
-        }).invoke()
+        }).invoke(qos: .userInitiated)
         
         let objectDetails = try ObjectDetails(protobufStruct: result.details)
         return ObjectType(details: objectDetails)

--- a/Modules/ProtobufMessages/Sources/Invocation.swift
+++ b/Modules/ProtobufMessages/Sources/Invocation.swift
@@ -19,6 +19,7 @@ public struct Invocation<Request, Response>: Sendable where Request: Message & S
     public func invoke(
         requestMask: (@Sendable (inout Request) -> Void)? = nil,
         responseMask: (@Sendable (inout Response) -> Void)? = nil,
+        qos: DispatchQoS.QoSClass = .default,
         file: StaticString = #file,
         function: String = #function,
         line: UInt = #line,
@@ -26,7 +27,7 @@ public struct Invocation<Request, Response>: Sendable where Request: Message & S
     ) async throws -> Response {
         do {
             return try await withUncancellableHandler {
-                try await internalInvoke(requestMask: requestMask, responseMask: responseMask)
+                try await internalInvoke(requestMask: requestMask, responseMask: responseMask, qos: qos)
             }
         } catch let error as CancellationError {
             // Ignore try Task.checkCancellation()
@@ -44,7 +45,8 @@ public struct Invocation<Request, Response>: Sendable where Request: Message & S
     
     private func internalInvoke(
         requestMask: ((inout Request) -> Void)?,
-        responseMask: ((inout Response) -> Void)?
+        responseMask: ((inout Response) -> Void)?,
+        qos: DispatchQoS.QoSClass
     ) async throws -> Response {
         
         let result: Response
@@ -58,9 +60,16 @@ public struct Invocation<Request, Response>: Sendable where Request: Message & S
         try Task.checkCancellation()
         
         do {
-            result = try await Task {
-                try invokeTask(request)
-            }.value
+            result = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Response, Error>) in
+                DispatchQueue.global(qos: qos).async {
+                    do {
+                        let response = try invokeTask(request)
+                        cont.resume(returning: response)
+                    } catch {
+                        cont.resume(throwing: error)
+                    }
+                }
+            }
         } catch {
             log(message: messageName, requestId: requestId, data: nil, error: error)
             throw error

--- a/Modules/Services/Sources/Services/Auth/AuthMiddleService.swift
+++ b/Modules/Services/Sources/Services/Auth/AuthMiddleService.swift
@@ -59,8 +59,8 @@ final class AuthMiddleService: AuthMiddleServiceProtocol {
                 $0.networkMode = networkMode
                 $0.joinStreamURL = joinStreamUrl
                 $0.networkCustomConfigFilePath = configPath ?? ""
-            }).invoke()
-    
+            }).invoke(qos: .userInitiated)
+
             return try response.account.asModel()
         } catch let responseError as Anytype_Rpc.Account.Create.Response.Error {
             throw responseError.asError ?? responseError
@@ -80,7 +80,7 @@ final class AuthMiddleService: AuthMiddleServiceProtocol {
     
     public func accountRecover() async throws {
         do {
-            _ = try await ClientCommands.accountRecover().invoke()
+            _ = try await ClientCommands.accountRecover().invoke(qos: .userInitiated)
         } catch {
             let code = (error as? Anytype_Rpc.Account.Recover.Response.Error)?.code ?? .null
             throw AuthServiceError.recoverAccountError(code: code)
@@ -102,7 +102,7 @@ final class AuthMiddleService: AuthMiddleServiceProtocol {
                 $0.networkMode = networkMode
                 $0.networkCustomConfigFilePath = configPath ?? ""
                 $0.joinStreamURL = joinStreamUrl
-            }).invoke(ignoreLogErrors: .accountLoadIsCanceled, .accountStoreNotMigrated)
+            }).invoke(qos: .userInitiated, ignoreLogErrors: .accountLoadIsCanceled, .accountStoreNotMigrated)
             
             return try response.account.asModel()
         } catch let responseError as Anytype_Rpc.Account.Select.Response.Error {

--- a/Modules/Services/Sources/Services/Bookmark/BookmarkService.swift
+++ b/Modules/Services/Sources/Services/Bookmark/BookmarkService.swift
@@ -49,7 +49,7 @@ final class BookmarkService: BookmarkServiceProtocol {
             $0.details = details
             $0.spaceID = spaceId
             $0.templateID = templateId ?? ""
-        }).invoke()
+        }).invoke(qos: .userInitiated)
         return try result.details.toDetails()
     }
     

--- a/Modules/Services/Sources/Services/ObjectActions/ObjectActionsService.swift
+++ b/Modules/Services/Sources/Services/ObjectActions/ObjectActionsService.swift
@@ -50,7 +50,7 @@ final class ObjectActionsService: ObjectActionsServiceProtocol {
             $0.templateID = templateId ?? ""
             $0.spaceID = spaceId
             $0.objectTypeUniqueKey = typeUniqueKey.value
-        }).invoke()
+        }).invoke(qos: .userInitiated)
         
         return try response.details.toDetails()
     }
@@ -105,8 +105,8 @@ final class ObjectActionsService: ObjectActionsServiceProtocol {
     public func duplicate(objectId: String) async throws -> String {
         let result = try await ClientCommands.objectDuplicate(.with {
             $0.contextID = objectId
-        }).invoke()
-        
+        }).invoke(qos: .userInitiated)
+
         return result.id
     }
 
@@ -246,6 +246,6 @@ final class ObjectActionsService: ObjectActionsServiceProtocol {
             $0.source = [setOfObjectType]
             $0.spaceID = spaceId
             $0.withChat = false
-        }).invoke().details.toDetails()
+        }).invoke(qos: .userInitiated).details.toDetails()
     }
 }

--- a/Modules/Services/Sources/Services/ObjectLifecycleService/ObjectLifecycleService.swift
+++ b/Modules/Services/Sources/Services/ObjectLifecycleService/ObjectLifecycleService.swift
@@ -17,7 +17,7 @@ final class ObjectLifecycleService: ObjectLifecycleServiceProtocol {
                 $0.contextID = contextId
                 $0.objectID = contextId
                 $0.spaceID = spaceId
-            }).invoke(ignoreLogErrors: .objectDeleted)
+            }).invoke(qos: .userInitiated, ignoreLogErrors: .objectDeleted)
             return result.objectView
         } catch let error as Anytype_Rpc.Object.Open.Response.Error {
             throw ObjectOpenError(error: error)
@@ -29,7 +29,7 @@ final class ObjectLifecycleService: ObjectLifecycleServiceProtocol {
             $0.contextID = contextId
             $0.objectID = contextId
             $0.spaceID = spaceId
-        }).invoke(ignoreLogErrors: .objectDeleted)
+        }).invoke(qos: .userInitiated, ignoreLogErrors: .objectDeleted)
         return result.objectView
     }
     

--- a/Modules/Services/Sources/Services/Properties/PropertiesService.swift
+++ b/Modules/Services/Sources/Services/Properties/PropertiesService.swift
@@ -68,7 +68,7 @@ final class PropertiesService: PropertiesServiceProtocol {
         let result = try await ClientCommands.objectCreateRelation(.with {
             $0.details = propertyDetails.asMiddleware
             $0.spaceID = spaceId
-        }).invoke()
+        }).invoke(qos: .userInitiated)
         
         guard let objectDetails = try? ObjectDetails(protobufStruct: result.details) else {
             throw PropertyServiceError.unableToCreateRelationFromObject

--- a/Modules/Services/Sources/Services/SearchService/SearchMiddleService.swift
+++ b/Modules/Services/Sources/Services/SearchService/SearchMiddleService.swift
@@ -30,7 +30,7 @@ final class SearchMiddleService: SearchMiddleServiceProtocol {
             $0.fullText = data.fullText
             $0.limit = Int32(data.limit)
             $0.keys = data.keys
-        }).invoke()
+        }).invoke(qos: .userInitiated)
         
         return response.records.asDetais
     }

--- a/Modules/Services/Sources/Services/SearchWithMetaService/SearchWithMetaMiddleService.swift
+++ b/Modules/Services/Sources/Services/SearchWithMetaService/SearchWithMetaMiddleService.swift
@@ -31,7 +31,7 @@ final class SearchWithMetaMiddleService: SearchWithMetaMiddleServiceProtocol {
             $0.limit = Int32(data.limit)
             $0.keys = data.keys
             $0.returnMeta = true
-        }).invoke()
+        }).invoke(qos: .userInitiated)
         
         return response.results.asResults
     }

--- a/Modules/Services/Sources/Services/Workspace/WorkspaceService.swift
+++ b/Modules/Services/Sources/Services/Workspace/WorkspaceService.swift
@@ -68,7 +68,7 @@ final class WorkspaceService: WorkspaceServiceProtocol {
             $0.details.fields[BundledPropertyKey.spaceType.rawValue] = spaceType.rawValue.protobufValue
             $0.useCase = useCase
             $0.withChat = withChat
-        }).invoke()
+        }).invoke(qos: .userInitiated)
         return result
     }
 
@@ -80,7 +80,7 @@ final class WorkspaceService: WorkspaceServiceProtocol {
             $0.details.fields[BundledPropertyKey.oneToOneRequestMetadataKey.rawValue] = metadataKey.protobufValue
             $0.useCase = .none
             $0.withChat = true
-        }).invoke()
+        }).invoke(qos: .userInitiated)
 
         return result.spaceID
     }
@@ -89,8 +89,8 @@ final class WorkspaceService: WorkspaceServiceProtocol {
         let result = try await ClientCommands.workspaceOpen(.with {
             $0.spaceID = spaceId
             $0.withChat = withChat
-        }).invoke()
-        
+        }).invoke(qos: .userInitiated)
+
         return result.info.asModel
     }
     


### PR DESCRIPTION
## Summary

- Switch `Invocation.internalInvoke` from `Task { sync }.value` to `withCheckedThrowingContinuation` + `DispatchQueue.global(qos:).async`, so the synchronous gomobile bridge call no longer pins a Swift Concurrency cooperative-pool worker for the duration of the middleware operation.
- Add a `qos:` parameter on `invoke()` defaulting to `.default`; pipe it through to the GCD dispatch.
- Pass `qos: .userInitiated` at 16 service-layer call sites where the user is blocked on the result (login/signup/recovery, workspace open/create, object open/show/create/duplicate, the create variants, search, search-with-meta). Secondary callers of `objectShow` / `objectCreate` stay on `.default`.

Cancellation semantics are preserved via the existing `withUncancellableHandler` wrapper.