### PR TITLE
IOS-6520 Search: debounce queries, stable list identity, drop per-keystroke list reset

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/Common/SearchView/SearchView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/Common/SearchView/SearchView.swift
@@ -49,6 +49,9 @@ struct SearchView<SearchData: SearchDataProtocol>: View {
         }
         .background(Color.Background.secondary)
         .task(id: searchText) {
+            // Debounce: a new keystroke changes the id, cancelling this task so
+            // the sleep throws and `search` is never called for intermediate terms.
+            guard (try? await Task.sleep(for: .milliseconds(300))) != nil else { return }
             await search(searchText)
         }
     }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/Common/SearchView/SearchView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/Common/SearchView/SearchView.swift
@@ -49,9 +49,13 @@ struct SearchView<SearchData: SearchDataProtocol>: View {
         }
         .background(Color.Background.secondary)
         .task(id: searchText) {
-            // Debounce: a new keystroke changes the id, cancelling this task so
-            // the sleep throws and `search` is never called for intermediate terms.
-            guard (try? await Task.sleep(for: .milliseconds(300))) != nil else { return }
+            // Debounce real typing: a new keystroke changes the id, cancelling this task so
+            // the sleep throws and `search` is never called for intermediate terms. Skip the
+            // delay for the initial/empty load so pickers populate immediately without a flash
+            // of the empty state (and its malformed empty-query title).
+            if searchText.isNotEmpty {
+                guard (try? await Task.sleep(for: .milliseconds(300))) != nil else { return }
+            }
             await search(searchText)
         }
     }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchState.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchState.swift
@@ -6,4 +6,16 @@ struct GlobalSearchState: Equatable, Hashable, Codable {
     var shouldGroupResults: Bool {
         sort.relation.canGroupByDate && searchText.isEmpty
     }
+
+    // Identity used to reset the results List scroll position only when the
+    // section or sort changes. Excludes `searchText` so typing diffs rows by id
+    // instead of tearing down the whole List on every keystroke.
+    var scrollResetKey: ScrollResetKey {
+        ScrollResetKey(section: section, sort: sort)
+    }
+
+    struct ScrollResetKey: Equatable, Hashable {
+        let section: ObjectTypeSection
+        let sort: ObjectSort
+    }
 }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchView.swift
@@ -115,7 +115,7 @@ struct GlobalSearchView: View {
             }
         }
         .scrollIndicators(.never)
-        .id(model.state)
+        .id(model.state.scrollResetKey)
     }
     
     private func itemRow(for rowModel: SearchWithMetaModel) -> some View {

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/GlobalSearch/GlobalSearchViewModel.swift
@@ -54,6 +54,7 @@ final class GlobalSearchViewModel {
     
     func startParticipantTask() async {
         for await participant in accountParticipantStorage.participantSequence(spaceId: moduleData.spaceId) {
+            guard participant.canEdit != participantCanEdit else { continue }
             participantCanEdit = participant.canEdit
             updateSections()
         }
@@ -166,7 +167,7 @@ final class GlobalSearchViewModel {
     
     private func listSectionData(title: String?, result: [SearchResultWithMeta]) -> ListSectionData<String?, SearchWithMetaModel> {
         ListSectionData(
-            id: title ?? UUID().uuidString,
+            id: title ?? "single_section",
             data: title,
             rows: result.compactMap { result in
                 searchWithMetaModelBuilder.buildModel(

--- a/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/ObjectsSearchViewModel/ObjectsSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Search screen/InternalViewModels/ObjectsSearchViewModel/ObjectsSearchViewModel.swift
@@ -92,13 +92,16 @@ private extension Array where Element == ObjectDetails {
                 details: details,
                 selectedIds: selectedIds
             )
+            let rowModel = SearchObjectRowView.Model(details: details)
             return ListRowConfiguration(
+                // Hash only the rendered fields so unrelated detail churn doesn't
+                // invalidate visually-identical rows.
                 id: details.id,
-                contentHash: details.hashValue ^ (selectionIndicator?.hashValue ?? 0)
+                contentHash: rowModel.hashValue ^ (selectionIndicator?.hashValue ?? 0)
             ) {
                 AnyView(
                     SearchObjectRowView(
-                        viewModel: SearchObjectRowView.Model(details: details),
+                        viewModel: rowModel,
                         selectionIndicatorViewModel: selectionIndicator
                     )
                 )

--- a/Anytype/Sources/PresentationLayer/Search screen/ViewModel/LegacySearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Search screen/ViewModel/LegacySearchViewModel.swift
@@ -54,8 +54,15 @@ extension LegacySearchViewModel {
     
     func didAskToSearch(text: String) {
         searchTask?.cancel()
-        
+
         searchTask = Task { @MainActor in
+            // Debounce only real typing: the next keystroke cancels this task, so the
+            // sleep throws and the middleware search is skipped for intermediate terms.
+            // The initial/empty-text load (onAppear and clear-to-empty) runs instantly,
+            // matching GlobalSearch's needDelay() behavior.
+            if text.isNotEmpty {
+                guard (try? await Task.sleep(for: .milliseconds(300))) != nil else { return }
+            }
             try? await internalViewModel.search(text: text)
             updateCreateItemButtonState(searchText: text)
         }


### PR DESCRIPTION
## Summary
- Scope the GlobalSearch `List` `.id` to section+sort (was `model.state`, which reset the whole list and tore down the table on every keystroke).
- Deterministic section ids (drop per-query `UUID`).
- 300ms in-task debounce on Legacy search and the shared `SearchView` (guarded so initial load is not delayed).
- Narrow the Legacy row content hash to rendered fields; guard the participant-path `updateSections`.
