### PR TITLE
IOS-6518 Widgets: Equatable row models + guard reassignment to confine re-renders

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Gallery/Common/GalleryWidgetRow.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Gallery/Common/GalleryWidgetRow.swift
@@ -6,6 +6,9 @@ struct GalleryWidgetRowModel: Identifiable, Equatable {
     let title: String?
     let icon: Icon?
     let cover: ObjectHeaderCoverType?
+    // Navigation identity compared by Equatable so re-render guards rebuild the row
+    // (and its onTap) when routing changes even if rendered fields stay the same.
+    let screenData: ScreenData
     @EquatableNoop var onTap: @MainActor () -> Void
 
     var id: String { objectId }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Gallery/Common/GalleryWidgetRow.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Gallery/Common/GalleryWidgetRow.swift
@@ -1,13 +1,15 @@
 import Foundation
 import SwiftUI
 
-struct GalleryWidgetRowModel {
+struct GalleryWidgetRowModel: Identifiable, Equatable {
     let objectId: String
     let title: String?
     let icon: Icon?
     let cover: ObjectHeaderCoverType?
-    let onTap: @MainActor () -> Void
-    
+    @EquatableNoop var onTap: @MainActor () -> Void
+
+    var id: String { objectId }
+
     var shouldIncreaseCoverHeight: Bool {
         cover.isNotNil && icon.isNil && title.isNil
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Gallery/Common/GalleryWidgetRowModel+Details.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Gallery/Common/GalleryWidgetRowModel+Details.swift
@@ -8,6 +8,7 @@ extension GalleryWidgetRowModel {
             title: details.showTitle ? details.title : nil,
             icon: details.showIcon ? details.icon : nil,
             cover: details.coverType,
+            screenData: details.screenData,
             onTap: details.onItemTap
         )
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Gallery/Common/GalleryWidgetView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Gallery/Common/GalleryWidgetView.swift
@@ -18,7 +18,7 @@ struct GalleryWidgetView: View {
         ScrollView(.horizontal) {
             HStack(spacing: 8) {
                 if let rows {
-                    ForEach(rows, id: \.objectId) { row in
+                    ForEach(rows) { row in
                         GalleryWidgetRow(model: row)
                     }
                     if showAllObjects {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/Content/Subviews/ListWidgetRowModel+ObjectDetails.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/Content/Subviews/ListWidgetRowModel+ObjectDetails.swift
@@ -9,6 +9,7 @@ extension ListWidgetRowModel {
         parentBadge: ParentObjectUnreadBadge? = nil,
         onTap: @escaping @MainActor (ScreenData) -> Void
     ) {
+        let screenData = details.screenData()
         self = ListWidgetRowModel(
             objectId: details.id,
             icon: details.objectIconImage,
@@ -16,8 +17,9 @@ extension ListWidgetRowModel {
             description: details.subtitle,
             chatPreview: chatPreview,
             parentBadge: parentBadge,
+            screenData: screenData,
             onTap: {
-                onTap(details.screenData())
+                onTap(screenData)
             }
         )
     }
@@ -34,6 +36,7 @@ extension ListWidgetRowModel {
             description: details.description,
             chatPreview: chatPreview,
             parentBadge: parentBadge,
+            screenData: details.screenData,
             onTap: details.onItemTap
         )
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/Content/Subviews/ListWidgetRowModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/Content/Subviews/ListWidgetRowModel.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-struct ListWidgetRowModel: Identifiable {
+struct ListWidgetRowModel: Identifiable, Equatable {
     let objectId: String
     let icon: Icon
     let title: String
     let description: String?
     let chatPreview: MessagePreviewModel?
     let parentBadge: ParentObjectUnreadBadge?
-    let onTap: @MainActor () -> Void
+    @EquatableNoop var onTap: @MainActor () -> Void
 
     var id: String { objectId }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/Content/Subviews/ListWidgetRowModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/Content/Subviews/ListWidgetRowModel.swift
@@ -7,6 +7,9 @@ struct ListWidgetRowModel: Identifiable, Equatable {
     let description: String?
     let chatPreview: MessagePreviewModel?
     let parentBadge: ParentObjectUnreadBadge?
+    // Navigation identity compared by Equatable so re-render guards rebuild the row
+    // (and its onTap) when routing changes even if rendered fields stay the same.
+    let screenData: ScreenData
     @EquatableNoop var onTap: @MainActor () -> Void
 
     var id: String { objectId }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/ListWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/ListWidgetViewModel.swift
@@ -102,7 +102,7 @@ final class ListWidgetViewModel: ObservableObject {
     }
     
     private func updateViewState() {
-        rows = rowDetails?.map { details in
+        let newRows = rowDetails?.map { details in
             ListWidgetRowModel(
                 details: details,
                 onTap: { [weak self] _ in
@@ -110,6 +110,8 @@ final class ListWidgetViewModel: ObservableObject {
                 }
             )
         }
+        guard newRows != rows else { return }
+        rows = newRows
     }
 
     private func updateHeader(dataviewState: WidgetDataviewState?) {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/ListWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/List/Common/ListWidgetViewModel.swift
@@ -115,7 +115,7 @@ final class ListWidgetViewModel: ObservableObject {
     }
 
     private func updateHeader(dataviewState: WidgetDataviewState?) {
-        headerItems = dataviewState?.dataview.map { dataView in
+        let newHeaderItems = dataviewState?.dataview.map { dataView in
             ViewWidgetTabsItemModel(
                 dataviewId: dataView.id,
                 title: dataView.nameWithPlaceholder,
@@ -125,6 +125,8 @@ final class ListWidgetViewModel: ObservableObject {
                 }
             )
         }
+        guard newHeaderItems != headerItems else { return }
+        headerItems = newHeaderItems
     }
     
     private func handleTapOnObject(details: ObjectDetails) {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SetCommon/SetObjectViewRows.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SetCommon/SetObjectViewRows.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum SetObjectViewWidgetRows {
+enum SetObjectViewWidgetRows: Equatable {
     case compactList(rows: [ListWidgetRowModel]?, id: String)
     case list(rows: [ListWidgetRowModel]?, id: String)
     case gallery(rows: [GalleryWidgetRowModel]?, id: String)

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SetCommon/Tabs/ViewWidgetTabsItemView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SetCommon/Tabs/ViewWidgetTabsItemView.swift
@@ -1,11 +1,11 @@
 import Foundation
 import SwiftUI
 
-struct ViewWidgetTabsItemModel {
+struct ViewWidgetTabsItemModel: Equatable {
     let dataviewId: String
     let title: String
     let isSelected: Bool
-    let onTap: () -> Void
+    @EquatableNoop var onTap: () -> Void
 }
 
 struct ViewWidgetTabsItemView: View {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
@@ -242,7 +242,7 @@ final class SetObjectWidgetInternalViewModel {
     }
     
     private func updateHeader(dataviewState: WidgetDataviewState?) {
-        headerItems = dataviewState?.dataview.map { dataView in
+        let newHeaderItems = dataviewState?.dataview.map { dataView in
             ViewWidgetTabsItemModel(
                 dataviewId: dataView.id,
                 title: dataView.nameWithPlaceholder,
@@ -251,6 +251,9 @@ final class SetObjectWidgetInternalViewModel {
                     self?.onActiveViewTap(dataView.id)
                 }
             )
+        }
+        if headerItems != newHeaderItems {
+            headerItems = newHeaderItems
         }
     }
     
@@ -359,7 +362,10 @@ final class SetObjectWidgetInternalViewModel {
     private func updateRowDetails(data: SubscriptionStorageState) {
         guard let setDocument else { return }
 
-        availableMoreObjects = data.total > data.items.count
+        let newAvailableMoreObjects = data.total > data.items.count
+        if availableMoreObjects != newAvailableMoreObjects {
+            availableMoreObjects = newAvailableMoreObjects
+        }
 
         let spaceView = spaceViewsStorage.spaceView(spaceId: setDocument.spaceId)
         let rowDetails = setObjectWidgetOrderHelper.reorder(

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/SpecificInternalModels/SetObjectWidgetInternalViewModel.swift
@@ -187,30 +187,37 @@ final class SetObjectWidgetInternalViewModel {
     // MARK: - Private for view updates
     
     private func updateRows(rowDetails: [SetContentViewItemConfiguration]?) {
-        showUnsupportedBanner = (style == .view) && !(setDocument?.activeView.type.isSupportedOnDevice ?? false)
+        let newShowUnsupportedBanner = (style == .view) && !(setDocument?.activeView.type.isSupportedOnDevice ?? false)
+        if showUnsupportedBanner != newShowUnsupportedBanner {
+            showUnsupportedBanner = newShowUnsupportedBanner
+        }
 
+        let newRows: SetObjectViewWidgetRows
         switch style {
         case .list:
             let listRows = buildListRows(from: rowDetails)
-            rows = .list(rows: listRows, id: activeViewId ?? "")
+            newRows = .list(rows: listRows, id: activeViewId ?? "")
         case .compactList:
             let listRows = buildListRows(from: rowDetails)
-            rows = .compactList(rows: listRows, id: activeViewId ?? "")
+            newRows = .compactList(rows: listRows, id: activeViewId ?? "")
         case .view:
             if isSetByImageType() {
                 let galleryRows = rowDetails.map { widgetRowModelBuilder.buildGalleryRows(from: $0) }
-                rows = .gallery(rows: galleryRows, id: activeViewId ?? "")
+                newRows = .gallery(rows: galleryRows, id: activeViewId ?? "")
             } else {
                 switch setDocument?.activeView.type {
                 case .table, .list, .kanban, .calendar, .graph, nil:
                     let listRows = buildListRows(from: rowDetails)
-                    rows = .compactList(rows: listRows, id: activeViewId ?? "")
+                    newRows = .compactList(rows: listRows, id: activeViewId ?? "")
                 case .gallery:
                     let galleryRows = rowDetails.map { widgetRowModelBuilder.buildGalleryRows(from: $0) }
-                    rows = .gallery(rows: galleryRows, id: activeViewId ?? "")
+                    newRows = .gallery(rows: galleryRows, id: activeViewId ?? "")
                 }
             }
         }
+
+        guard newRows != rows else { return }
+        rows = newRows
     }
 
     private func buildListRows(from configs: [SetContentViewItemConfiguration]?) -> [ListWidgetRowModel]? {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/Rows/TreeWidgetRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/Rows/TreeWidgetRowView.swift
@@ -14,6 +14,9 @@ struct TreeWidgetRowViewModel: Identifiable, Equatable {
     let icon: Icon
     let expandedType: ExpandedType
     let level: Int
+    // Navigation identity compared by Equatable so re-render guards rebuild the row
+    // (and its tapObject) when routing changes even if rendered fields stay the same.
+    let screenData: ScreenData
     @EquatableNoop var tapExpand: (TreeWidgetRowViewModel) -> Void
     @EquatableNoop var tapCollapse: (TreeWidgetRowViewModel) -> Void
     @EquatableNoop var tapObject: (TreeWidgetRowViewModel) -> Void

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/Rows/TreeWidgetRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/Rows/TreeWidgetRowView.swift
@@ -1,22 +1,24 @@
 import Foundation
 import SwiftUI
 
-struct TreeWidgetRowViewModel {
-    
-    enum ExpandedType {
+struct TreeWidgetRowViewModel: Identifiable, Equatable {
+
+    enum ExpandedType: Equatable {
         case arrow(expanded: Bool)
         case icon(asset: ImageAsset)
     }
-    
+
     let rowId: String
     let objectId: String
     let title: String
     let icon: Icon
     let expandedType: ExpandedType
     let level: Int
-    let tapExpand: (TreeWidgetRowViewModel) -> Void
-    let tapCollapse: (TreeWidgetRowViewModel) -> Void
-    let tapObject: (TreeWidgetRowViewModel) -> Void
+    @EquatableNoop var tapExpand: (TreeWidgetRowViewModel) -> Void
+    @EquatableNoop var tapCollapse: (TreeWidgetRowViewModel) -> Void
+    @EquatableNoop var tapObject: (TreeWidgetRowViewModel) -> Void
+
+    var id: String { rowId }
 }
 
 struct TreeWidgetRowView: View {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetView.swift
@@ -56,8 +56,8 @@ struct TreeWidgetView: View {
         ) {
             if let rows = model.rows {
                 VStack(spacing: 0) {
-                    ForEach(rows, id: \.rowId) {
-                        TreeWidgetRowView(model: $0, showDivider: $0.rowId != rows.last?.rowId)
+                    ForEach(rows) {
+                        TreeWidgetRowView(model: $0, showDivider: $0.id != rows.last?.id)
                             .transition(.move(edge: .top).combined(with: .opacity))
                     }
                     if model.availableMore {

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetViewModel.swift
@@ -167,10 +167,12 @@ final class TreeWidgetViewModel: ObservableObject {
     private func updateTree() {
         guard let firstLevelSubscriptionData else { return }
         let links = firstLevelSubscriptionData.map { $0.id }
+        let newRows = buildRows(links: links, idPrefix: "", level: 0)
+        guard newRows != rows else { return }
         // First-paint mount must NOT animate — would re-introduce the loading flash
         // IOS-5812 fixed. Subsequent rebuilds animate (expand/collapse + sync churn).
         withAnimation(rows == nil ? nil : .disclosureSmall) {
-            rows = buildRows(links: links, idPrefix: "", level: 0)
+            rows = newRows
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Widgets/Tree/Common/TreeWidgetViewModel.swift
@@ -199,14 +199,15 @@ final class TreeWidgetViewModel: ObservableObject {
                     canBeExpanded: level < Constants.maxExpandableLevel
                 ),
                 level: level,
+                screenData: details.screenData(),
                 tapExpand: { [weak self] model in
                     self?.onTapExpand(model: model)
                 },
                 tapCollapse: { [weak self] model in
                     self?.onTapCollapse(model: model)
                 },
-                tapObject: { [weak self] _ in
-                    self?.handleTapOnObject(details: details)
+                tapObject: { [weak self] model in
+                    self?.handleTapOnObject(screenData: model.screenData)
                 }
             )
             
@@ -223,10 +224,10 @@ final class TreeWidgetViewModel: ObservableObject {
         return (firstLevelSubscriptionData ?? []) + (childSubscriptionData ?? [])
     }
     
-    private func handleTapOnObject(details: ObjectDetails) {
+    private func handleTapOnObject(screenData: ScreenData) {
         guard let info = widgetObject.widgetInfo(blockId: widgetBlockId) else { return }
         AnytypeAnalytics.instance().logOpenSidebarObject(createType: info.widgetCreateType)
-        output?.onObjectSelected(screenData: details.screenData())
+        output?.onObjectSelected(screenData: screenData)
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetContentViewDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetContentViewDataBuilder.swift
@@ -149,6 +149,7 @@ final class SetContentViewDataBuilder: SetContentViewDataBuilderProtocol {
                 coverType: coverType(item.details, dataView: dataView, activeView: activeView, spaceId: spaceId, detailsStorage: storage),
                 minHeight: minHeight,
                 chatPreview: chatPreview,
+                screenData: item.details.screenData(),
                 onItemTap: { [details = item.details] in
                     onItemTap(details)
                 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/Row/SetContentViewItemConfiguration.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/Row/SetContentViewItemConfiguration.swift
@@ -17,8 +17,11 @@ struct SetContentViewItemConfiguration: Identifiable, Hashable {
     let coverType: ObjectHeaderCoverType?
     let minHeight: CGFloat?
     let chatPreview: MessagePreviewModel?
+    // Navigation identity compared by Hashable so consumers (e.g. widget re-render guards)
+    // rebuild the row when routing changes even if rendered fields stay the same.
+    let screenData: ScreenData
     @EquatableNoop var onItemTap: @MainActor () -> Void
-    
+
     init(
         id: String,
         title: String,
@@ -34,6 +37,7 @@ struct SetContentViewItemConfiguration: Identifiable, Hashable {
         coverType: ObjectHeaderCoverType?,
         minHeight: CGFloat?,
         chatPreview: MessagePreviewModel? = nil,
+        screenData: ScreenData,
         onItemTap: @escaping @MainActor () -> Void
     ) {
         self.id = id
@@ -50,6 +54,7 @@ struct SetContentViewItemConfiguration: Identifiable, Hashable {
         self.coverType = coverType
         self.minHeight = minHeight
         self.chatPreview = chatPreview
+        self.screenData = screenData
         self.onItemTap = onItemTap
     }
 }


### PR DESCRIPTION
## Summary
- Conform List/Tree/Gallery/SetObject widget row models to `Equatable` (tap closures wrapped in `@EquatableNoop`) and guard the rows reassignment, so identical subscription ticks no longer re-publish and `ForEach` can diff.
- Drop now-redundant explicit `ForEach` key paths (ids are stable).

Older widget rows were non-`Equatable` and rebuilt wholesale on every subscription tick, defeating diffing. Same pattern as the existing MyFavorites/RecentlyEdited widgets.
