### PR TITLE
IOS-6508 Authenticate ubi in update_cache to avoid GitHub API rate limit

### DIFF
--- a/.github/workflows/update_cache.yaml
+++ b/.github/workflows/update_cache.yaml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Build tools
         run: make setup-env
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Update build cache
         run: bundle exec fastlane build_for_tests


### PR DESCRIPTION
## Summary
- `make setup-env` installs SwiftGen via `ubi`, which calls the GitHub API. Unauthenticated, it hits the anonymous 60-requests/hour limit on shared runners and fails the cache refresh at `setup-env` (403 rate limit exceeded).
- Pass `github.token` to the Build tools step so `ubi` authenticates and gets the 5000/hour limit.
- Unblocks the `Update build cache` workflow, which refreshes the poisoned Xcode ModuleCache that is currently failing every PR's Unit Tests.

https://claude.ai/code/session_014tCBJkjU3irycULc59mNu4