### PR TITLE
IOS-0000 Picture cover option for Gallery views + remove bookmark auto-fallback

### DIFF
--- a/AnyTypeTests/Services/SetContentViewDataBuilderTests.swift
+++ b/AnyTypeTests/Services/SetContentViewDataBuilderTests.swift
@@ -199,6 +199,34 @@ struct SetContentViewDataBuilderTests {
         #expect(result != nil)
         #expect(result?.chatId == targetId)
     }
+
+    @Test("Bookmark with picture property returns picture as cover")
+    func testBookmarkWithPicture_ReturnsPictureCover() {
+        // 1. Object has bookmark layout
+        // 2. Picture property is not empty
+        // 3. Picture object exists in storage and is an image
+        // Result: Should return .cover(.imageId(pictureId))
+        
+        #expect(true, "Bookmark picture cover logic is implemented")
+    }
+
+    @Test("Bookmark with invalid picture reference returns nil")
+    func testBookmarkWithInvalidPicture_ReturnsNil() {
+        
+        #expect(true, "Invalid picture references are handled safely")
+    }
+
+    @Test("Explicit cover takes precedence over bookmark picture")
+    func testExplicitCover_TakesPrecedence() {
+        // Cover priority order:
+        // 1. Explicit page cover (highest)
+        // 2. Image layout objects
+        // 3. Bookmark picture
+        // 4. Relation-based cover
+        // Result: If explicit cover is set, bookmark picture is not used
+        
+        #expect(true, "Cover priority order is maintained")
+    }
 }
 
 extension ObjectDetails {

--- a/AnyTypeTests/Services/SetContentViewDataBuilderTests.swift
+++ b/AnyTypeTests/Services/SetContentViewDataBuilderTests.swift
@@ -208,31 +208,19 @@ struct SetContentViewDataBuilderTests {
     func testPictureCover_ImageInStorage_ReturnsImageCover() {
         let pictureId = "picture-image-1"
         let storage = ObjectDetailsStorage()
-        storage.add(details: makeObject(id: pictureId, layout: .image))
-        let object = makeObject(id: "bookmark-1", layout: .bookmark, picture: pictureId)
+        storage.add(details: .mock(id: pictureId, layout: .image))
+        let object = ObjectDetails.mock(id: "bookmark-1", layout: .bookmark, picture: pictureId)
 
-        let result = builder.coverType(
-            object,
-            dataView: BlockDataview(),
-            activeView: galleryView(coverRelationKey: SetViewSettingsImagePreviewCover.picture.rawValue),
-            spaceId: spaceId,
-            detailsStorage: storage
-        )
+        let result = cover(for: object, coverKey: SetViewSettingsImagePreviewCover.picture.rawValue, storage: storage)
 
         #expect(result == .cover(.imageId(pictureId)))
     }
 
     @Test("Picture cover returns nil when the picture property is empty")
     func testPictureCover_EmptyPicture_ReturnsNil() {
-        let object = makeObject(id: "bookmark-1", layout: .bookmark)
+        let object = ObjectDetails.mock(id: "bookmark-1", layout: .bookmark)
 
-        let result = builder.coverType(
-            object,
-            dataView: BlockDataview(),
-            activeView: galleryView(coverRelationKey: SetViewSettingsImagePreviewCover.picture.rawValue),
-            spaceId: spaceId,
-            detailsStorage: ObjectDetailsStorage()
-        )
+        let result = cover(for: object, coverKey: SetViewSettingsImagePreviewCover.picture.rawValue, storage: ObjectDetailsStorage())
 
         #expect(result == nil)
     }
@@ -241,31 +229,19 @@ struct SetContentViewDataBuilderTests {
     func testPictureCover_NonImageTarget_ReturnsNil() {
         let pictureId = "not-an-image"
         let storage = ObjectDetailsStorage()
-        storage.add(details: makeObject(id: pictureId, layout: .basic))
-        let object = makeObject(id: "bookmark-1", layout: .bookmark, picture: pictureId)
+        storage.add(details: .mock(id: pictureId, layout: .basic))
+        let object = ObjectDetails.mock(id: "bookmark-1", layout: .bookmark, picture: pictureId)
 
-        let result = builder.coverType(
-            object,
-            dataView: BlockDataview(),
-            activeView: galleryView(coverRelationKey: SetViewSettingsImagePreviewCover.picture.rawValue),
-            spaceId: spaceId,
-            detailsStorage: storage
-        )
+        let result = cover(for: object, coverKey: SetViewSettingsImagePreviewCover.picture.rawValue, storage: storage)
 
         #expect(result == nil)
     }
 
     @Test("Picture cover returns nil when the picture target is missing from storage")
     func testPictureCover_TargetMissing_ReturnsNil() {
-        let object = makeObject(id: "bookmark-1", layout: .bookmark, picture: "ghost-id")
+        let object = ObjectDetails.mock(id: "bookmark-1", layout: .bookmark, picture: "ghost-id")
 
-        let result = builder.coverType(
-            object,
-            dataView: BlockDataview(),
-            activeView: galleryView(coverRelationKey: SetViewSettingsImagePreviewCover.picture.rawValue),
-            spaceId: spaceId,
-            detailsStorage: ObjectDetailsStorage()
-        )
+        let result = cover(for: object, coverKey: SetViewSettingsImagePreviewCover.picture.rawValue, storage: ObjectDetailsStorage())
 
         #expect(result == nil)
     }
@@ -274,16 +250,10 @@ struct SetContentViewDataBuilderTests {
     func testNoneCover_BookmarkWithPicture_ReturnsNil() {
         let pictureId = "picture-image-1"
         let storage = ObjectDetailsStorage()
-        storage.add(details: makeObject(id: pictureId, layout: .image))
-        let object = makeObject(id: "bookmark-1", layout: .bookmark, picture: pictureId)
+        storage.add(details: .mock(id: pictureId, layout: .image))
+        let object = ObjectDetails.mock(id: "bookmark-1", layout: .bookmark, picture: pictureId)
 
-        let result = builder.coverType(
-            object,
-            dataView: BlockDataview(),
-            activeView: galleryView(coverRelationKey: SetViewSettingsImagePreviewCover.none.rawValue),
-            spaceId: spaceId,
-            detailsStorage: storage
-        )
+        let result = cover(for: object, coverKey: SetViewSettingsImagePreviewCover.none.rawValue, storage: storage)
 
         #expect(result == nil)
     }
@@ -292,21 +262,10 @@ struct SetContentViewDataBuilderTests {
     func testNonGalleryView_ReturnsNil() {
         let pictureId = "picture-image-1"
         let storage = ObjectDetailsStorage()
-        storage.add(details: makeObject(id: pictureId, layout: .image))
-        let object = makeObject(id: "bookmark-1", layout: .bookmark, picture: pictureId)
+        storage.add(details: .mock(id: pictureId, layout: .image))
+        let object = ObjectDetails.mock(id: "bookmark-1", layout: .bookmark, picture: pictureId)
 
-        let listView = DataviewView.empty.updated(
-            type: .list,
-            coverRelationKey: SetViewSettingsImagePreviewCover.picture.rawValue
-        )
-
-        let result = builder.coverType(
-            object,
-            dataView: BlockDataview(),
-            activeView: listView,
-            spaceId: spaceId,
-            detailsStorage: storage
-        )
+        let result = cover(for: object, coverKey: SetViewSettingsImagePreviewCover.picture.rawValue, storage: storage, viewType: .list)
 
         #expect(result == nil)
     }
@@ -315,23 +274,27 @@ struct SetContentViewDataBuilderTests {
 
     private let spaceId = "space-1"
 
-    private func galleryView(coverRelationKey: String) -> DataviewView {
-        DataviewView.empty.updated(type: .gallery, coverRelationKey: coverRelationKey)
-    }
-
-    private func makeObject(id: String, layout: DetailsLayout, picture: String? = nil) -> ObjectDetails {
-        var values: [String: Google_Protobuf_Value] = [:]
-        values[BundledPropertyKey.resolvedLayout.rawValue] = layout.rawValue.protobufValue
-        if let picture {
-            values[BundledPropertyKey.picture.rawValue] = picture.protobufValue
-        }
-        return ObjectDetails(id: id, values: values)
+    private func cover(
+        for object: ObjectDetails,
+        coverKey: String,
+        storage: ObjectDetailsStorage,
+        viewType: DataviewViewType = .gallery
+    ) -> ObjectHeaderCoverType? {
+        let view = DataviewView.empty.updated(type: viewType, coverRelationKey: coverKey)
+        return builder.coverType(object, dataView: BlockDataview(), activeView: view, spaceId: spaceId, detailsStorage: storage)
     }
 }
 
 extension ObjectDetails {
-    static func mock(id: String) -> ObjectDetails {
-        ObjectDetails(id: id, values: [:])
+    static func mock(id: String, layout: DetailsLayout? = nil, picture: String? = nil) -> ObjectDetails {
+        var values: [String: Google_Protobuf_Value] = [:]
+        if let layout {
+            values[BundledPropertyKey.resolvedLayout.rawValue] = layout.rawValue.protobufValue
+        }
+        if let picture {
+            values[BundledPropertyKey.picture.rawValue] = picture.protobufValue
+        }
+        return ObjectDetails(id: id, values: values)
     }
 }
 

--- a/AnyTypeTests/Services/SetContentViewDataBuilderTests.swift
+++ b/AnyTypeTests/Services/SetContentViewDataBuilderTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import Anytype
 import Services
+import SwiftProtobuf
 
 @Suite
 struct SetContentViewDataBuilderTests {
@@ -9,6 +10,7 @@ struct SetContentViewDataBuilderTests {
     private let builder: SetContentViewDataBuilder
 
     init() {
+        Container.shared.propertyDetailsStorage.register { MockPropertyDetailsStorage() }
         self.builder = SetContentViewDataBuilder()
     }
 
@@ -200,32 +202,130 @@ struct SetContentViewDataBuilderTests {
         #expect(result?.chatId == targetId)
     }
 
-    @Test("Bookmark with picture property returns picture as cover")
-    func testBookmarkWithPicture_ReturnsPictureCover() {
-        // 1. Object has bookmark layout
-        // 2. Picture property is not empty
-        // 3. Picture object exists in storage and is an image
-        // Result: Should return .cover(.imageId(pictureId))
-        
-        #expect(true, "Bookmark picture cover logic is implemented")
+    // MARK: - Gallery cover: Picture property
+
+    @Test("Picture cover resolves the picture property image")
+    func testPictureCover_ImageInStorage_ReturnsImageCover() {
+        let pictureId = "picture-image-1"
+        let storage = ObjectDetailsStorage()
+        storage.add(details: makeObject(id: pictureId, layout: .image))
+        let object = makeObject(id: "bookmark-1", layout: .bookmark, picture: pictureId)
+
+        let result = builder.coverType(
+            object,
+            dataView: BlockDataview(),
+            activeView: galleryView(coverRelationKey: SetViewSettingsImagePreviewCover.picture.rawValue),
+            spaceId: spaceId,
+            detailsStorage: storage
+        )
+
+        #expect(result == .cover(.imageId(pictureId)))
     }
 
-    @Test("Bookmark with invalid picture reference returns nil")
-    func testBookmarkWithInvalidPicture_ReturnsNil() {
-        
-        #expect(true, "Invalid picture references are handled safely")
+    @Test("Picture cover returns nil when the picture property is empty")
+    func testPictureCover_EmptyPicture_ReturnsNil() {
+        let object = makeObject(id: "bookmark-1", layout: .bookmark)
+
+        let result = builder.coverType(
+            object,
+            dataView: BlockDataview(),
+            activeView: galleryView(coverRelationKey: SetViewSettingsImagePreviewCover.picture.rawValue),
+            spaceId: spaceId,
+            detailsStorage: ObjectDetailsStorage()
+        )
+
+        #expect(result == nil)
     }
 
-    @Test("Explicit cover takes precedence over bookmark picture")
-    func testExplicitCover_TakesPrecedence() {
-        // Cover priority order:
-        // 1. Explicit page cover (highest)
-        // 2. Image layout objects
-        // 3. Bookmark picture
-        // 4. Relation-based cover
-        // Result: If explicit cover is set, bookmark picture is not used
-        
-        #expect(true, "Cover priority order is maintained")
+    @Test("Picture cover returns nil when the picture target is not an image")
+    func testPictureCover_NonImageTarget_ReturnsNil() {
+        let pictureId = "not-an-image"
+        let storage = ObjectDetailsStorage()
+        storage.add(details: makeObject(id: pictureId, layout: .basic))
+        let object = makeObject(id: "bookmark-1", layout: .bookmark, picture: pictureId)
+
+        let result = builder.coverType(
+            object,
+            dataView: BlockDataview(),
+            activeView: galleryView(coverRelationKey: SetViewSettingsImagePreviewCover.picture.rawValue),
+            spaceId: spaceId,
+            detailsStorage: storage
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test("Picture cover returns nil when the picture target is missing from storage")
+    func testPictureCover_TargetMissing_ReturnsNil() {
+        let object = makeObject(id: "bookmark-1", layout: .bookmark, picture: "ghost-id")
+
+        let result = builder.coverType(
+            object,
+            dataView: BlockDataview(),
+            activeView: galleryView(coverRelationKey: SetViewSettingsImagePreviewCover.picture.rawValue),
+            spaceId: spaceId,
+            detailsStorage: ObjectDetailsStorage()
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test("None cover does not auto-show a bookmark picture")
+    func testNoneCover_BookmarkWithPicture_ReturnsNil() {
+        let pictureId = "picture-image-1"
+        let storage = ObjectDetailsStorage()
+        storage.add(details: makeObject(id: pictureId, layout: .image))
+        let object = makeObject(id: "bookmark-1", layout: .bookmark, picture: pictureId)
+
+        let result = builder.coverType(
+            object,
+            dataView: BlockDataview(),
+            activeView: galleryView(coverRelationKey: SetViewSettingsImagePreviewCover.none.rawValue),
+            spaceId: spaceId,
+            detailsStorage: storage
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test("Non-gallery view returns nil cover")
+    func testNonGalleryView_ReturnsNil() {
+        let pictureId = "picture-image-1"
+        let storage = ObjectDetailsStorage()
+        storage.add(details: makeObject(id: pictureId, layout: .image))
+        let object = makeObject(id: "bookmark-1", layout: .bookmark, picture: pictureId)
+
+        let listView = DataviewView.empty.updated(
+            type: .list,
+            coverRelationKey: SetViewSettingsImagePreviewCover.picture.rawValue
+        )
+
+        let result = builder.coverType(
+            object,
+            dataView: BlockDataview(),
+            activeView: listView,
+            spaceId: spaceId,
+            detailsStorage: storage
+        )
+
+        #expect(result == nil)
+    }
+
+    // MARK: - Helpers
+
+    private let spaceId = "space-1"
+
+    private func galleryView(coverRelationKey: String) -> DataviewView {
+        DataviewView.empty.updated(type: .gallery, coverRelationKey: coverRelationKey)
+    }
+
+    private func makeObject(id: String, layout: DetailsLayout, picture: String? = nil) -> ObjectDetails {
+        var values: [String: Google_Protobuf_Value] = [:]
+        values[BundledPropertyKey.resolvedLayout.rawValue] = layout.rawValue.protobufValue
+        if let picture {
+            values[BundledPropertyKey.picture.rawValue] = picture.protobufValue
+        }
+        return ObjectDetails(id: id, values: values)
     }
 }
 

--- a/Anytype.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Anytype.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amplitude/AmplitudeCore-Swift.git",
       "state" : {
-        "revision" : "13fd0eb0aa080816ffa409669758b2e8787322b2",
-        "version" : "1.1.0"
+        "revision" : "95d5feb7085a7383777852c44f802ee442f1aea5",
+        "version" : "1.4.4"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/attaswift/BigInt.git",
       "state" : {
-        "revision" : "d013a2b66ee468aade6da1f26c6d55cb6cd2e9ad",
-        "version" : "5.5.2"
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
-        "version" : "8.0.2"
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "3cdb78efb79b4a5383c3911488d8025bfc545b5e",
-        "version" : "4.3.0"
+        "revision" : "c756a29784521063b6a1202907e2cc47f41b667c",
+        "version" : "4.5.0"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a54383ada6cecde007d374f58f864e29370ba5c3",
-        "version" : "1.3.2"
+        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
+        "version" : "1.6.0"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
-        "version" : "3.12.3"
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {

--- a/Anytype.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Anytype.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amplitude/AmplitudeCore-Swift.git",
       "state" : {
-        "revision" : "95d5feb7085a7383777852c44f802ee442f1aea5",
-        "version" : "1.4.4"
+        "revision" : "13fd0eb0aa080816ffa409669758b2e8787322b2",
+        "version" : "1.1.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/attaswift/BigInt.git",
       "state" : {
-        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
-        "version" : "5.7.0"
+        "revision" : "d013a2b66ee468aade6da1f26c6d55cb6cd2e9ad",
+        "version" : "5.5.2"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
-        "version" : "8.1.0"
+        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
+        "version" : "8.0.2"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "c756a29784521063b6a1202907e2cc47f41b667c",
-        "version" : "4.5.0"
+        "revision" : "3cdb78efb79b4a5383c3911488d8025bfc545b5e",
+        "version" : "4.3.0"
       }
     },
     {
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "a62862c99f5bcb28fd78617fab1a5fe29607c06c",
-        "version" : "8.28.0"
+        "revision" : "cf44aa8cb4147f39e698c1f28be0b6b2c89f79d2",
+        "version" : "8.58.2"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
+        "revision" : "a54383ada6cecde007d374f58f864e29370ba5c3",
+        "version" : "1.3.2"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+        "revision" : "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
+        "version" : "3.12.3"
       }
     },
     {

--- a/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
+++ b/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
@@ -132,9 +132,7 @@ extension BundledPropertiesValueProvider {
     var isSet: Bool { resolvedLayoutValue.isSet }
     
     var isObjectType: Bool { resolvedLayoutValue.isObjectType }
-    
-    var isBookmark: Bool { resolvedLayoutValue == .bookmark }
-    
+
     var isSupportedForOpening: Bool { resolvedLayoutValue.isSupportedForOpening }
 
     var isSupportedForDiscussion: Bool { resolvedLayoutValue.isSupportedForDiscussion }

--- a/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
+++ b/Anytype/Sources/Models/Extensions/ObjectDetailsExtensions.swift
@@ -133,6 +133,8 @@ extension BundledPropertiesValueProvider {
     
     var isObjectType: Bool { resolvedLayoutValue.isObjectType }
     
+    var isBookmark: Bool { resolvedLayoutValue == .bookmark }
+    
     var isSupportedForOpening: Bool { resolvedLayoutValue.isSupportedForOpening }
 
     var isSupportedForDiscussion: Bool { resolvedLayoutValue.isSupportedForDiscussion }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetContentViewDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetContentViewDataBuilder.swift
@@ -209,14 +209,62 @@ final class SetContentViewDataBuilder: SetContentViewDataBuilderProtocol {
         guard activeView.type == .gallery else {
             return nil
         }
+        
+        let showPictureCover = activeView.coverRelationKey == SetViewSettingsImagePreviewCover.picture.rawValue
+        if showPictureCover {
+            return pictureCoverType(details, detailsStorage: detailsStorage)
+        }
+        
         let showPageCover = activeView.coverRelationKey == SetViewSettingsImagePreviewCover.pageCover.rawValue
         if showPageCover, let documentCover = details.documentCover {
             return .cover(documentCover)
         } else if showPageCover, details.objectType.isImageLayout {
             return .cover(DocumentCover.imageId(details.id))
-        } else {
-            return relationCoverType(details, dataView: dataView, activeView: activeView, spaceId: spaceId, detailsStorage: detailsStorage)
         }
+        
+        // Check for bookmark picture (fallback for bookmarks without explicit cover)
+        if let bookmarkPictureCover = bookmarkPictureCoverType(details, detailsStorage: detailsStorage) {
+            return bookmarkPictureCover
+        }
+        
+        return relationCoverType(details, dataView: dataView, activeView: activeView, spaceId: spaceId, detailsStorage: detailsStorage)
+    }
+    
+    private func pictureCoverType(
+        _ details: ObjectDetails,
+        detailsStorage: ObjectDetailsStorage
+    ) -> ObjectHeaderCoverType? {
+        return picturePropertyCover(details, detailsStorage: detailsStorage)
+    }
+    
+    private func bookmarkPictureCoverType(
+        _ details: ObjectDetails,
+        detailsStorage: ObjectDetailsStorage
+    ) -> ObjectHeaderCoverType? {
+        // Only apply to bookmark objects as a fallback
+        guard details.isBookmark else {
+            return nil
+        }
+        
+        return picturePropertyCover(details, detailsStorage: detailsStorage)
+    }
+    
+    private func picturePropertyCover(
+        _ details: ObjectDetails,
+        detailsStorage: ObjectDetailsStorage
+    ) -> ObjectHeaderCoverType? {
+        let pictureId = details.picture
+        
+        guard pictureId.isNotEmpty else {
+            return nil
+        }
+        
+        guard let pictureDetails = detailsStorage.get(id: pictureId),
+              pictureDetails.resolvedLayoutValue.isImage else {
+            return nil
+        }
+        
+        return .cover(.imageId(pictureId))
     }
     
     private func relationCoverType(

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetContentViewDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetContentViewDataBuilder.swift
@@ -199,7 +199,7 @@ final class SetContentViewDataBuilder: SetContentViewDataBuilderProtocol {
         }
     }
     
-    private func coverType(
+    func coverType(
         _ details: ObjectDetails,
         dataView: BlockDataview,
         activeView: DataviewView,
@@ -212,43 +212,19 @@ final class SetContentViewDataBuilder: SetContentViewDataBuilderProtocol {
         
         let showPictureCover = activeView.coverRelationKey == SetViewSettingsImagePreviewCover.picture.rawValue
         if showPictureCover {
-            return pictureCoverType(details, detailsStorage: detailsStorage)
+            return picturePropertyCover(details, detailsStorage: detailsStorage)
         }
-        
+
         let showPageCover = activeView.coverRelationKey == SetViewSettingsImagePreviewCover.pageCover.rawValue
         if showPageCover, let documentCover = details.documentCover {
             return .cover(documentCover)
         } else if showPageCover, details.objectType.isImageLayout {
             return .cover(DocumentCover.imageId(details.id))
         }
-        
-        // Check for bookmark picture (fallback for bookmarks without explicit cover)
-        if let bookmarkPictureCover = bookmarkPictureCoverType(details, detailsStorage: detailsStorage) {
-            return bookmarkPictureCover
-        }
-        
+
         return relationCoverType(details, dataView: dataView, activeView: activeView, spaceId: spaceId, detailsStorage: detailsStorage)
     }
-    
-    private func pictureCoverType(
-        _ details: ObjectDetails,
-        detailsStorage: ObjectDetailsStorage
-    ) -> ObjectHeaderCoverType? {
-        return picturePropertyCover(details, detailsStorage: detailsStorage)
-    }
-    
-    private func bookmarkPictureCoverType(
-        _ details: ObjectDetails,
-        detailsStorage: ObjectDetailsStorage
-    ) -> ObjectHeaderCoverType? {
-        // Only apply to bookmark objects as a fallback
-        guard details.isBookmark else {
-            return nil
-        }
-        
-        return picturePropertyCover(details, detailsStorage: detailsStorage)
-    }
-    
+
     private func picturePropertyCover(
         _ details: ObjectDetails,
         detailsStorage: ObjectDetailsStorage

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetContentViewDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetContentViewDataBuilder.swift
@@ -230,17 +230,12 @@ final class SetContentViewDataBuilder: SetContentViewDataBuilderProtocol {
         detailsStorage: ObjectDetailsStorage
     ) -> ObjectHeaderCoverType? {
         let pictureId = details.picture
-        
+
         guard pictureId.isNotEmpty else {
             return nil
         }
-        
-        guard let pictureDetails = detailsStorage.get(id: pictureId),
-              pictureDetails.resolvedLayoutValue.isImage else {
-            return nil
-        }
-        
-        return .cover(.imageId(pictureId))
+
+        return findCover(at: [pictureId], details, detailsStorage: detailsStorage)
     }
     
     private func relationCoverType(

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/ImagePreview/SetViewSettingsImagePreviewCover.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/ImagePreview/SetViewSettingsImagePreviewCover.swift
@@ -1,6 +1,7 @@
 enum SetViewSettingsImagePreviewCover: String, CaseIterable, Identifiable {
     case none = ""
     case pageCover
+    case picture = "picture"
     
     var id: String {
         rawValue
@@ -12,6 +13,8 @@ enum SetViewSettingsImagePreviewCover: String, CaseIterable, Identifiable {
             return Loc.none
         case .pageCover:
             return Loc.cover
+        case .picture:
+            return Loc.picture
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/ImagePreview/SetViewSettingsImagePreviewCover.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Popups/RelationsSettings/ImagePreview/SetViewSettingsImagePreviewCover.swift
@@ -1,7 +1,7 @@
 enum SetViewSettingsImagePreviewCover: String, CaseIterable, Identifiable {
     case none = ""
     case pageCover
-    case picture = "picture"
+    case picture
     
     var id: String {
         rawValue


### PR DESCRIPTION
## Summary
- Keep the explicit "Picture" cover option for Gallery views (resolves the object's `picture` image, matching anytype-ts desktop), with the resolver reusing the existing `findCover` helper.
- Remove the bookmark picture auto-fallback that overrode the user's explicit "None"/relation cover choice and diverged from desktop.
- Replace placeholder `#expect(true)` tests with real `coverType` tests (picture path, no-fallback regression, non-gallery) and revert unrelated dependency bumps in `Package.resolved`.
