### PR TITLE
IOS-6476 Fix Current User filter not working on iOS

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Group/SetGroupSubscriptionDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Group/SetGroupSubscriptionDataBuilder.swift
@@ -1,25 +1,32 @@
 import Foundation
 import Services
+import AnytypeCore
 
 @MainActor
 protocol SetGroupSubscriptionDataBuilderProtocol {
-    
+
     var groupSubscriptionId: String { get }
-    
+
     func groupsData(_ setDocument: some SetDocumentProtocol) -> GroupsSubscriptionData
 }
 
 @MainActor
 final class SetGroupSubscriptionDataBuilder: SetGroupSubscriptionDataBuilderProtocol {
-    
+
     let groupSubscriptionId = "Set.Groups-\(UUID().uuidString)"
-    
+
+    @Injected(\.participantsStorage)
+    private var participantsStorage: any ParticipantsStorageProtocol
+
     nonisolated init() {}
-    
+
     func groupsData(_ setDocument: some SetDocumentProtocol) -> GroupsSubscriptionData {
+        let participantId = participantsStorage.participants
+            .first { $0.spaceId == setDocument.spaceId }?.id
         var filters = setDocument.activeView.filters
             .enrichingFormats(with: setDocument.dataViewRelationsDetails)
             .removingUnsupportedFilters()
+            .resolvingCurrentUserPlaceholder(participantId: participantId)
         filters.append(SearchHelper.filterOutParticipantType())
         return GroupsSubscriptionData(
             spaceId: setDocument.spaceId,

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionDataBuilder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Services
+import AnytypeCore
 
 protocol SetSubscriptionDataBuilderProtocol: AnyObject, Sendable {
     
@@ -9,26 +10,34 @@ protocol SetSubscriptionDataBuilderProtocol: AnyObject, Sendable {
 }
 
 final class SetSubscriptionDataBuilder: SetSubscriptionDataBuilderProtocol, Sendable {
-    
+
     let subscriptionId = "Set-\(UUID().uuidString)"
-    
+
+    @Injected(\.participantsStorage)
+    private var participantsStorage: any ParticipantsStorageProtocol
+
     init() {}
-    
+
     // MARK: - SetSubscriptionDataBuilderProtocol
-    
+
     func set(_ data: SetSubscriptionData) -> SubscriptionData {
         let numberOfRowsPerPageInSubscriptions = data.numberOfRowsPerPage
 
         let keys = buildKeys(with: data)
-        
+
         let offset = max((data.currentPage - 1) * numberOfRowsPerPageInSubscriptions, 0)
-        
+
+        let participantId = participantsStorage.participants
+            .first { $0.spaceId == data.spaceId }?.id
+        let filters = data.filters
+            .resolvingCurrentUserPlaceholder(participantId: participantId)
+
         return .search(
             SubscriptionData.Search(
                 identifier: data.identifier,
                 spaceId: data.spaceId,
                 sorts: data.sorts,
-                filters: data.filters,
+                filters: filters,
                 limit: numberOfRowsPerPageInSubscriptions,
                 offset: offset,
                 keys: keys,

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/DataviewFilter+Condition.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/DataviewFilter+Condition.swift
@@ -56,6 +56,30 @@ extension Array where Element == DataviewFilter {
             return filter.isSupportedForSubscription ? filter : nil
         }
     }
+
+    // Middleware stores a "Current User" filter value as a placeholder struct ({ type, value }),
+    // not a participant id. The placeholder is resolved client-side (same as desktop/Android) by
+    // substituting the current participant id before subscribing.
+    func resolvingCurrentUserPlaceholder(participantId: String?) -> [DataviewFilter] {
+        map { filter in
+            var resolved = filter
+            // Advanced filter: recurse into nested conditions
+            if filter.operator != .no {
+                resolved.nestedFilters = filter.nestedFilters
+                    .resolvingCurrentUserPlaceholder(participantId: participantId)
+                return resolved
+            }
+            guard let placeholder = RelationPlaceholder(filter.value),
+                  case .currentUser = placeholder.type,
+                  let participantId else { return filter }
+            // Match the value shape to the condition: list-based conditions expect a list,
+            // equality-based conditions expect a scalar (see SearchHelper).
+            resolved.value = filter.condition.expectsListValue
+                ? [participantId].protobufValue
+                : participantId.protobufValue
+            return resolved
+        }
+    }
 }
 
 extension DataviewFilter.Condition {
@@ -65,6 +89,16 @@ extension DataviewFilter.Condition {
             return false
         default:
             return true
+        }
+    }
+
+    // List-based conditions expect a list value; equality-based conditions expect a scalar.
+    var expectsListValue: Bool {
+        switch self {
+        case .in, .notIn, .allIn, .notAllIn, .exactIn, .notExactIn:
+            return true
+        default:
+            return false
         }
     }
     

--- a/Modules/Services/Sources/Models/Properties/Models/RelationPlaceholder.swift
+++ b/Modules/Services/Sources/Models/Properties/Models/RelationPlaceholder.swift
@@ -6,7 +6,7 @@ public struct RelationPlaceholder: Sendable {
     public let type: PlaceholderType
     public let value: Google_Protobuf_Value?
 
-    init?(_ protobufValue: Google_Protobuf_Value) {
+    public init?(_ protobufValue: Google_Protobuf_Value) {
         guard case .structValue(let structValue) = protobufValue.kind else { return nil }
         guard let typeValue = structValue.fields["type"]?.safeIntValue else { return nil }
         self.type = PlaceholderType(rawValue: typeValue)


### PR DESCRIPTION
## Summary
- Resolve the "Current User" dataview filter placeholder client-side into the current participant id before subscribing, so Sets/Collections/Queries filtered by `Assignee = Current User` return results on iOS (as they already do on desktop/Android).
- The middleware stores this value as a placeholder struct (`{ type: currentUser, value }`) in the filter `value`; iOS previously passed it through unresolved, matching nothing.
- Covers both the main Set subscription (`SetSubscriptionDataBuilder`) and grouped-Set group enumeration (`SetGroupSubscriptionDataBuilder`); recurses into advanced/nested filters; value shape matches the condition (list for in-style, scalar for equality).

https://claude.ai/code/session_01TeftV2hts4NppaTVr1AxYD