### PR TITLE
IOS-6237 Bump sentry-cocoa 8.28.0 -> 8.58.2

### DIFF
--- a/Anytype.xcodeproj/project.pbxproj
+++ b/Anytype.xcodeproj/project.pbxproj
@@ -2149,7 +2149,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
 				kind = exactVersion;
-				version = 8.28.0;
+				version = 8.58.2;
 			};
 		};
 		2AC1262B2B90F65F003A4A8D /* XCRemoteSwiftPackageReference "Factory" */ = {

--- a/Anytype.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Anytype.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "a62862c99f5bcb28fd78617fab1a5fe29607c06c",
-        "version" : "8.28.0"
+        "revision" : "cf44aa8cb4147f39e698c1f28be0b6b2c89f79d2",
+        "version" : "8.58.2"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Updates `sentry-cocoa` from 8.28.0 to 8.58.2 (latest within the 8.x line; 9.x is a major breaking bump).
- No source changes — all APIs in use (`SentrySDK.start/capture/setUser/configureScope/crashedLastRun`, `SentryMessage`, `Attachment`, `scope.setTag/addAttachment/setLevel`) are stable across this range.
- Session Replay is not configured in this project, so the new iOS 26 + Xcode 26 PII-safety default that disables it has no effect on us.