### PR TITLE
IOS-6263 Install iOS platform on CI after Xcode setup

### DIFF
--- a/.github/workflows/branch_build.yaml
+++ b/.github/workflows/branch_build.yaml
@@ -38,6 +38,9 @@ jobs:
         with:
           xcode-version: '26.1'
 
+      - name: Install iOS Platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Download Middleware
         run: make setup-middle-ci
         env:

--- a/.github/workflows/dev_build.yaml
+++ b/.github/workflows/dev_build.yaml
@@ -39,6 +39,9 @@ jobs:
         with:
           xcode-version: '26.1'
 
+      - name: Install iOS Platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Download Middleware
         run: make setup-middle-ci
         env:

--- a/.github/workflows/ipa.yaml
+++ b/.github/workflows/ipa.yaml
@@ -32,6 +32,9 @@ jobs:
         with:
           xcode-version: '26.1'
 
+      - name: Install iOS Platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Download Middleware
         run: make setup-middle-ci
         env:

--- a/.github/workflows/license-checks.yml
+++ b/.github/workflows/license-checks.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           xcode-version: '26.1'
 
+      - name: Install iOS Platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Download Middleware
         run: make setup-middle-ci
         env:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           xcode-version: '26.1'
 
+      - name: Install iOS Platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Download Middleware
         run: make setup-middle-ci
         env:

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -37,6 +37,9 @@ jobs:
         with:
           xcode-version: '26.1'
 
+      - name: Install iOS Platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Download Middleware
         run: make setup-middle-ci
         env:

--- a/.github/workflows/test_fastlane_build.yaml
+++ b/.github/workflows/test_fastlane_build.yaml
@@ -30,6 +30,9 @@ jobs:
         with:
           xcode-version: '26.1'
 
+      - name: Install iOS Platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Download Middleware
         run: make setup-middle-ci
         env:

--- a/.github/workflows/update_cache.yaml
+++ b/.github/workflows/update_cache.yaml
@@ -30,6 +30,9 @@ jobs:
         with:
           xcode-version: '26.1'
 
+      - name: Install iOS Platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Download Middleware
         run: make setup-middle-ci
         env:


### PR DESCRIPTION
## Summary
- Cherry-pick of #5004 to release branch
- The `macos-26` runner image no longer bundles the iOS platform SDK with Xcode 26.1.1
- Added `xcodebuild -downloadPlatform iOS` step after Xcode setup in all 8 workflows