### PR TITLE
IOS-6521 Editor: O(n) layout traversal, empty-diff early-out, per-section height cache

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/CompositionalBlock/SpreadsheetDataSource.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/CompositionalBlock/SpreadsheetDataSource.swift
@@ -7,7 +7,15 @@ final class SpreadsheetViewDataSource {
     typealias DataSource = UICollectionViewDiffableDataSource<Int, EditorItem>
     typealias Snapshot = NSDiffableDataSourceSnapshot<Int, EditorItem>
 
-    var allModels = [[EditorItem]]()
+    var allModels = [[EditorItem]]() {
+        didSet {
+            // Content/structure changed: invalidate memoized section heights so the
+            // layout re-measures on the next prepare() (single-cell edits keep using
+            // the targeted setNeedsLayout(indexPath:) path). Driven from the write
+            // itself so a new mutation path can't forget to invalidate.
+            (collectionView.collectionViewLayout as? SpreadsheetLayout)?.invalidateCachedHeights()
+        }
+    }
     private lazy var dataSource: DataSource = makeCollectionViewDataSource()
     private let collectionView: EditorCollectionView
     private let templateCell = EditorViewListCell()
@@ -55,10 +63,6 @@ final class SpreadsheetViewDataSource {
         }
 
         self.allModels = allModels
-        // Content/structure changed: invalidate memoized section heights so the
-        // layout re-measures on the next prepare() (single-cell edits keep using
-        // the targeted setNeedsLayout(indexPath:) path).
-        (collectionView.collectionViewLayout as? SpreadsheetLayout)?.invalidateCachedHeights()
         applyBlocksSectionSnapshot(snapshot, animatingDifferences: true)
     }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/CompositionalBlock/SpreadsheetDataSource.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/CompositionalBlock/SpreadsheetDataSource.swift
@@ -55,6 +55,10 @@ final class SpreadsheetViewDataSource {
         }
 
         self.allModels = allModels
+        // Content/structure changed: invalidate memoized section heights so the
+        // layout re-measures on the next prepare() (single-cell edits keep using
+        // the targeted setNeedsLayout(indexPath:) path).
+        (collectionView.collectionViewLayout as? SpreadsheetLayout)?.invalidateCachedHeights()
         applyBlocksSectionSnapshot(snapshot, animatingDifferences: true)
     }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/CompositionalBlock/SpreadsheetLayout.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/CompositionalBlock/SpreadsheetLayout.swift
@@ -77,6 +77,12 @@ final class SpreadsheetLayout: UICollectionViewLayout {
         }
 
         for sectionIndex in 0..<dataSource.allModels.count {
+            // Re-measure only sections whose cached height was invalidated
+            // (a single-cell edit nils one section; `reset()`/`invalidateEverything()`
+            // clear the whole cache). Avoids re-measuring the entire table on every
+            // attribute-only invalidation.
+            if cachedSectionHeights[sectionIndex] != nil { continue }
+
             var sectionMaxHeight: CGFloat = 0
 
             for rowIndex in 0..<dataSource.allModels[sectionIndex].count {
@@ -108,6 +114,8 @@ final class SpreadsheetLayout: UICollectionViewLayout {
     }
 
     private func reset() {
+        // Column widths changed: every cached height is stale (width drives text wrapping).
+        invalidateCachedHeights()
         prepare()
     }
 
@@ -157,6 +165,12 @@ final class SpreadsheetLayout: UICollectionViewLayout {
 }
 
 extension SpreadsheetLayout {
+    // Drop all memoized section heights: content/structure of `allModels` changed,
+    // so every section must be re-measured on the next `prepare()`.
+    func invalidateCachedHeights() {
+        cachedSectionHeights.removeAll()
+    }
+
     func setNeedsLayout(indexPath: IndexPath) {
         guard let dataSource = dataSource,
               dataSource.contentConfigurationProvider(at: indexPath).isNotNil else { return }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/CompositionalBlock/SpreadsheetLayout.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/CompositionalBlock/SpreadsheetLayout.swift
@@ -27,7 +27,7 @@ final class SpreadsheetLayout: UICollectionViewLayout {
         dataSource = nil
         cancellables.removeAll()
         attributes.removeAll()
-        cachedSectionHeights.removeAll()
+        invalidateCachedHeights()
         contentSize = .zero
         lastSelectedAttributes.removeAll()
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
@@ -141,16 +141,26 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
     
     private func handleUpdate(ids: [String]) {
         let blocksViewModels = blockBuilder.buildEditorItems(infos: ids, ignoreCache: false)
-        
+
+        let wasEmpty = modelsHolder.items.isEmpty
         let difference = modelsHolder.difference(between: blocksViewModels)
         if difference.insertions.isNotEmpty {
             modelsHolder.applyDifference(difference: difference)
         } else {
             modelsHolder.items = blocksViewModels
         }
-        
+
         guard document.isOpened else { return }
-        
+
+        // Skip re-applying a full-section snapshot when nothing structurally changed.
+        // `flattenBlockIds` is id-deduped, but a no-op emission still pays a full
+        // diff inside `apply`. Keep applying when the models were just populated
+        // (initial render) or when the initial scroll is still pending.
+        let initialScrollPending = !didScrollToInitialBlock && configuration.blockId != nil
+        if difference.isEmpty, !wasEmpty, !initialScrollPending {
+            return
+        }
+
         viewInput?.update(changes: difference, allModels: modelsHolder.items, isRealData: true) { [weak self] in
             guard let self else { return }
             cursorManager.handleGeneralUpdate(with: modelsHolder.items, type: document.details?.type)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/FlowLayout/EditorCollectionFlowLayout+LayoutDetails.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/FlowLayout/EditorCollectionFlowLayout+LayoutDetails.swift
@@ -28,18 +28,10 @@ extension EditorCollectionFlowLayout {
     
     // MARK: - Private
     nonisolated private static func traverseBlock(_ block: BlockInformation, dictionary: [String: BlockInformation]) -> [String] {
-        block.childrenIds.map { childId -> [String] in
-
-            var childIndentifiers = [String]()
-            if let childInformation = dictionary[childId] {
-                childIndentifiers.append(childInformation.id)
-                childIndentifiers.append(
-                    contentsOf: traverseBlock(childInformation, dictionary: dictionary)
-                )
-            }
-
-            return childIndentifiers
-        }.flatMap { $0 }
+        block.childrenIds.flatMap { childId -> [String] in
+            guard let childInformation = dictionary[childId] else { return [] }
+            return [childId] + traverseBlock(childInformation, dictionary: dictionary)
+        }
     }
     
     nonisolated private static func findIdentation(

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/FlowLayout/EditorCollectionFlowLayout+LayoutDetails.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/FlowLayout/EditorCollectionFlowLayout+LayoutDetails.swift
@@ -6,14 +6,14 @@ extension EditorCollectionFlowLayout {
     nonisolated static func blockLayoutDetails(blockInfos: [BlockInformation]) -> [String: BlockLayoutDetails] {
         var output = [String: BlockLayoutDetails]()
         
-        let dictionary = Dictionary(
+        let dictionary: [String: BlockInformation] = Dictionary(
             uniqueKeysWithValues: blockInfos.map { ($0.id, $0) }
         )
         
         for rootBlockInfo in blockInfos {
             output[rootBlockInfo.id] = BlockLayoutDetails(
                 id: rootBlockInfo.id,
-                allChildIds: traverseBlock(rootBlockInfo, blockInfos: blockInfos),
+                allChildIds: traverseBlock(rootBlockInfo, dictionary: dictionary),
                 indentations: findIdentation(
                     currentIdentations: [],
                     blockInfo: rootBlockInfo,
@@ -27,17 +27,17 @@ extension EditorCollectionFlowLayout {
     }
     
     // MARK: - Private
-    nonisolated private static func traverseBlock(_ block: BlockInformation, blockInfos: [BlockInformation]) -> [String] {
+    nonisolated private static func traverseBlock(_ block: BlockInformation, dictionary: [String: BlockInformation]) -> [String] {
         block.childrenIds.map { childId -> [String] in
-            
+
             var childIndentifiers = [String]()
-            if let childInformation = blockInfos.first(where: { info in info.id == childId }) {
+            if let childInformation = dictionary[childId] {
                 childIndentifiers.append(childInformation.id)
                 childIndentifiers.append(
-                    contentsOf: traverseBlock(childInformation, blockInfos: blockInfos)
+                    contentsOf: traverseBlock(childInformation, dictionary: dictionary)
                 )
             }
-            
+
             return childIndentifiers
         }.flatMap { $0 }
     }
@@ -45,7 +45,7 @@ extension EditorCollectionFlowLayout {
     nonisolated private static func findIdentation(
         currentIdentations: [BlockIndentationStyle],
         blockInfo: BlockInformation,
-        dictionary: [AnyHashable : BlockInformation]
+        dictionary: [String: BlockInformation]
     ) -> [BlockIndentationStyle] {
         guard let parentId = blockInfo.configurationData.parentId,
               let parent = dictionary[parentId]  else {


### PR DESCRIPTION
## Summary
- Replace the O(n²) per-child block traversal in layout details with an O(1) dictionary lookup (linear over the document).
- Early-out of the full-snapshot re-apply when the computed diff is empty (preserving initial render and deep-link scroll-to-block).
- Memoize `SpreadsheetLayout` section heights so a single-cell edit re-measures only its section; invalidate on content / column-width change.
