### PR TITLE
IOS-6440 Guard empty ids before ObjectSubscribeIds

### DIFF
--- a/Anytype/Sources/ServiceLayer/Subscriptions/ObjectIdsSubscriptionService.swift
+++ b/Anytype/Sources/ServiceLayer/Subscriptions/ObjectIdsSubscriptionService.swift
@@ -29,7 +29,13 @@ actor ObjectIdsSubscriptionService: ObjectIdsSubscriptionServiceProtocol {
         additionalKeys: [BundledPropertyKey],
         update: @escaping @Sendable ([ObjectDetails]) async -> Void
     ) async {
-        
+
+        if objectIds.isEmpty {
+            try? await subscriptionStorage.stopSubscription()
+            await update([])
+            return
+        }
+
         let keys: [BundledPropertyKey] = .builder {
             BundledPropertyKey.objectListKeys
             additionalKeys


### PR DESCRIPTION
## Bug

The Go middleware is changing the `ObjectSubscribeIds` RPC so that calling it with an **empty** `ids` array now returns an error ("ids are required") instead of an empty success response.

`ObjectIdsSubscriptionService.startSubscription` passed its `objectIds` straight through to the RPC with no empty check. The chat/discussion attachment path (`ChatMessagesStorage.updateAttachmentSubscription` / `DiscussionMessagesStorage`) builds `attachmentIds` by unioning message attachments over the visible range — scrolling through text-only messages (no attachments) produces an **empty** set. Today that succeeds with zero records, but after the middleware change it would throw, firing spurious non-fatal assertions/telemetry (domain "Middle.ObjectSubscribeIds") and an assertion alert popup in internal/enterprise builds.

## Fix

Add an early-return guard in `ObjectIdsSubscriptionService.startSubscription`, mirroring the existing pattern in `TreeSubscriptionManager`: when `objectIds.isEmpty`, stop the subscription, deliver an empty update via the `update` closure, and skip the RPC. "Empty ids = clear the subscription" — consistent with the Tree path and the anytype-ts client. One place covers both chat consumers.

## Note

This accompanies the middleware change that rejects empty `ids` on `ObjectSubscribeIds`.

Closes IOS-6440