### PR TITLE
IOS-6250 Fix bullet list selection-stuck regression after style menu

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
@@ -165,7 +165,9 @@ final class EditorPageController: UIViewController {
     }
 
     override func setEditing(_ editing: Bool, animated: Bool) {
-        guard isEditing != editing else { return }
+        // collectionView.isEditing can be mutated outside this method;
+        // guard on both flags so any drift gets resynced.
+        guard isEditing != editing || collectionView.isEditing != editing else { return }
         super.setEditing(editing, animated: animated)
         collectionView.isEditing = editing
         bottomNavigationManager.multiselectActive(!editing)


### PR DESCRIPTION
## Summary
- After IOS-6189 added `guard isEditing != editing` to `EditorPageController.setEditing`, the style-menu dismiss path could no longer resync `collectionView.isEditing` because `endEditing()` flips it directly while `UIViewController.isEditing` stays `true` — leaving the empty-area tap recognizer permanently gated off.
- Relax the guard to also re-run when `collectionView.isEditing` has drifted out of sync with the target. Preserves the IOS-6189 crash fix (the `receiveOnMain` hop in `bindViewModel` still keeps `super.setEditing` off the FloatingPanel animation completion thread).
- Added a one-line WHY comment so the OR clause isn't later "cleaned up" as redundant.