### PR TITLE
IOS-6519 Set/DataView: diff-guard configurations, cache columns, native keyboard dismiss

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -61,12 +61,21 @@ final class EditorSetViewModel: ObservableObject {
     // the pinned table header reads this in its body, which re-evaluates on every
     // model publish (e.g. a row edit) and would otherwise re-run the sort/filter/map.
     @Published private(set) var colums: [PropertyDetails] = []
+    // Captured by value into the `.equatable()` table header; recomputed on the same
+    // path as `colums` so a viewer→editor permission flip refreshes the header
+    // deterministically instead of relying on an incidental unrelated publish.
+    @Published private(set) var canEditRelationValuesInView = false
 
     private func updateColumns() {
         let newColumns = setDocument.sortedRelations(for: setDocument.activeView.id)
             .filter { $0.option.isVisible }.map(\.relationDetails)
-        guard newColumns != colums else { return }
-        colums = newColumns
+        if newColumns != colums {
+            colums = newColumns
+        }
+        let newCanEditRelationValues = setDocument.setPermissions.canEditRelationValuesInView
+        if canEditRelationValuesInView != newCanEditRelationValues {
+            canEditRelationValuesInView = newCanEditRelationValues
+        }
     }
     
     var isGroupBackgroundColors: Bool {
@@ -279,7 +288,11 @@ final class EditorSetViewModel: ObservableObject {
         // without a .dataviewUpdated event, so refresh the cached columns here too.
         // updateColumns() diff-guards, so redundant calls are free.
         setDocument.syncPublisher.receiveOnMain().sink { [weak self] in
-            self?.updateColumns()
+            guard let self else { return }
+            updateColumns()
+            // A relation format/read-only change doesn't emit a record Amend, so refresh
+            // the per-record cell configs too. Diff-guarded → a no-op when nothing changed.
+            updateConfigurations(with: Array(recordsDict.keys))
         }.store(in: &subscriptions)
 
         Task { @MainActor [weak self] in

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -56,10 +56,17 @@ final class EditorSetViewModel: ObservableObject {
     var isEmptyViews: Bool {
         setDocument.dataView.views.isEmpty
     }
-    
-    var colums: [PropertyDetails] {
-        setDocument.sortedRelations(for: setDocument.activeView.id)
+
+    // Cached on the dataview-update path instead of recomputed on every access:
+    // the pinned table header reads this in its body, which re-evaluates on every
+    // model publish (e.g. a row edit) and would otherwise re-run the sort/filter/map.
+    @Published private(set) var colums: [PropertyDetails] = []
+
+    private func updateColumns() {
+        let newColumns = setDocument.sortedRelations(for: setDocument.activeView.id)
             .filter { $0.option.isVisible }.map(\.relationDetails)
+        guard newColumns != colums else { return }
+        colums = newColumns
     }
     
     var isGroupBackgroundColors: Bool {
@@ -267,7 +274,14 @@ final class EditorSetViewModel: ObservableObject {
                 await self?.onDataChange(update)
             }
         }.store(in: &subscriptions)
-        
+
+        // Relation-details changes (rename, read-only/format) arrive via syncPublisher
+        // without a .dataviewUpdated event, so refresh the cached columns here too.
+        // updateColumns() diff-guards, so redundant calls are free.
+        setDocument.syncPublisher.receiveOnMain().sink { [weak self] in
+            self?.updateColumns()
+        }.store(in: &subscriptions)
+
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
@@ -436,6 +450,7 @@ final class EditorSetViewModel: ObservableObject {
         }
         setupTitle()
         setupDescription()
+        updateColumns()
         await startSubscriptionIfNeeded()
         updateConfigurations(with: Array(recordsDict.keys))
 
@@ -623,7 +638,12 @@ final class EditorSetViewModel: ObservableObject {
                 tempConfigurationsDict[groupId] = configurations
             }
         }
-        configurationsDict = sortedConfigurationsDict(with: tempConfigurationsDict)
+        let sortedDict = sortedConfigurationsDict(with: tempConfigurationsDict)
+        // Diff-guard: skip the publish when nothing changed so a single-record event
+        // doesn't re-render the whole grid/table. SetContentViewItemConfiguration is
+        // Equatable (onItemTap is @EquatableNoop), so this compare is cheap.
+        guard sortedDict != configurationsDict else { return }
+        configurationsDict = sortedDict
     }
     
     private func sortedConfigurationsDict(

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -706,7 +706,10 @@ final class EditorSetViewModel: ObservableObject {
     
     @MainActor
     private func itemTapped(_ details: ObjectDetails) {
-        openObject(details: details)
+        // Row closures capture a details snapshot; the configurations diff-guard can keep a row
+        // whose navigation-relevant fields (bookmark source, chatId, layout) changed invisibly.
+        let freshDetails = subscriptionStorages.values.compactMap { $0.detailsStorage.get(id: details.id) }.first
+        openObject(details: freshDetails ?? details)
     }
     
     private func clearState() async {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -57,13 +57,9 @@ final class EditorSetViewModel: ObservableObject {
         setDocument.dataView.views.isEmpty
     }
 
-    // Cached on the dataview-update path instead of recomputed on every access:
-    // the pinned table header reads this in its body, which re-evaluates on every
-    // model publish (e.g. a row edit) and would otherwise re-run the sort/filter/map.
+    // Cached to avoid re-sorting on every body re-evaluation; diff-guarded.
     @Published private(set) var colums: [PropertyDetails] = []
-    // Captured by value into the `.equatable()` table header; recomputed on the same
-    // path as `colums` so a viewer→editor permission flip refreshes the header
-    // deterministically instead of relying on an incidental unrelated publish.
+    // Captured by value so a permission flip refreshes the header deterministically.
     @Published private(set) var canEditRelationValuesInView = false
 
     private func updateColumns() {
@@ -284,14 +280,11 @@ final class EditorSetViewModel: ObservableObject {
             }
         }.store(in: &subscriptions)
 
-        // Relation-details changes (rename, read-only/format) arrive via syncPublisher
-        // without a .dataviewUpdated event, so refresh the cached columns here too.
-        // updateColumns() diff-guards, so redundant calls are free.
+        // Relation renames/format changes arrive via syncPublisher without a dataview event.
         setDocument.syncPublisher.receiveOnMain().sink { [weak self] in
             guard let self else { return }
             updateColumns()
-            // A relation format/read-only change doesn't emit a record Amend, so refresh
-            // the per-record cell configs too. Diff-guarded → a no-op when nothing changed.
+            // Relation format/read-only changes emit no record Amend; refresh cell configs (diff-guarded).
             updateConfigurations(with: Array(recordsDict.keys))
         }.store(in: &subscriptions)
 
@@ -652,9 +645,7 @@ final class EditorSetViewModel: ObservableObject {
             }
         }
         let sortedDict = sortedConfigurationsDict(with: tempConfigurationsDict)
-        // Diff-guard: skip the publish when nothing changed so a single-record event
-        // doesn't re-render the whole grid/table. SetContentViewItemConfiguration is
-        // Equatable (onItemTap is @EquatableNoop), so this compare is cheap.
+        // Diff-guard: skip publish when unchanged; SetContentViewItemConfiguration is Equatable.
         guard sortedDict != configurationsDict else { return }
         configurationsDict = sortedDict
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/SetTableView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/SetTableView.swift
@@ -85,7 +85,7 @@ struct SetTableView: View {
             headerSettingsView
             SetTableViewHeader(
                 columns: model.colums,
-                canEditRelationValuesInView: model.setDocument.setPermissions.canEditRelationValuesInView
+                canEditRelationValuesInView: model.canEditRelationValuesInView
             )
             .equatable()
         }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/SetTableView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/SetTableView.swift
@@ -24,10 +24,7 @@ struct SetTableView: View {
             OffsetAwareScrollView(
                 axes: [.vertical],
                 showsIndicators: false,
-                offsetChanged: {
-                    offset.y = $0.y
-                    UIApplication.shared.hideKeyboard()
-                }
+                offsetChanged: { offset.y = $0.y }
             ) {
                 Spacer.fixedHeight(tableHeaderSize.height)
                 LazyVStack(
@@ -42,6 +39,7 @@ struct SetTableView: View {
                 .padding(.top, -headerMinimizedSize.height)
             }
         }
+        .scrollDismissesKeyboard(.immediately)
     }
     
     @ViewBuilder
@@ -85,7 +83,11 @@ struct SetTableView: View {
     private var compoundHeader: some View {
         VStack(spacing: 0) {
             headerSettingsView
-            SetTableViewHeader(model: model)
+            SetTableViewHeader(
+                columns: model.colums,
+                canEditRelationValuesInView: model.setDocument.setPermissions.canEditRelationValuesInView
+            )
+            .equatable()
         }
         .background(Color.Background.primary)
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/SetTableViewHeader.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/SetTableViewHeader.swift
@@ -1,8 +1,14 @@
 import SwiftUI
+import Services
 
-struct SetTableViewHeader: View {
-    @ObservedObject var model: EditorSetViewModel
-    
+struct SetTableViewHeader: View, Equatable {
+    let columns: [PropertyDetails]
+    let canEditRelationValuesInView: Bool
+
+    nonisolated static func == (lhs: SetTableViewHeader, rhs: SetTableViewHeader) -> Bool {
+        lhs.columns == rhs.columns && lhs.canEditRelationValuesInView == rhs.canEditRelationValuesInView
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             AnytypeDivider()
@@ -10,13 +16,13 @@ struct SetTableViewHeader: View {
             AnytypeDivider()
         }
     }
-    
+
     private var content: some View {
         LazyHStack(spacing: 0) {
-            ForEach(model.colums, id: \.key) { data in
+            ForEach(columns, id: \.key) { data in
                 HStack(spacing: 0) {
                     Spacer.fixedWidth(15)
-                    if data.isReadOnlyValue || !model.setDocument.setPermissions.canEditRelationValuesInView {
+                    if data.isReadOnlyValue || !canEditRelationValuesInView {
                         Image(asset: .relationLockedSmall)
                             .tint(.Control.secondary)
                         Spacer.fixedWidth(4)
@@ -27,7 +33,7 @@ struct SetTableViewHeader: View {
                         .minimumScaleFactor(0.5)
                     Spacer()
                 }.frame(width: 144)
-                
+
                 Rectangle()
                     .frame(width: .onePixel, height: 18)
                     .foregroundStyle(Color.Shape.primary)
@@ -39,6 +45,6 @@ struct SetTableViewHeader: View {
 
 struct SetTableViewHeader_Previews: PreviewProvider {
     static var previews: some View {
-        SetTableViewHeader(model: EditorSetViewModel.emptyPreview)
+        SetTableViewHeader(columns: [], canEditRelationValuesInView: true)
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/SetTableViewHeader.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/SetTableViewHeader.swift
@@ -5,10 +5,6 @@ struct SetTableViewHeader: View, Equatable {
     let columns: [PropertyDetails]
     let canEditRelationValuesInView: Bool
 
-    nonisolated static func == (lhs: SetTableViewHeader, rhs: SetTableViewHeader) -> Bool {
-        lhs.columns == rhs.columns && lhs.canEditRelationValuesInView == rhs.canEditRelationValuesInView
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             AnytypeDivider()


### PR DESCRIPTION
## Summary
- Guard the `configurationsDict` reassignment so a no-op dataview event no longer re-renders the whole grid/table.
- Cache `columns` as `@Published` (recomputed on dataview/relation-sync updates) + `.equatable()` table header, instead of recomputing on every pinned-header body pass.
- Use native `.scrollDismissesKeyboard(.immediately)` instead of calling `hideKeyboard()` on every scroll frame.
