### PR TITLE
IOS-5994 Clean up debug profile files after Sentry upload

### DIFF
--- a/Anytype/Sources/CoreLayer/Sentry/DebugProfileEventHandler.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/DebugProfileEventHandler.swift
@@ -21,6 +21,8 @@ actor DebugProfileEventHandler: DebugProfileEventHandlerProtocol {
 
     @Injected(\.debugProfileSentryReporter)
     private var reporter: any DebugProfileSentryReporterProtocol
+    @Injected(\.debugService)
+    private var debugService: any DebugServiceProtocol
 
     private var subscription: AnyCancellable?
 
@@ -47,6 +49,10 @@ actor DebugProfileEventHandler: DebugProfileEventHandlerProtocol {
     private func forwardToSentry(_ profile: Anytype_Event.Debug.ProfileCreated) {
         let reason = profile.reason.isEmpty ? "Unknown" : profile.reason
         Self.log.debug("DebugProfileCreated: reason=\(reason), path=\(profile.path), full=\(profile.full)")
-        reporter.report(path: profile.path, reasonTag: reason, jsonInfo: profile.jsonInfo)
+        reporter.report(path: profile.path, reasonTag: reason, jsonInfo: profile.jsonInfo) { [debugService] in
+            Task {
+                await debugService.cleanupReport(ts: Int(Date().timeIntervalSince1970))
+            }
+        }
     }
 }

--- a/Anytype/Sources/CoreLayer/Sentry/DebugProfileSentryReporter.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/DebugProfileSentryReporter.swift
@@ -21,8 +21,13 @@ final class DebugProfileSentryReporter: DebugProfileSentryReporterProtocol {
                     scope.setExtra(value: jsonInfo, key: "info")
                 }
             }
+            // Use data-based attachment, not path-based: Sentry's transport reads
+            // path attachments lazily on its own queue, but the caller deletes the
+            // source file via `onCaptured`. Memory-map the read so we don't heap-copy
+            // a multi-MB zip during the very memory/thermal pressure event that
+            // produced it; the mapping stays valid even after the file is unlinked.
             if !path.isEmpty,
-               let data = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+               let data = try? Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe) {
                 let url = URL(fileURLWithPath: path)
                 scope.addAttachment(Attachment(
                     data: data,

--- a/Anytype/Sources/CoreLayer/Sentry/DebugProfileSentryReporter.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/DebugProfileSentryReporter.swift
@@ -2,11 +2,11 @@ import Foundation
 import Sentry
 
 protocol DebugProfileSentryReporterProtocol: Sendable {
-    func report(path: String, reasonTag: String, jsonInfo: String?)
+    func report(path: String, reasonTag: String, jsonInfo: String?, onCaptured: @Sendable () -> Void)
 }
 
 final class DebugProfileSentryReporter: DebugProfileSentryReporterProtocol {
-    func report(path: String, reasonTag: String, jsonInfo: String?) {
+    func report(path: String, reasonTag: String, jsonInfo: String?, onCaptured: @Sendable () -> Void) {
         let event = Event(level: .info)
         event.message = SentryMessage(formatted: "MW_\(reasonTag)")
         event.tags = ["report": "mw_profile", "reason": reasonTag]
@@ -21,15 +21,18 @@ final class DebugProfileSentryReporter: DebugProfileSentryReporterProtocol {
                     scope.setExtra(value: jsonInfo, key: "info")
                 }
             }
-            if !path.isEmpty {
+            if !path.isEmpty,
+               let data = try? Data(contentsOf: URL(fileURLWithPath: path)) {
                 let url = URL(fileURLWithPath: path)
                 scope.addAttachment(Attachment(
-                    path: path,
+                    data: data,
                     filename: url.lastPathComponent,
                     contentType: url.debugProfileContentType
                 ))
             }
         }
+
+        onCaptured()
     }
 }
 

--- a/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
@@ -71,7 +71,10 @@ actor MemoryPressureProfilerTrigger: MemoryPressureProfilerTriggerProtocol {
         guard let path = await debugService.runProfiler(durationInSeconds: 0, reason: reason) else {
             return
         }
-        sentryReporter.report(path: path, reasonTag: reason.tag, jsonInfo: nil)
-        await debugService.cleanupReport(ts: Int(Date().timeIntervalSince1970))
+        sentryReporter.report(path: path, reasonTag: reason.tag, jsonInfo: nil) { [debugService] in
+            Task {
+                await debugService.cleanupReport(ts: Int(Date().timeIntervalSince1970))
+            }
+        }
     }
 }

--- a/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
@@ -71,7 +71,10 @@ actor ThermalProfilerTrigger: ThermalProfilerTriggerProtocol {
         guard let path = await debugService.runProfiler(durationInSeconds: Self.profileDuration, reason: reason) else {
             return
         }
-        sentryReporter.report(path: path, reasonTag: reason.tag, jsonInfo: nil)
-        await debugService.cleanupReport(ts: Int(Date().timeIntervalSince1970))
+        sentryReporter.report(path: path, reasonTag: reason.tag, jsonInfo: nil) { [debugService] in
+            Task {
+                await debugService.cleanupReport(ts: Int(Date().timeIntervalSince1970))
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- After memory/thermal triggers (and the middleware-initiated `debugProfileCreated` event handler) upload a profile zip to Sentry, sweep the source pool via `debugService.cleanupReport(ts: now)` so files in `ProfilesDir` don't accumulate forever.
- `DebugProfileSentryReporterProtocol.report` gains an `onCaptured: @Sendable () -> Void` callback that fires after `SentrySDK.capture` returns. Callers fire-and-forget the cleanup in that closure so it runs only once Sentry holds the bytes — not before.
- Switched the Sentry attachment from path-based to data-based (memory-mapped via `.mappedIfSafe`) so Sentry's lazy transport-queue read can't race the cleanup deletion. Mmap avoids a heap copy of the multi-MB zip during the memory/thermal pressure event that produced it; the mapping stays valid even after the file is unlinked.

Follow-up to #4988 (merged).