### PR TITLE
IOS-6498 Fix negative subscription offset from Set/Collection widgets

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/SetSubscriptionDataBuilder+Widget.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Models/SetSubscriptionDataBuilder+Widget.swift
@@ -12,7 +12,7 @@ extension SetSubscriptionDataBuilderProtocol {
             identifier: identifier,
             document: setDocument,
             groupFilter: nil,
-            currentPage: 0,
+            currentPage: 1,
             numberOfRowsPerPage: widgetInfo.fixedLimit,
             collectionId: setDocument.isCollection() ? setDocument.objectId : nil,
             objectOrderIds: setDocument.objectOrderIds(for: subscriptionId),

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionDataBuilder.swift
@@ -21,7 +21,7 @@ final class SetSubscriptionDataBuilder: SetSubscriptionDataBuilderProtocol, Send
 
         let keys = buildKeys(with: data)
         
-        let offset = (data.currentPage - 1) * numberOfRowsPerPageInSubscriptions
+        let offset = max((data.currentPage - 1) * numberOfRowsPerPageInSubscriptions, 0)
         
         return .search(
             SubscriptionData.Search(


### PR DESCRIPTION
## Summary
- Widget Set/Collection subscriptions sent a negative `offset` (`currentPage: 0` → `(0-1)*6 = -6`), which the new subscription engine (v0.50.10+, GO-7320) rejects with `normalize subscribe request: offset out of range: -6`, popping ~30 error toasts on space open. Legacy middleware silently clamped it to 0.
- Fix `SetSubscriptionDataBuilder+Widget` to pass `currentPage: 1` (first page → offset 0), matching the Editor's `max(selectedPage, 1)`.
- Clamp `offset = max(…, 0)` in `SetSubscriptionDataBuilder` as defense-in-depth — the single chokepoint for the only computed offset in the app.

Closes IOS-6498