### PR TITLE
IOS-6492 Fix Links/Backlinks empty panel by rendering resolved objects

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Object/ObjectPropertyListData.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Object/ObjectPropertyListData.swift
@@ -2,4 +2,7 @@ struct ObjectPropertyListData {
     let configuration: PropertyModuleConfiguration
     let interactor: any ObjectPropertyListInteractorProtocol
     let relationSelectedOptionsModel: PropertySelectedOptionsModel
+    // Set only for read-only object relations (links/backlinks): when present, the
+    // panel renders these already-resolved objects instead of running a filtered search.
+    var preloadedReadOnlyOptions: [ObjectPropertyOption]? = nil
 }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Object/ObjectPropertyListViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Object/ObjectPropertyListViewModel.swift
@@ -22,6 +22,8 @@ final class ObjectPropertyListViewModel {
     private let interactor: any ObjectPropertyListInteractorProtocol
     @ObservationIgnored
     private let relationSelectedOptionsModel: any PropertySelectedOptionsModelProtocol
+    @ObservationIgnored
+    private let preloadedReadOnlyOptions: [ObjectPropertyOption]?
 
     @ObservationIgnored
     @Injected(\.objectActionsService)
@@ -35,6 +37,7 @@ final class ObjectPropertyListViewModel {
         self.output = output
         self.interactor = data.interactor
         self.relationSelectedOptionsModel = data.relationSelectedOptionsModel
+        self.preloadedReadOnlyOptions = data.preloadedReadOnlyOptions
     }
 
     func startSelectedOptionsSubscription() async {
@@ -120,6 +123,13 @@ final class ObjectPropertyListViewModel {
     }
     
     func searchTextChanged() async {
+        // Read-only object relations (links/backlinks) render already-resolved objects
+        // instead of re-querying via filtered search, which drops hidden/legacy objects.
+        if let preloadedReadOnlyOptions {
+            options = preloadedReadOnlyOptions
+            setEmptyIfNeeded()
+            return
+        }
         do {
             let selectedOptions = try await interactor.searchOptions(text: searchText, limitObjectIds: selectedOptionsIds)
             let rawOptions = try await interactor.searchOptions(text: searchText, excludeObjectIds: selectedOptionsIds)

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Object/ObjectPropertyOption.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/PropertyDetailsViews/Object/ObjectPropertyOption.swift
@@ -22,6 +22,19 @@ struct ObjectPropertyOption: Equatable, Identifiable {
 }
 
 extension ObjectPropertyOption {
+    init(objectOption: Property.Object.Option) {
+        id = objectOption.id
+        icon = objectOption.icon ?? .object(.defaultObjectIcon)
+        title = objectOption.title
+        type = objectOption.type
+        isArchived = objectOption.isArchived
+        isDeleted = objectOption.isDeleted
+        disableDeletion = true
+        disableDuplication = true
+        objectScreenData = objectOption.editorScreenData
+        screenData = objectOption.editorScreenData
+    }
+
     init(objectDetails: ObjectDetails) {
         id = objectDetails.id
         icon = objectDetails.objectIconImage

--- a/Anytype/Sources/PresentationLayer/PropertyValueFlow/PropertyValueCoordinator/PropertyValueCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/PropertyValueFlow/PropertyValueCoordinator/PropertyValueCoordinatorViewModel.swift
@@ -106,7 +106,10 @@ final class PropertyValueCoordinatorViewModel:
                     relationSelectedOptionsModel: PropertySelectedOptionsModel(
                         config: configuration,
                         selectedOptionsIds: object.selectedObjects.compactMap { $0.id }
-                    )
+                    ),
+                    preloadedReadOnlyOptions: object.links != nil
+                        ? object.selectedObjects.map(ObjectPropertyOption.init(objectOption:))
+                        : nil
                 ),
                 output: self
             ).eraseToAnyView()


### PR DESCRIPTION
## Summary
- Links/Backlinks property panels showed "The property is empty" despite a non-zero count, because the read-only panel re-ran a filtered `objectSearch` (`notHiddenFilters`) that dropped hidden/legacy objects, while the summary count read directly from `ObjectDetailsStorage`.
- For the `links`/`backlinks` relations (gated on `object.links != nil`), the panel now renders the already-resolved `selectedObjects` via a new optional `preloadedReadOnlyOptions`, skipping the search — mirroring Android's store-based rendering so count and list can't diverge.
- Scoped to links/backlinks only: editable object relations and the read-only `type` relation (which has no screen data) keep the unchanged search path.

https://claude.ai/code/session_01S3i6XKnXtgJfJrMUeosnCo