### PR TITLE
IOS-6219 Add mention button to keyboard accessory toolbar (release)

### DIFF
--- a/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
+++ b/Anytype/Sources/Analytics/AnytypeAnalytics/AnytypeAnalytics+Events.swift
@@ -1312,6 +1312,18 @@ extension AnytypeAnalytics {
     func logKeyboardBarHideKeyboardMenu() {
         logEvent("KeyboardBarHideKeyboardMenu")
     }
+
+    func logKeyboardBarDeleteBlockMenu() {
+        logEvent("KeyboardBarDeleteBlockMenu")
+    }
+
+    func logKeyboardBarIndentLeftMenu() {
+        logEvent("KeyboardBarIndentLeftMenu")
+    }
+
+    func logKeyboardBarIndentRightMenu() {
+        logEvent("KeyboardBarIndentRightMenu")
+    }
     
     func logScreenHistory() {
         logEvent("ScreenHistory")

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewStateManager.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewStateManager.swift
@@ -429,6 +429,14 @@ extension AccessoryViewStateManagerImpl {
             configuration?.output?.didSelectShowStyleMenu()
         case .keyboardDismiss:
             UIApplication.shared.hideKeyboard()
+        case .mention:
+            configuration.map {
+                $0.textView.insertStringAfterCaret(
+                    TextTriggerSymbols.mention(prependSpace: shouldPrependSpace(textView: $0.textView))
+                )
+            }
+            showMentionsView()
+            configuration?.output?.accessoryState = .search
         case .slashMenu:
             configuration?.textView.insertStringAfterCaret(TextTriggerSymbols.slashMenu)
             showSlashMenuView()
@@ -466,12 +474,18 @@ extension AccessoryViewStateManagerImpl {
             AnytypeAnalytics.instance().logKeyboardBarHideKeyboardMenu()
         case .showStyleMenu:
             AnytypeAnalytics.instance().logKeyboardBarStyleMenu()
+        case .mention:
+            AnytypeAnalytics.instance().logKeyboardBarMentionMenu()
         case .editingMode:
             AnytypeAnalytics.instance().logKeyboardBarSelectionMenu()
         case .undoRedo:
             AnytypeAnalytics.instance().logKeyboardBarUndoMenu()
-        case .deleteBlock, .indentLeft, .indentRight:
-            break
+        case .deleteBlock:
+            AnytypeAnalytics.instance().logKeyboardBarDeleteBlockMenu()
+        case .indentLeft:
+            AnytypeAnalytics.instance().logKeyboardBarIndentLeftMenu()
+        case .indentRight:
+            AnytypeAnalytics.instance().logKeyboardBarIndentRightMenu()
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewStateManager.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/AccessoryViewStateManager.swift
@@ -430,9 +430,9 @@ extension AccessoryViewStateManagerImpl {
         case .keyboardDismiss:
             UIApplication.shared.hideKeyboard()
         case .mention:
-            configuration.map {
-                $0.textView.insertStringAfterCaret(
-                    TextTriggerSymbols.mention(prependSpace: shouldPrependSpace(textView: $0.textView))
+            if let textView = configuration?.textView {
+                textView.insertStringAfterCaret(
+                    TextTriggerSymbols.mention(prependSpace: shouldPrependSpace(textView: textView))
                 )
             }
             showMentionsView()

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/EditorAccessoryView/CursorModeView/CursorModeAccessoryViewDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/EditorAccessoryView/CursorModeView/CursorModeAccessoryViewDelegate.swift
@@ -3,4 +3,5 @@ import UIKit
 @MainActor
 protocol CursorModeAccessoryViewDelegate: AnyObject {
     func showSlashMenuView()
+    func showMentionsView()
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/EditorAccessoryView/CursorModeView/CursorModeAccessoryViewItem.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/EditorAccessoryView/CursorModeView/CursorModeAccessoryViewItem.swift
@@ -5,6 +5,7 @@ extension CursorModeAccessoryView {
         case slash
         case style
         case actions
+        case mention
         case undoRedo
         case deleteBlock
         case indentRight
@@ -16,6 +17,8 @@ extension CursorModeAccessoryView {
                 return UIImage(asset: .X32.slashMenu)
             case .style:
                 return UIImage(asset: .X32.style)
+            case .mention:
+                return UIImage(asset: .X32.mention)
             case .deleteBlock:
                 return UIImage(asset: .X32.delete)
             case .indentLeft:
@@ -35,6 +38,8 @@ extension CursorModeAccessoryView {
                 return .slashMenu
             case .style:
                 return .showStyleMenu
+            case .mention:
+                return .mention
             case .deleteBlock:
                 return .deleteBlock
             case .indentLeft:

--- a/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/EditorAccessoryView/CursorModeView/CursorModeAccessoryViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/AccessoryView/EditorAccessoryView/CursorModeView/CursorModeAccessoryViewModel.swift
@@ -10,6 +10,8 @@ enum CursorModeAccessoryViewAction {
     case keyboardDismiss
     /// Show bottom sheet style menu
     case showStyleMenu
+    /// Show mention menu
+    case mention
     /// Enter editing mode
     case editingMode
     /// Show undo / redo mode
@@ -35,9 +37,9 @@ final class CursorModeAccessoryViewModel {
         } else {
             switch configuration.usecase {
             case .editor:
-                actions = [.slash, .style, .actions, .undoRedo, .deleteBlock, .indentRight, .indentLeft]
+                actions = [.slash, .style, .actions, .mention, .undoRedo, .deleteBlock, .indentRight, .indentLeft]
             case .simpleTable:
-                actions = [.style, .actions, .undoRedo]
+                actions = [.style, .actions, .mention, .undoRedo]
             }
         }
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #4978 onto `release` so the @ mention button on the keyboard accessory toolbar ships in this release, not only in develop.
- Restores `.mention` action on the cursor-mode accessory view and instruments analytics for delete/indent buttons.

Original PR: #4978
Linear: https://linear.app/anytype/issue/IOS-6219