### PR TITLE
IOS-6435 Fix Dependabot alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
       mutex_m
     jmespath (1.6.2)
     json (2.19.5)
-    jwt (2.10.2)
+    jwt (2.10.3)
       base64
     license_finder (7.1.0)
       bundler


### PR DESCRIPTION
## Summary
- Bump transitive `jwt` gem 2.10.2 → 2.10.3 in `Gemfile.lock` to resolve the only open Dependabot alert (high severity: empty-key HMAC bypass, sibling of CVE-2026-44351).
- Conservative update — no other gems changed. New version is within all existing constraints (`< 3`).