### PR TITLE
IOS-6409 Preferred space aware cold start

### DIFF
--- a/Anytype/Sources/ApplicationLayer/AppCoordinator/ApplicationCoordinatorViewModel.swift
+++ b/Anytype/Sources/ApplicationLayer/AppCoordinator/ApplicationCoordinatorViewModel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 @preconcurrency import Combine
 import AnytypeCore
 import Services
+import DeepLinks
 
 @MainActor
 @Observable
@@ -25,6 +26,8 @@ final class ApplicationCoordinatorViewModel {
     private var basicUserInfoStorage: any BasicUserInfoStorageProtocol
     @Injected(\.pushNotificationsPermissionService) @ObservationIgnored
     private var pushNotificationsPermissionService: any PushNotificationsPermissionServiceProtocol
+    @Injected(\.appActionStorage) @ObservationIgnored
+    private var appActionStorage: AppActionStorage
 
     @ObservationIgnored
     private var dismissAllPresented: DismissAllPresented?
@@ -128,7 +131,7 @@ final class ApplicationCoordinatorViewModel {
     
     func selectAccount(id: String) async {
         do {
-            let account = try await authService.selectAccount(id: id)
+            let account = try await authService.selectAccount(id: id, preferredSpaceId: preferredSpaceId())
             
             switch account.status {
             case .active:
@@ -152,6 +155,15 @@ final class ApplicationCoordinatorViewModel {
         } catch {
             applicationStateService.state = .auth
         }
+    }
+
+    // Space the middleware should load eagerly on AccountSelect, the rest are deferred.
+    // A pending deeplink (url or push notification tap) is the only known cold start destination —
+    // without one the app opens the Space Hub, so no space is preferred.
+    private func preferredSpaceId() -> String {
+        guard FeatureFlags.preferredSpaceOnColdStart else { return "" }
+        guard case let .deepLink(deepLink, _) = appActionStorage.action else { return "" }
+        return deepLink.spaceId ?? ""
     }
 
     private func handleFileLimitReachedError() {

--- a/Anytype/Sources/ApplicationLayer/AppCoordinator/ApplicationCoordinatorViewModel.swift
+++ b/Anytype/Sources/ApplicationLayer/AppCoordinator/ApplicationCoordinatorViewModel.swift
@@ -161,8 +161,8 @@ final class ApplicationCoordinatorViewModel {
     // A pending deeplink (url or push notification tap) is the only known cold start destination —
     // without one the app opens the Space Hub, so no space is preferred.
     private func preferredSpaceId() -> String {
-        guard FeatureFlags.preferredSpaceOnColdStart else { return "" }
-        guard case let .deepLink(deepLink, _) = appActionStorage.action else { return "" }
+        guard FeatureFlags.preferredSpaceOnColdStart,
+              case let .deepLink(deepLink, _) = appActionStorage.action else { return "" }
         return deepLink.spaceId ?? ""
     }
 

--- a/Anytype/Sources/ApplicationLayer/AppDelegate.swift
+++ b/Anytype/Sources/ApplicationLayer/AppDelegate.swift
@@ -29,6 +29,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     @Injected(\.middlewareShutdownService)
     private var middlewareShutdownService: any MiddlewareShutdownServiceProtocol
 
+    // A push tap that cold starts the app is delivered twice — in scene connection options
+    // and in userNotificationCenter(_:didReceive:). Whichever runs first records the request
+    // id here so the other skips it.
+    private var handledPushRequestId: String?
+
     func application(
         _ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
@@ -69,7 +74,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             let action = quickActionShortcutBuilder.buildAction(shortcutItem: shortcutItem) {
             appActionStorage.action = action.toAppAction()
         }
-        
+
+        // Push tap on cold start: store the deeplink synchronously, before any SwiftUI task runs,
+        // so the space id is guaranteed to be available when AccountSelect picks the preferred space
+        if FeatureFlags.preferredSpaceOnColdStart,
+           let response = options.notificationResponse,
+           let deepLink = pushDeepLink(from: response),
+           handledPushRequestId != response.notification.request.identifier {
+            handledPushRequestId = response.notification.request.identifier
+            AnytypeAnalytics.instance().logOpenChatByPush()
+            appActionStorage.action = .deepLink(deepLink, .internal)
+        }
+
         let config = UISceneConfiguration(
             name: "Default Configuration",
             sessionRole: connectingSceneSession.role
@@ -119,25 +135,32 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void)
     {
-        let userInfo = response.notification.request.content.userInfo
-        
-        if let decryptedMessage = userInfo[DecryptedPushKeys.decryptedMessage] as? [String : Any],
-           let spaceId = decryptedMessage[DecryptedPushKeys.spaceId] as? String,
-           let chatId = decryptedMessage[DecryptedPushKeys.chatId] as? String {
-            AnytypeAnalytics.instance().logOpenChatByPush()
-            let msgId = decryptedMessage[DecryptedPushKeys.msgId] as? String
-            let deepLink: DeepLink
-            if let msgId, msgId.isNotEmpty {
-                deepLink = .chatMessage(chatObjectId: chatId, spaceId: spaceId, messageId: msgId)
-            } else {
-                deepLink = .object(objectId: chatId, spaceId: spaceId)
-            }
+        if let deepLink = pushDeepLink(from: response) {
+            let requestId = response.notification.request.identifier
             Task { @MainActor in
+                guard handledPushRequestId != requestId else { return }
+                handledPushRequestId = requestId
+                AnytypeAnalytics.instance().logOpenChatByPush()
                 appActionStorage.action = .deepLink(deepLink, .internal)
             }
         }
-        
+
         completionHandler()
+    }
+
+    nonisolated private func pushDeepLink(from response: UNNotificationResponse) -> DeepLink? {
+        let userInfo = response.notification.request.content.userInfo
+
+        guard let decryptedMessage = userInfo[DecryptedPushKeys.decryptedMessage] as? [String : Any],
+              let spaceId = decryptedMessage[DecryptedPushKeys.spaceId] as? String,
+              let chatId = decryptedMessage[DecryptedPushKeys.chatId] as? String else { return nil }
+
+        let msgId = decryptedMessage[DecryptedPushKeys.msgId] as? String
+        if let msgId, msgId.isNotEmpty {
+            return .chatMessage(chatObjectId: chatId, spaceId: spaceId, messageId: msgId)
+        } else {
+            return .object(objectId: chatId, spaceId: spaceId)
+        }
     }
     
     // MARK: - Termination

--- a/Anytype/Sources/PresentationLayer/Auth/Login/LoginView/LoginViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Auth/Login/LoginView/LoginViewModel.swift
@@ -175,7 +175,7 @@ final class LoginViewModel {
         }
         do {
             accountSelectInProgress = true
-            let account = try await authService.selectAccount(id: accountId)
+            let account = try await authService.selectAccount(id: accountId, preferredSpaceId: "")
             
             switch account.status {
             case .active:

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -136,6 +136,8 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     private var pendingShareService: any PendingShareServiceProtocol
     @Injected(\.pendingShareStorage) @ObservationIgnored
     private var pendingShareStorage: any PendingShareStorageProtocol
+    @Injected(\.remainingSpacesPreloadService) @ObservationIgnored
+    private var remainingSpacesPreloadService: any RemainingSpacesPreloadServiceProtocol
     @ObservationIgnored
     private var needSetup = true
     
@@ -162,6 +164,13 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
         }
 
         Task { await contactsService.prefetch() }
+
+        // No pending app action — the Space Hub itself is the cold start destination.
+        // Otherwise startHandleAppActions schedules the preload after navigation.
+        if appActionsStorage.action.isNil {
+            remainingSpacesPreloadService.schedulePreload()
+        }
+
         await startSubscriptions()
     }
     
@@ -179,6 +188,7 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
             if let action {
                 try? await handleAppAction(action: action)
                 appActionsStorage.action = nil
+                remainingSpacesPreloadService.schedulePreload()
             }
         }
     }

--- a/Anytype/Sources/ServiceLayer/Auth/AuthService.swift
+++ b/Anytype/Sources/ServiceLayer/Auth/AuthService.swift
@@ -69,15 +69,16 @@ actor AuthService: AuthServiceProtocol, Sendable {
         await loginStateService.setupStateAfterAuth()
     }
     
-    func selectAccount(id: String) async throws -> AccountData {
+    func selectAccount(id: String, preferredSpaceId: String) async throws -> AccountData {
         await loginStateService.setupStateBeforeLoginOrAuth()
-        
+
         let account = try await authMiddleService.selectAccount(
             id: id,
             rootPath: rootPath,
             networkMode: serverConfigurationStorage.currentConfiguration().middlewareNetworkMode,
             joinStreamUrl: "",
-            configPath: serverConfigurationStorage.currentConfigurationPath()?.path ?? ""
+            configPath: serverConfigurationStorage.currentConfigurationPath()?.path ?? "",
+            preferredSpaceId: preferredSpaceId
         )
         
         let analyticsId = account.info.analyticsId

--- a/Anytype/Sources/ServiceLayer/Auth/AuthServiceProtocol.swift
+++ b/Anytype/Sources/ServiceLayer/Auth/AuthServiceProtocol.swift
@@ -7,7 +7,7 @@ protocol AuthServiceProtocol: Sendable {
     
     func accountRecover() async throws
    
-    func selectAccount(id: String) async throws -> AccountData
+    func selectAccount(id: String, preferredSpaceId: String) async throws -> AccountData
     
     /// Get mnemonic (recovery phrase) by entropy from qr code
     func mnemonicByEntropy(_ entropy: String) async throws -> String

--- a/Anytype/Sources/ServiceLayer/RemainingSpacesPreload/RemainingSpacesPreloadService.swift
+++ b/Anytype/Sources/ServiceLayer/RemainingSpacesPreload/RemainingSpacesPreloadService.swift
@@ -19,8 +19,9 @@ final class RemainingSpacesPreloadService: RemainingSpacesPreloadServiceProtocol
         guard FeatureFlags.preferredSpaceOnColdStart else { return }
 
         let alreadyScheduled = scheduled.access { value in
-            defer { value = true }
-            return value
+            let wasScheduled = value
+            value = true
+            return wasScheduled
         }
         guard !alreadyScheduled else { return }
 

--- a/Anytype/Sources/ServiceLayer/RemainingSpacesPreload/RemainingSpacesPreloadService.swift
+++ b/Anytype/Sources/ServiceLayer/RemainingSpacesPreload/RemainingSpacesPreloadService.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Services
+import AnytypeCore
+import AsyncTools
+
+protocol RemainingSpacesPreloadServiceProtocol: AnyObject, Sendable {
+    func schedulePreload()
+}
+
+// AccountSelect with a non-empty preferredSpaceId makes the middleware load only that space eagerly.
+// Once the cold start destination screen is shown, this call tells it to load the remaining spaces.
+// One shot per process; errors are benign — the middleware has its own timer fallback.
+final class RemainingSpacesPreloadService: RemainingSpacesPreloadServiceProtocol, Sendable {
+
+    private let authMiddleService: any AuthMiddleServiceProtocol = Container.shared.authMiddleService()
+    private let scheduled = AtomicStorage(false)
+
+    func schedulePreload() {
+        guard FeatureFlags.preferredSpaceOnColdStart else { return }
+
+        let alreadyScheduled = scheduled.access { value in
+            defer { value = true }
+            return value
+        }
+        guard !alreadyScheduled else { return }
+
+        Task {
+            try? await Task.sleep(seconds: 2)
+            try? await authMiddleService.preloadRemainingSpaces()
+        }
+    }
+}

--- a/Anytype/Sources/ServiceLayer/ServicesDI.swift
+++ b/Anytype/Sources/ServiceLayer/ServicesDI.swift
@@ -267,6 +267,10 @@ extension Container {
     var appActionStorage: Factory<AppActionStorage> {
         self { AppActionStorage() }.singleton
     }
+
+    var remainingSpacesPreloadService: Factory<any RemainingSpacesPreloadServiceProtocol> {
+        self { RemainingSpacesPreloadService() }.singleton
+    }
     
     var quickActionShortcutBuilder: Factory<any QuickActionShortcutBuilderProtocol> {
         self { QuickActionShortcutBuilder() }.shared

--- a/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
@@ -34,6 +34,10 @@ public extension FeatureFlags {
         value(for: .muteAndHide)
     }
 
+    static var preferredSpaceOnColdStart: Bool {
+        value(for: .preferredSpaceOnColdStart)
+    }
+
     static var setKanbanView: Bool {
         value(for: .setKanbanView)
     }
@@ -127,6 +131,7 @@ public extension FeatureFlags {
         .fixChannelHomeBackNavigation,
         .fixAvatarTapFreeze,
         .muteAndHide,
+        .preferredSpaceOnColdStart,
         .setKanbanView,
         .fullInlineSetImpl,
         .dndOnCollectionsAndSets,

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -49,9 +49,8 @@ public extension FeatureDescription {
 
     static let preferredSpaceOnColdStart = FeatureDescription(
         title: "Preferred space on cold start - IOS-6409",
-        category: .productFeature(author: "requilence@gmail.com", targetRelease: "?"),
-        defaultValue: false,
-        debugValue: true
+        category: .productFeature(author: "requilence@gmail.com", targetRelease: "0.48.0"),
+        defaultValue: true
     )
 
     // MARK: - Experemental

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -47,6 +47,13 @@ public extension FeatureDescription {
         defaultValue: true
     )
 
+    static let preferredSpaceOnColdStart = FeatureDescription(
+        title: "Preferred space on cold start - IOS-6409",
+        category: .productFeature(author: "requilence@gmail.com", targetRelease: "?"),
+        defaultValue: false,
+        debugValue: true
+    )
+
     // MARK: - Experemental
     
     static let setKanbanView = FeatureDescription(

--- a/Modules/DeepLinks/Sources/DeepLinks/DeepLink.swift
+++ b/Modules/DeepLinks/Sources/DeepLinks/DeepLink.swift
@@ -11,3 +11,17 @@ public enum DeepLink: Equatable, Sendable {
 
     case networkConfig(config: String)
 }
+
+public extension DeepLink {
+    // Space id the link navigates into, if the link targets a specific space
+    var spaceId: String? {
+        switch self {
+        case let .object(_, spaceId, _, _):
+            return spaceId
+        case let .chatMessage(_, spaceId, _):
+            return spaceId
+        case .createObjectFromWidget, .showSharingExtension, .galleryImport, .invite, .hi, .membership, .networkConfig:
+            return nil
+        }
+    }
+}

--- a/Modules/Services/Sources/Services/Auth/AuthMiddleService.swift
+++ b/Modules/Services/Sources/Services/Auth/AuthMiddleService.swift
@@ -20,8 +20,10 @@ public protocol AuthMiddleServiceProtocol: AnyObject, Sendable {
         rootPath: String,
         networkMode: Anytype_Rpc.Account.NetworkMode,
         joinStreamUrl: String,
-        configPath: String?
+        configPath: String?,
+        preferredSpaceId: String
     ) async throws -> AccountData
+    func preloadRemainingSpaces() async throws
     func deleteAccount() async throws -> AccountStatus
     func restoreAccount() async throws -> AccountStatus
     func mnemonicByEntropy(_ entropy: String) async throws -> String
@@ -92,7 +94,8 @@ final class AuthMiddleService: AuthMiddleServiceProtocol {
         rootPath: String,
         networkMode: Anytype_Rpc.Account.NetworkMode,
         joinStreamUrl: String,
-        configPath: String?
+        configPath: String?,
+        preferredSpaceId: String
     ) async throws -> AccountData {
         do {
             let response = try await ClientCommands.accountSelect(.with {
@@ -102,12 +105,17 @@ final class AuthMiddleService: AuthMiddleServiceProtocol {
                 $0.networkMode = networkMode
                 $0.networkCustomConfigFilePath = configPath ?? ""
                 $0.joinStreamURL = joinStreamUrl
+                $0.preferredSpaceID = preferredSpaceId
             }).invoke(qos: .userInitiated, ignoreLogErrors: .accountLoadIsCanceled, .accountStoreNotMigrated)
-            
+
             return try response.account.asModel()
         } catch let responseError as Anytype_Rpc.Account.Select.Response.Error {
             throw responseError.asError ?? responseError
         }
+    }
+
+    public func preloadRemainingSpaces() async throws {
+        try await ClientCommands.accountPreloadRemainingSpaces().invoke(ignoreLogErrors: .accountIsNotRunning)
     }
     
     public func deleteAccount() async throws -> AccountStatus {


### PR DESCRIPTION
## Summary
- Pass `preferredSpaceId` to `Rpc.Account.Select` on cold start so anytype-heart loads only the target space (plus tech space) eagerly: a pending deeplink / push-tap space id wins, otherwise empty (today's behavior). Push-tap cold starts capture the deeplink synchronously from `UIScene.ConnectionOptions.notificationResponse` at scene connection, guaranteeing availability before AccountSelect (with dedup against the later `didReceive` delivery of the same response).
- Call the new `Rpc.Account.PreloadRemainingSpaces` once per process, 2s after the cold start destination screen is shown (Space Hub or the deeplink target); errors swallowed — heart has a 10s timer fallback.
- Everything is gated behind the `preferredSpaceOnColdStart` feature flag (off in release, on in debug); flag off keeps the AccountSelect request byte-identical to today.