### PR TITLE
IOS-6508 Clear stale Clang module cache before CI build

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -26,6 +26,14 @@ jobs:
           swiftpm-cache-restore-keys: spm-soucepackages-
           cache-read-only: true
 
+      # The macos-26 runner pool is heterogeneous: SDK headers carry different mtimes
+      # across runners. Clang's cached precompiled modules are mtime-locked to the runner
+      # that built them, so a restored ModuleCache fails on a different runner with
+      # "file has been modified since the module file was built". Drop it so Clang rebuilds
+      # modules against the current runner's SDK; the rest of the cached DerivedData stands.
+      - name: Clear stale module cache
+        run: rm -rf ~/Library/Developer/Xcode/DerivedData/*/ModuleCache.noindex || true
+
       - name: Prepare deps
         uses: ./.github/actions/prepare-deps
 


### PR DESCRIPTION
## Summary
- The `macos-26` runner pool is **heterogeneous**: SDK headers carry different mtimes across runners. Clang's cached precompiled modules (`.pcm` in `ModuleCache.noindex`) are mtime-locked to the runner that built them, so a restored ModuleCache fails on a different runner with `file has been modified since the module file was built` → `could not build module '_DarwinFoundation1'`.
- Refreshing the cache doesn't help — it just flips which runner variant fails. The fix is to drop `ModuleCache.noindex` after cache restore so Clang rebuilds modules against the current runner's SDK. The rest of the cached DerivedData (compiled artifacts, SwiftPM) is preserved, so the build stays fast.

This is the root cause behind the recent `Build & Test` failures on PRs.

https://claude.ai/code/session_014tCBJkjU3irycULc59mNu4