### PR TITLE
IOS-5994 Guard DebugService.runProfiler against concurrent invocations

### DIFF
--- a/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
@@ -72,5 +72,6 @@ actor MemoryPressureProfilerTrigger: MemoryPressureProfilerTriggerProtocol {
             return
         }
         sentryReporter.report(path: path, reasonTag: reason.tag, jsonInfo: nil)
+        await debugService.cleanupReport(ts: Int(Date().timeIntervalSince1970))
     }
 }

--- a/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
@@ -72,5 +72,6 @@ actor ThermalProfilerTrigger: ThermalProfilerTriggerProtocol {
             return
         }
         sentryReporter.report(path: path, reasonTag: reason.tag, jsonInfo: nil)
+        await debugService.cleanupReport(ts: Int(Date().timeIntervalSince1970))
     }
 }

--- a/Modules/Services/Sources/Services/Debug/DebugService.swift
+++ b/Modules/Services/Sources/Services/Debug/DebugService.swift
@@ -199,7 +199,7 @@ final class DebugService: ObservableObject, DebugServiceProtocol {
     }
 
     func runProfiler(durationInSeconds: Int, reason: DebugProfilerReason) async -> String? {
-        let acquired = profilerRunning.withLock { running -> Bool in
+        let acquired = profilerRunning.withLock { running in
             guard !running else { return false }
             running = true
             return true

--- a/Modules/Services/Sources/Services/Debug/DebugService.swift
+++ b/Modules/Services/Sources/Services/Debug/DebugService.swift
@@ -2,6 +2,7 @@ import Foundation
 import ProtobufMessages
 import AnytypeCore
 import Combine
+import os
 
 
 public enum DebugRunProfilerState: Codable {
@@ -94,7 +95,8 @@ final class DebugService: ObservableObject, DebugServiceProtocol {
     }
     
     private let storage = Storage()
-    
+    private let profilerRunning = OSAllocatedUnfairLock(initialState: false)
+
     public func exportLocalStore() async throws -> String {
         let tempDirString = FileManager.default.createTempDirectory().path
         
@@ -197,7 +199,15 @@ final class DebugService: ObservableObject, DebugServiceProtocol {
     }
 
     func runProfiler(durationInSeconds: Int, reason: DebugProfilerReason) async -> String? {
-        try? await ClientCommands.debugRunProfiler(.with {
+        let acquired = profilerRunning.withLock { running -> Bool in
+            guard !running else { return false }
+            running = true
+            return true
+        }
+        guard acquired else { return nil }
+        defer { profilerRunning.withLock { $0 = false } }
+
+        return try? await ClientCommands.debugRunProfiler(.with {
             $0.durationInSeconds = Int32(durationInSeconds)
             $0.reason = reason.protoReason
             $0.reasonDesc = reason.desc


### PR DESCRIPTION
## Summary
- Memory-pressure and thermal-state triggers can both fire `debugService.runProfiler(...)` concurrently on a stressed device. The underlying `DebugService.runProfiler` is a thin pass-through to `ClientCommands.debugRunProfiler` with no serialization, so two profilers would run in parallel — compounding the resource cost on an already-stressed device and skewing the data being profiled.
- Adds an `OSAllocatedUnfairLock<Bool>` inside `DebugService` that gates `runProfiler` to one in-flight call. Overlapping calls return `nil` immediately, matching the existing failure path (no Sentry upload, triggers keep their cooldowns).
- The manual `startDebugRunProfiler()` (debug menu "Run profiler" button) is intentionally not gated — a developer pressing that button has explicitly opted into the cost.