### PR TITLE
IOS-5994 Extend pressure triggers + diagnostic [MW_PROFILE] logs

### DIFF
--- a/Anytype/Sources/CoreLayer/Sentry/DebugProfileSentryReporter.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/DebugProfileSentryReporter.swift
@@ -11,8 +11,15 @@ final class DebugProfileSentryReporter: DebugProfileSentryReporterProtocol {
     private static let log = EventLogger(category: "DebugProfileSentryReporter")
 
     func report(path: String, reasonTag: String, jsonInfo: String?, onCaptured: @Sendable () -> Void) {
-        let fileSize = (try? FileManager.default.attributesOfItem(atPath: path)[.size]) as? Int ?? 0
-        Self.log.debug("[MW_PROFILE] Report queued: reason=\(reasonTag), bytes=\(fileSize)")
+        // Use data-based attachment, not path-based: Sentry's transport reads
+        // path attachments lazily on its own queue, but the caller deletes the
+        // source file via `onCaptured`. Memory-map the read so we don't heap-copy
+        // a multi-MB zip during the very memory/thermal pressure event that
+        // produced it; the mapping stays valid even after the file is unlinked.
+        let url = path.isEmpty ? nil : URL(fileURLWithPath: path)
+        let attachmentData = url.flatMap { try? Data(contentsOf: $0, options: .mappedIfSafe) }
+        Self.log.debug("[MW_PROFILE] Report queued: reason=\(reasonTag), bytes=\(attachmentData?.count ?? 0)")
+
         let event = Event(level: .info)
         event.message = SentryMessage(formatted: "MW_\(reasonTag)")
         event.tags = ["report": "mw_profile", "reason": reasonTag]
@@ -27,16 +34,9 @@ final class DebugProfileSentryReporter: DebugProfileSentryReporterProtocol {
                     scope.setExtra(value: jsonInfo, key: "info")
                 }
             }
-            // Use data-based attachment, not path-based: Sentry's transport reads
-            // path attachments lazily on its own queue, but the caller deletes the
-            // source file via `onCaptured`. Memory-map the read so we don't heap-copy
-            // a multi-MB zip during the very memory/thermal pressure event that
-            // produced it; the mapping stays valid even after the file is unlinked.
-            if !path.isEmpty,
-               let data = try? Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe) {
-                let url = URL(fileURLWithPath: path)
+            if let url, let attachmentData {
                 scope.addAttachment(Attachment(
-                    data: data,
+                    data: attachmentData,
                     filename: url.lastPathComponent,
                     contentType: url.debugProfileContentType
                 ))

--- a/Anytype/Sources/CoreLayer/Sentry/DebugProfileSentryReporter.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/DebugProfileSentryReporter.swift
@@ -1,12 +1,18 @@
 import Foundation
 import Sentry
+import Logger
 
 protocol DebugProfileSentryReporterProtocol: Sendable {
     func report(path: String, reasonTag: String, jsonInfo: String?, onCaptured: @Sendable () -> Void)
 }
 
 final class DebugProfileSentryReporter: DebugProfileSentryReporterProtocol {
+
+    private static let log = EventLogger(category: "DebugProfileSentryReporter")
+
     func report(path: String, reasonTag: String, jsonInfo: String?, onCaptured: @Sendable () -> Void) {
+        let fileSize = (try? FileManager.default.attributesOfItem(atPath: path)[.size]) as? Int ?? 0
+        Self.log.debug("[MW_PROFILE] Report queued: reason=\(reasonTag), bytes=\(fileSize)")
         let event = Event(level: .info)
         event.message = SentryMessage(formatted: "MW_\(reasonTag)")
         event.tags = ["report": "mw_profile", "reason": reasonTag]

--- a/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
@@ -65,6 +65,8 @@ actor MemoryPressureProfilerTrigger: MemoryPressureProfilerTriggerProtocol {
             await trigger(reason: .memoryPressure(.critical))
         } else if data.contains(.warning) {
             await trigger(reason: .memoryPressure(.warning))
+        } else if data.contains(.normal) {
+            await trigger(reason: .memoryPressure(.normal))
         }
     }
 

--- a/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
@@ -26,9 +26,13 @@ actor MemoryPressureProfilerTrigger: MemoryPressureProfilerTriggerProtocol {
     init() {}
 
     func startSubscription() async {
-        guard CoreEnvironment.targetType.isDebug else { return }
+        guard CoreEnvironment.targetType.isDebug else {
+            Self.log.debug("[MW_PROFILE] Memory pressure subscription skipped: not a debug-class build")
+            return
+        }
+        Self.log.debug("[MW_PROFILE] Memory pressure subscription started")
         let source = DispatchSource.makeMemoryPressureSource(
-            eventMask: [.warning, .critical],
+            eventMask: [.normal, .warning, .critical],
             queue: .global(qos: .utility)
         )
         source.setEventHandler { [weak self] in
@@ -52,7 +56,11 @@ actor MemoryPressureProfilerTrigger: MemoryPressureProfilerTriggerProtocol {
     }
 
     private func handleEventFire() async {
-        guard let data = source?.data else { return }
+        guard let data = source?.data else {
+            Self.log.debug("[MW_PROFILE] Memory pressure event fired but source.data was nil")
+            return
+        }
+        Self.log.debug("[MW_PROFILE] Memory pressure event fired: \(data.logName)")
         if data.contains(.critical) {
             await trigger(reason: .memoryPressure(.critical))
         } else if data.contains(.warning) {
@@ -63,18 +71,30 @@ actor MemoryPressureProfilerTrigger: MemoryPressureProfilerTriggerProtocol {
     private func trigger(reason: DebugProfilerReason) async {
         let instant = ContinuousClock.now
         if let lastTrigger, lastTrigger.duration(to: instant) < Self.cooldown {
-            Self.log.debug("Profiler skipped (cooldown): \(reason)")
+            Self.log.debug("[MW_PROFILE] Memory profiler skipped (cooldown): \(reason)")
             return
         }
         lastTrigger = instant
-        Self.log.debug("Profiler triggered: \(reason)")
+        Self.log.debug("[MW_PROFILE] Memory profiler triggered: \(reason)")
         guard let path = await debugService.runProfiler(durationInSeconds: 0, reason: reason) else {
+            Self.log.debug("[MW_PROFILE] Memory runProfiler returned nil for reason: \(reason)")
             return
         }
+        Self.log.debug("[MW_PROFILE] Memory runProfiler returned non-nil path for reason: \(reason)")
         sentryReporter.report(path: path, reasonTag: reason.tag, jsonInfo: nil) { [debugService] in
             Task {
+                Self.log.debug("[MW_PROFILE] Memory report handed to Sentry, cleaning up source files")
                 await debugService.cleanupReport(ts: Int(Date().timeIntervalSince1970))
             }
         }
+    }
+}
+
+private extension DispatchSource.MemoryPressureEvent {
+    var logName: String {
+        if contains(.critical) { return "critical" }
+        if contains(.warning) { return "warning" }
+        if contains(.normal) { return "normal" }
+        return "unknown(rawValue=\(rawValue))"
     }
 }

--- a/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
@@ -73,16 +73,16 @@ actor MemoryPressureProfilerTrigger: MemoryPressureProfilerTriggerProtocol {
     private func trigger(reason: DebugProfilerReason) async {
         let instant = ContinuousClock.now
         if let lastTrigger, lastTrigger.duration(to: instant) < Self.cooldown {
-            Self.log.debug("[MW_PROFILE] Memory profiler skipped (cooldown): \(reason)")
+            Self.log.debug("[MW_PROFILE] Memory profiler skipped (cooldown): \(reason.tag)")
             return
         }
         lastTrigger = instant
-        Self.log.debug("[MW_PROFILE] Memory profiler triggered: \(reason)")
+        Self.log.debug("[MW_PROFILE] Memory profiler triggered: \(reason.tag)")
         guard let path = await debugService.runProfiler(durationInSeconds: 0, reason: reason) else {
-            Self.log.debug("[MW_PROFILE] Memory runProfiler returned nil for reason: \(reason)")
+            Self.log.debug("[MW_PROFILE] Memory runProfiler returned nil for reason: \(reason.tag)")
             return
         }
-        Self.log.debug("[MW_PROFILE] Memory runProfiler returned non-nil path for reason: \(reason)")
+        Self.log.debug("[MW_PROFILE] Memory runProfiler returned non-nil path for reason: \(reason.tag)")
         sentryReporter.report(path: path, reasonTag: reason.tag, jsonInfo: nil) { [debugService] in
             Task {
                 Self.log.debug("[MW_PROFILE] Memory report handed to Sentry, cleaning up source files")

--- a/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
@@ -27,7 +27,15 @@ actor ThermalProfilerTrigger: ThermalProfilerTriggerProtocol {
     init() {}
 
     func startSubscription() async {
-        guard CoreEnvironment.targetType.isDebug else { return }
+        guard CoreEnvironment.targetType.isDebug else {
+            Self.log.debug("[MW_PROFILE] Thermal subscription skipped: not a debug-class build")
+            return
+        }
+        // Apple requires reading `thermalState` before registering the observer,
+        // otherwise `thermalStateDidChangeNotification` is never delivered.
+        // https://developer.apple.com/documentation/foundation/processinfo/thermalstatedidchangenotification
+        let initialState = ProcessInfo.processInfo.thermalState
+        Self.log.debug("[MW_PROFILE] Thermal subscription started, initial state: \(String(describing: initialState))")
         let token = NotificationCenter.default.addObserver(
             forName: ProcessInfo.thermalStateDidChangeNotification,
             object: nil,
@@ -50,6 +58,7 @@ actor ThermalProfilerTrigger: ThermalProfilerTriggerProtocol {
 
     private func handleThermalChange() async {
         let state = ProcessInfo.processInfo.thermalState
+        Self.log.debug("[MW_PROFILE] Thermal state changed: \(String(describing: state))")
         switch state {
         case .serious:
             await trigger(reason: .thermalState(.serious))
@@ -63,16 +72,19 @@ actor ThermalProfilerTrigger: ThermalProfilerTriggerProtocol {
     private func trigger(reason: DebugProfilerReason) async {
         let instant = ContinuousClock.now
         if let lastTrigger, lastTrigger.duration(to: instant) < Self.cooldown {
-            Self.log.debug("Profiler skipped (cooldown): \(reason)")
+            Self.log.debug("[MW_PROFILE] Thermal profiler skipped (cooldown): \(reason)")
             return
         }
         lastTrigger = instant
-        Self.log.debug("Profiler triggered: \(reason)")
+        Self.log.debug("[MW_PROFILE] Thermal profiler triggered: \(reason)")
         guard let path = await debugService.runProfiler(durationInSeconds: Self.profileDuration, reason: reason) else {
+            Self.log.debug("[MW_PROFILE] Thermal runProfiler returned nil for reason: \(reason)")
             return
         }
+        Self.log.debug("[MW_PROFILE] Thermal runProfiler returned non-nil path for reason: \(reason)")
         sentryReporter.report(path: path, reasonTag: reason.tag, jsonInfo: nil) { [debugService] in
             Task {
+                Self.log.debug("[MW_PROFILE] Thermal report handed to Sentry, cleaning up source files")
                 await debugService.cleanupReport(ts: Int(Date().timeIntervalSince1970))
             }
         }

--- a/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
@@ -60,6 +60,8 @@ actor ThermalProfilerTrigger: ThermalProfilerTriggerProtocol {
         let state = ProcessInfo.processInfo.thermalState
         Self.log.debug("[MW_PROFILE] Thermal state changed: \(String(describing: state))")
         switch state {
+        case .fair:
+            await trigger(reason: .thermalState(.fair))
         case .serious:
             await trigger(reason: .thermalState(.serious))
         case .critical:

--- a/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
@@ -74,16 +74,16 @@ actor ThermalProfilerTrigger: ThermalProfilerTriggerProtocol {
     private func trigger(reason: DebugProfilerReason) async {
         let instant = ContinuousClock.now
         if let lastTrigger, lastTrigger.duration(to: instant) < Self.cooldown {
-            Self.log.debug("[MW_PROFILE] Thermal profiler skipped (cooldown): \(reason)")
+            Self.log.debug("[MW_PROFILE] Thermal profiler skipped (cooldown): \(reason.tag)")
             return
         }
         lastTrigger = instant
-        Self.log.debug("[MW_PROFILE] Thermal profiler triggered: \(reason)")
+        Self.log.debug("[MW_PROFILE] Thermal profiler triggered: \(reason.tag)")
         guard let path = await debugService.runProfiler(durationInSeconds: Self.profileDuration, reason: reason) else {
-            Self.log.debug("[MW_PROFILE] Thermal runProfiler returned nil for reason: \(reason)")
+            Self.log.debug("[MW_PROFILE] Thermal runProfiler returned nil for reason: \(reason.tag)")
             return
         }
-        Self.log.debug("[MW_PROFILE] Thermal runProfiler returned non-nil path for reason: \(reason)")
+        Self.log.debug("[MW_PROFILE] Thermal runProfiler returned non-nil path for reason: \(reason.tag)")
         sentryReporter.report(path: path, reasonTag: reason.tag, jsonInfo: nil) { [debugService] in
             Task {
                 Self.log.debug("[MW_PROFILE] Thermal report handed to Sentry, cleaning up source files")

--- a/Modules/Services/Sources/Services/Debug/DebugService.swift
+++ b/Modules/Services/Sources/Services/Debug/DebugService.swift
@@ -17,11 +17,13 @@ public enum DebugProfilerReason: Sendable {
     case memoryPressure(MemorySeverity)
 
     public enum ThermalSeverity: Sendable {
+        case fair
         case serious
         case critical
     }
 
     public enum MemorySeverity: Sendable {
+        case normal
         case warning
         case critical
     }
@@ -29,8 +31,10 @@ public enum DebugProfilerReason: Sendable {
     var desc: String {
         switch self {
         case .userRequest: return "User request"
+        case .thermalState(.fair): return "iOS thermal state: fair"
         case .thermalState(.serious): return "iOS thermal state: serious"
         case .thermalState(.critical): return "iOS thermal state: critical"
+        case .memoryPressure(.normal): return "iOS memory pressure: normal"
         case .memoryPressure(.warning): return "iOS memory pressure: warning"
         case .memoryPressure(.critical): return "iOS memory pressure: critical"
         }
@@ -39,8 +43,10 @@ public enum DebugProfilerReason: Sendable {
     public var tag: String {
         switch self {
         case .userRequest: return "user_request"
+        case .thermalState(.fair): return "thermal_fair"
         case .thermalState(.serious): return "thermal_serious"
         case .thermalState(.critical): return "thermal_critical"
+        case .memoryPressure(.normal): return "memory_pressure_normal"
         case .memoryPressure(.warning): return "memory_pressure_warn"
         case .memoryPressure(.critical): return "memory_pressure_critical"
         }
@@ -237,8 +243,13 @@ private extension DebugProfilerReason {
     var protoReason: Anytype_Rpc.Debug.RunProfiler.Request.Reason {
         switch self {
         case .userRequest: return .userRequest
+        // Middleware protobuf enum is closed; .fair / .normal piggyback on
+        // .userRequest while the truth is preserved in `reasonDesc` and the
+        // Sentry `tag` string.
+        case .thermalState(.fair): return .userRequest
         case .thermalState(.serious): return .thermalSerious
         case .thermalState(.critical): return .thermalCritical
+        case .memoryPressure(.normal): return .userRequest
         case .memoryPressure(.warning): return .memoryPressureWarn
         case .memoryPressure(.critical): return .memoryPressureCritical
         }


### PR DESCRIPTION
## Summary
- Add `[MW_PROFILE]`-prefixed Pulse logs at every step of the thermal/memory pressure trigger pipeline (subscription start, OS event arrival, `runProfiler` outcome, Sentry handoff, cleanup). Visible via the in-app Pulse viewer on Nightly.
- Fix Apple-required pre-read of `ProcessInfo.thermalState` before registering the observer (without it, `thermalStateDidChangeNotification` is never delivered per Apple docs — original implementation was silently broken).
- Extend triggers to also fire on `.fair` thermal and `.normal` memory pressure (`.nominal` still skipped). New `DebugProfilerReason` severities map to `.userRequest` in the closed middleware protobuf enum; accurate `tag` / `desc` preserved for Sentry tags and middleware reports.