### PR TITLE
IOS-5994 Add feature toggle for thermal/memory pressure debug reporting

### DIFF
--- a/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/MemoryPressureProfilerTrigger.swift
@@ -26,6 +26,10 @@ actor MemoryPressureProfilerTrigger: MemoryPressureProfilerTriggerProtocol {
     init() {}
 
     func startSubscription() async {
+        guard FeatureFlags.pressureDebugReports else {
+            Self.log.debug("[MW_PROFILE] Memory pressure subscription skipped: toggle OFF")
+            return
+        }
         guard CoreEnvironment.targetType.isDebug else {
             Self.log.debug("[MW_PROFILE] Memory pressure subscription skipped: not a debug-class build")
             return

--- a/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
+++ b/Anytype/Sources/CoreLayer/Sentry/ThermalProfilerTrigger.swift
@@ -27,6 +27,10 @@ actor ThermalProfilerTrigger: ThermalProfilerTriggerProtocol {
     init() {}
 
     func startSubscription() async {
+        guard FeatureFlags.pressureDebugReports else {
+            Self.log.debug("[MW_PROFILE] Thermal subscription skipped: toggle OFF")
+            return
+        }
         guard CoreEnvironment.targetType.isDebug else {
             Self.log.debug("[MW_PROFILE] Thermal subscription skipped: not a debug-class build")
             return

--- a/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
@@ -114,6 +114,10 @@ public extension FeatureFlags {
         value(for: .showHangedObjects)
     }
 
+    static var pressureDebugReports: Bool {
+        value(for: .pressureDebugReports)
+    }
+
     // All toggles
     static let features: [FeatureDescription] = [
         .showUploadStatusIndicator,
@@ -142,6 +146,7 @@ public extension FeatureFlags {
         .logMiddlewareRequests,
         .showPushMessagesInForeground,
         .spaceHubAlwaysShowLoading,
-        .showHangedObjects
+        .showHangedObjects,
+        .pressureDebugReports
     ]
 }

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -176,4 +176,11 @@ public extension FeatureDescription {
         category: .developerTool,
         defaultValue: false
     )
+
+    static let pressureDebugReports = FeatureDescription(
+        title: "Detect thermal/memory pressure and send debug reports - IOS-5994",
+        category: .developerTool,
+        defaultValue: false,
+        debugValue: true
+    )
 }


### PR DESCRIPTION
## Summary
- Adds `pressureDebugReports` developer-tool feature toggle (`defaultValue: false` / `debugValue: true` → ON by default in debug builds, OFF in release).
- Gates `ThermalProfilerTrigger.startSubscription()` and `MemoryPressureProfilerTrigger.startSubscription()` on the toggle — when OFF, no observer / dispatch source is registered, so no detection, profiling, or Sentry upload occurs.
- Manual debug-menu triggering (`triggerManually`) is unaffected by design; `DebugProfileEventHandler` is left untouched.