### PR TITLE
IOS-6309 Fix CI: install iOS platform, setup-env for cache, retry downloadPlatform

### DIFF
--- a/.github/actions/install-ios-platform/action.yml
+++ b/.github/actions/install-ios-platform/action.yml
@@ -1,0 +1,17 @@
+name: Install iOS Platform
+# Downloads the iOS simulator runtime matching the pinned Xcode SDK. Without this the
+# runner may only have a newer runtime, and build-for-testing fails to resolve a simulator
+# destination ("iOS XX.Y is not installed").
+# Retries because -downloadPlatform intermittently fails with "Unable to connect to
+# simulator" on fresh runners.
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        for i in 1 2 3; do
+          xcodebuild -downloadPlatform iOS && exit 0
+          echo "downloadPlatform attempt $i failed; retrying in 30s..."
+          sleep 30
+        done
+        exit 1

--- a/.github/workflows/dev_build.yaml
+++ b/.github/workflows/dev_build.yaml
@@ -40,7 +40,7 @@ jobs:
           xcode-version: '26.1'
 
       - name: Install iOS Platform
-        run: xcodebuild -downloadPlatform iOS
+        uses: ./.github/actions/install-ios-platform
 
       - name: Download Middleware
         run: make setup-middle-ci

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -35,7 +35,7 @@ jobs:
           xcode-version: '26.1'
 
       - name: Install iOS Platform
-        run: xcodebuild -downloadPlatform iOS
+        uses: ./.github/actions/install-ios-platform
 
       - name: Download Middleware
         run: make setup-middle-ci

--- a/.github/workflows/update_cache.yaml
+++ b/.github/workflows/update_cache.yaml
@@ -31,7 +31,7 @@ jobs:
           xcode-version: '26.1'
 
       - name: Install iOS Platform
-        run: xcodebuild -downloadPlatform iOS
+        uses: ./.github/actions/install-ios-platform
 
       - name: Download Middleware
         run: make setup-middle-ci
@@ -39,7 +39,7 @@ jobs:
           MIDDLEWARE_TOKEN: ${{ secrets.MIDDLEWARE_TOKEN }}
 
       - name: Build tools
-        run: make setup-tools
+        run: make setup-env
 
       - name: Update build cache
         run: bundle exec fastlane build_for_tests

--- a/.github/workflows/update_middleware.yaml
+++ b/.github/workflows/update_middleware.yaml
@@ -107,6 +107,9 @@ jobs:
         with:
           xcode-version: '26.1'
 
+      - name: Install iOS Platform
+        uses: ./.github/actions/install-ios-platform
+
       # Install required development tools (e.g., SwiftGen, Sourcery)
       - name: Setup tools
         run: make setup-env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Privacy-focused, local-first workspace for iOS. Swift + SwiftUI + Custom Middlew
 
 ## 🚀 Quick Start
 ```bash
-make setup-env && make setup-tools && make setup-middle  # First time
+make setup-env && make setup-middle  # First time
 make generate                                             # After any asset/flag/localization change
 ```
 **Requirements**: Xcode 16.1+, Swift Package Manager


### PR DESCRIPTION
## Summary
- Add `Install iOS Platform` step to `update_middleware.yaml` (and its nightly caller) — build-for-testing was failing with "iOS XX.Y is not installed" because the runner only had a newer simulator runtime than the pinned Xcode SDK.
- Fix `update_cache.yaml` to run `make setup-env` instead of the nonexistent `make setup-tools` target.
- Extract the iOS-platform download into a shared composite action `./.github/actions/install-ios-platform` with a 3× retry to absorb transient "Unable to connect to simulator" flakes; reused across the middleware, cache, dev-build, and PR-test workflows.
- Drop the stale `make setup-tools` from CLAUDE.md first-time setup.

Cherry-pick of the same fixes shipped to `release` in #5012.