### PR TITLE
IOS-6299 Add Copy Deeplink action to object menu

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectAction.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectAction.swift
@@ -13,6 +13,7 @@ enum ObjectAction: Hashable, Identifiable {
     case templateToggleDefaultState(isDefault: Bool)
     case delete
     case copyLink
+    case copyDeepLink
     case inviteMembers
     case editInfo
 
@@ -69,6 +70,8 @@ enum ObjectAction: Hashable, Identifiable {
                 ObjectAction.copyLink
             }
 
+            ObjectAction.copyDeepLink
+
             if details.resolvedLayoutValue.isChat && spaceType != .oneToOne && !details.isArchived {
                 if permissions.canEditDetails {
                     ObjectAction.editInfo
@@ -112,6 +115,8 @@ enum ObjectAction: Hashable, Identifiable {
             return "delete"
         case .copyLink:
             return "copyLink"
+        case .copyDeepLink:
+            return "copyDeepLink"
         case .inviteMembers:
             return "inviteMembers"
         case .editInfo:
@@ -137,6 +142,8 @@ enum ObjectAction: Hashable, Identifiable {
             return 22
         case .locked:
             return 30
+        case .copyDeepLink:
+            return 31
         case .inviteMembers:
             return 35
         case .copyLink:

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionRow.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectActions/ObjectActionRow.swift
@@ -71,6 +71,8 @@ extension ObjectAction {
             return Loc.delete
         case .copyLink:
             return Loc.copyInviteLink
+        case .copyDeepLink:
+            return Loc.copyDeeplink
         case .inviteMembers:
             return Loc.Chat.inviteMembers
         case .editInfo:
@@ -102,6 +104,8 @@ extension ObjectAction {
             return .X32.delete
         case .copyLink:
             return .X32.copy
+        case .copyDeepLink:
+            return .X32.linkTo
         case .inviteMembers:
             return .X32.Island.addMember
         case .editInfo:
@@ -123,6 +127,8 @@ extension ObjectAction {
             return .system("star.fill")
         case .copyLink:
             return .system("link")
+        case .copyDeepLink:
+            return .system("point.topleft.down.to.point.bottomright.curvepath")
         case .archive(false):
             return .system("trash")
         default:

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
@@ -4,6 +4,7 @@ import UIKit
 import FloatingPanel
 import SwiftUI
 import AnytypeCore
+import DeepLinks
 
 enum ObjectSettingsAction {
     case cover(ObjectCoverPickerAction)
@@ -59,6 +60,8 @@ final class ObjectSettingsViewModel {
     private var workspaceStorage: any SpaceViewsStorageProtocol
     @Injected(\.universalLinkParser) @ObservationIgnored
     private var universalLinkParser: any UniversalLinkParserProtocol
+    @Injected(\.deepLinkParser) @ObservationIgnored
+    private var deepLinkParser: any DeepLinkParserProtocol
     @Injected(\.workspaceService) @ObservationIgnored
     private var workspaceService: any WorkspaceServiceProtocol
     @Injected(\.participantSpacesStorage) @ObservationIgnored
@@ -397,6 +400,19 @@ final class ObjectSettingsViewModel {
 
         let invite = try? await workspaceService.getCurrentInvite(spaceId: details.spaceId)
         let link = universalLinkParser.createUrl(link: .object(objectId: details.id, spaceId: details.spaceId, cid: invite?.cid, key: invite?.fileKey))
+
+        UIPasteboard.general.string = link?.absoluteString
+        toastData = ToastBarData(Loc.copied)
+        dismiss.toggle()
+    }
+
+    func copyDeepLinkAction() async throws {
+        guard let details = document.details else { return }
+
+        let link = deepLinkParser.createUrl(
+            deepLink: .object(objectId: details.id, spaceId: details.spaceId, cid: nil, key: nil),
+            scheme: .main
+        )
 
         UIPasteboard.general.string = link?.absoluteString
         toastData = ToastBarData(Loc.copied)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/Models/ObjectMenuSectionType.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/Models/ObjectMenuSectionType.swift
@@ -30,7 +30,7 @@ extension ObjectMenuSectionType {
             return .mainSettings
         case .undoRedo, .copyLink, .inviteMembers:
             return .mainSettings
-        case .linkItself, .locked, .makeAsTemplate:
+        case .linkItself, .locked, .makeAsTemplate, .copyDeepLink:
             return .moreCollapsible
         case .templateToggleDefaultState, .duplicate, .archive, .delete:
             return .finalActions

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/ObjectSettingsMenuViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettingsMenu/ObjectSettingsMenuViewModel.swift
@@ -155,6 +155,8 @@ final class ObjectSettingsMenuViewModel {
             try? await viewModel.deleteAction()
         case .copyLink:
             try? await viewModel.copyLinkAction()
+        case .copyDeepLink:
+            try? await viewModel.copyDeepLinkAction()
         case .inviteMembers:
             viewModel.inviteMembersAction()
         case .editInfo:

--- a/Modules/DeepLinks/Sources/DeepLinks/DeepLinkParser.swift
+++ b/Modules/DeepLinks/Sources/DeepLinks/DeepLinkParser.swift
@@ -114,12 +114,17 @@ final class DeepLinkParser: DeepLinkParserProtocol, Sendable {
             return components.url
         case let .object(objectId, spaceId, cid, key):
             guard var components = URLComponents(string: host + LinkPaths.object) else { return nil }
-            components.queryItems = [
+            var queryItems = [
                 URLQueryItem(name: "objectId", value: objectId),
-                URLQueryItem(name: "spaceId", value: spaceId),
-                URLQueryItem(name: "cid", value: cid),
-                URLQueryItem(name: "key", value: key)
+                URLQueryItem(name: "spaceId", value: spaceId)
             ]
+            if let cid {
+                queryItems.append(URLQueryItem(name: "cid", value: cid))
+            }
+            if let key {
+                queryItems.append(URLQueryItem(name: "key", value: key))
+            }
+            components.queryItems = queryItems
             return components.url
         case let .chatMessage(chatObjectId, spaceId, messageId):
             guard var components = URLComponents(string: host + LinkPaths.object) else { return nil }

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -272,6 +272,7 @@ public enum Loc {
     return Loc.tr("UI", "copied to clipboard", String(describing: p1), fallback: "%@ copied to clipboard")
   }
   public static let copy = Loc.tr("UI", "Copy", fallback: "Copy")
+  public static let copyDeeplink = Loc.tr("UI", "Copy Deeplink", fallback: "Copy Deeplink")
   public static let copyInviteLink = Loc.tr("UI", "Copy Invite Link", fallback: "Copy Invite Link")
   public static let copyLink = Loc.tr("UI", "Copy link", fallback: "Copy link")
   public static let copySpaceInfo = Loc.tr("UI", "Copy space info", fallback: "Copy space info")

--- a/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
@@ -22123,6 +22123,17 @@
         }
       }
     },
+    "Copy Deeplink" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Deeplink"
+          }
+        }
+      }
+    },
     "Copy link" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
## Summary
- Adds a **Copy Deeplink** action to the object three-dots menu (inside the **More** submenu, last row) that copies an invite-free `anytype://object?objectId=…&spaceId=…` deep link to the pasteboard.
- Fixes `DeepLinkParser.createUrl(.object)` to omit `cid`/`key` query items when nil, instead of emitting empty `…&cid&key` params.
- Available across editor / set / collection / object type pages; the action is intentionally ungated (a local deep link is freely copyable).

Linear: IOS-6299
