### PR TITLE
IOS-6250 Fix nested bullet list indentation jump on block insertion

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
@@ -84,8 +84,9 @@ final class EditorPageController: UIViewController {
     private let showHeader: Bool
     var viewModel: (any EditorPageViewModelProtocol)! {
         didSet {
-            viewModel.setupSubscriptions()
+            // Layout metadata must subscribe before model snapshot updates to avoid first-frame indentation fallback.
             layout.blockLayoutDetailsPublisher = viewModel.document.blockLayoutDetailsPublisher.receiveOnMain().eraseToAnyPublisher()
+            viewModel.setupSubscriptions()
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/FlowLayout/EditorCollectionFlowLayout.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/FlowLayout/EditorCollectionFlowLayout.swift
@@ -268,8 +268,14 @@ final class EditorCollectionFlowLayout: UICollectionViewLayout {
             }
         }
         
+        for newDetails in newLayoutDetailsDict.values {
+            guard blockLayoutDetails[newDetails.id] == nil,
+                  let layoutItem = cachedAttributes[newDetails.id] else { continue }
+            invalidationIndexPaths.append(layoutItem.indexPath)
+        }
+
         blockLayoutDetails = newLayoutDetailsDict
-        
+
         if invalidationIndexPaths.isNotEmpty {
             invalidateLayout(with: CustomInvalidation(indexPaths: invalidationIndexPaths))
         }


### PR DESCRIPTION
## Summary
- Swap subscription order in `EditorPageController.viewModel.didSet` so layout details publisher subscribes before the data source, ensuring `blockLayoutDetails` is populated before `prepare()` runs for new blocks
- Add new-block handling in `EditorCollectionFlowLayout.invalidateLayout` as a safety net — invalidates blocks that appear in the new layout dict but were absent from the old one