### PR TITLE
IOS-6575 Middleware RPC/event pipeline: perf + correctness fixes

### DIFF
--- a/Anytype/Sources/CoreLayer/MiddlewareHandler/InvocationMesagesHandler.swift
+++ b/Anytype/Sources/CoreLayer/MiddlewareHandler/InvocationMesagesHandler.swift
@@ -7,9 +7,11 @@ import SwiftEntryKit
 final class InvocationMesagesHandler: InvocationMesagesHandlerProtocol {
     
     var enableLogger: Bool = false
-    
+
+    var isLogEnabled: Bool { enableLogger }
+
     func logHandler(message: InvocationMessage) {
-        
+
         guard enableLogger else { return }
         
         // Delete emoji. Pulse crash issue https://github.com/kean/PulsePro/issues/22

--- a/Anytype/Sources/Models/Documents/Events/EventsListener.swift
+++ b/Anytype/Sources/Models/Documents/Events/EventsListener.swift
@@ -104,19 +104,14 @@ actor EventsListener: EventsListenerProtocol {
 
         // Both walks below are O(document size). Mention texts depend on block
         // content and on details of mentioned objects; indentation metadata and
-        // numbered-list values depend on block changes only.
-        let convertedUpdates = middlewareUpdates + localUpdates
-        let hasBlockUpdates = convertedUpdates.contains { update in
-            switch update {
-            case .general, .block, .unhandled:
-                return true
-            default:
-                return false
-            }
-        }
-        let hasDetailsUpdates = convertedUpdates.contains { update in
-            guard case .details = update else { return false }
-            return true
+        // numbered-list values depend on block changes only. Classify in a single
+        // early-exit pass instead of two scans over a merged array.
+        var hasBlockUpdates = false
+        var hasDetailsUpdates = false
+        for update in [middlewareUpdates, localUpdates].joined() {
+            hasBlockUpdates = hasBlockUpdates || update.affectsBlocks
+            hasDetailsUpdates = hasDetailsUpdates || update.affectsDetails
+            if hasBlockUpdates && hasDetailsUpdates { break }
         }
 
         let markupUpdates = hasBlockUpdates || hasDetailsUpdates

--- a/Anytype/Sources/Models/Documents/Events/EventsListener.swift
+++ b/Anytype/Sources/Models/Documents/Events/EventsListener.swift
@@ -101,15 +101,34 @@ actor EventsListener: EventsListenerProtocol {
     private func handle(events: EventsBunch) {
         let middlewareUpdates = events.middlewareEvents.compactMap(\.value).compactMap { middlewareConverter.convert($0) }
         let localUpdates = events.localEvents.flatMap { localConverter.convert($0) }
-        let markupUpdates = mentionMarkupEventProvider.updateMentionsEvent()
 
-        let builderChangedIds = IndentationBuilder.build(
-            container: infoContainer,
-            id: objectId
-        )
-        let builderUpdates: [DocumentUpdate] = builderChangedIds.map { .block(blockId: $0) }
-    
+        // Both walks below are O(document size). Mention texts depend on block
+        // content and on details of mentioned objects; indentation metadata and
+        // numbered-list values depend on block changes only.
+        let convertedUpdates = middlewareUpdates + localUpdates
+        let hasBlockUpdates = convertedUpdates.contains { update in
+            switch update {
+            case .general, .block, .unhandled:
+                return true
+            default:
+                return false
+            }
+        }
+        let hasDetailsUpdates = convertedUpdates.contains { update in
+            guard case .details = update else { return false }
+            return true
+        }
+
+        let markupUpdates = hasBlockUpdates || hasDetailsUpdates
+            ? mentionMarkupEventProvider.updateMentionsEvent()
+            : []
+
+        let builderUpdates: [DocumentUpdate] = hasBlockUpdates
+            ? IndentationBuilder.build(container: infoContainer, id: objectId).map { .block(blockId: $0) }
+            : []
+
         let updates = middlewareUpdates + markupUpdates + localUpdates + builderUpdates
+        guard updates.isNotEmpty else { return }
         receiveUpdates(updates)
     }
     

--- a/Anytype/Sources/Models/Documents/Events/Model/DocumentUpdate.swift
+++ b/Anytype/Sources/Models/Documents/Events/Model/DocumentUpdate.swift
@@ -21,4 +21,24 @@ extension DocumentUpdate {
             return false
         }
     }
+
+    // Mention texts and indentation/numbered-list metadata are rebuilt only when
+    // blocks change; mention texts also depend on details of mentioned objects.
+    var affectsBlocks: Bool {
+        switch self {
+        case .general, .block, .unhandled:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var affectsDetails: Bool {
+        switch self {
+        case .details:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Anytype/Sources/ServiceLayer/SubscriptionsToggler/Internals/SubscriptionStorage.swift
+++ b/Anytype/Sources/ServiceLayer/SubscriptionsToggler/Internals/SubscriptionStorage.swift
@@ -157,7 +157,7 @@ actor SubscriptionStorage: SubscriptionStorageProtocol {
 
         guard didMutate else { return }
 
-        state.items = orderIds.compactMap { detailsStorage.get(id: $0) }
+        updateItemsCache()
 
         if oldState != state {
             await update?(state)

--- a/Anytype/Sources/ServiceLayer/SubscriptionsToggler/Internals/SubscriptionStorage.swift
+++ b/Anytype/Sources/ServiceLayer/SubscriptionsToggler/Internals/SubscriptionStorage.swift
@@ -107,30 +107,41 @@ actor SubscriptionStorage: SubscriptionStorageProtocol {
         anytypeAssert(events.localEvents.isEmpty, "Local events with emplty objectId: \(events)")
         
         let oldState = state
-        
+
+        // Every event bunch in the app reaches every subscription. Rebuilding
+        // items + comparing state for bunches that touched nothing here is pure
+        // waste, so track whether any event actually applied to this sub.
+        var didMutate = false
+
         for event in events.middlewareEvents {
             switch event.value {
             case .objectDetailsSet(let data):
                 guard idsContainsMySub(data.subIds, incudeDeps: true) else { break }
                 _ = detailsStorage.set(data: data)
+                didMutate = true
             case .objectDetailsAmend(let data):
                 guard idsContainsMySub(data.subIds, incudeDeps: true) else { break }
                 _ = detailsStorage.amend(data: data)
+                didMutate = true
             case .objectDetailsUnset(let data):
                 guard idsContainsMySub(data.subIds, incudeDeps: true) else { break }
                 _ = detailsStorage.unset(data: data)
+                didMutate = true
             case .subscriptionPosition(let data):
                 guard idsContainsMySub([data.subID]) else { break }
                 let update: SubscriptionUpdate = .move(from: data.id, after: data.afterID.isNotEmpty ? data.afterID : nil)
                 orderIds.applySubscriptionUpdate(update)
+                didMutate = true
             case .subscriptionAdd(let data):
                 guard idsContainsMySub([data.subID]) else { break }
                 let update: SubscriptionUpdate = .add(data.id, after: data.afterID.isNotEmpty ? data.afterID : nil)
                 orderIds.applySubscriptionUpdate(update)
+                didMutate = true
             case .subscriptionRemove(let data):
                 guard idsContainsMySub([data.subID]) else { break }
                 let update: SubscriptionUpdate = .remove(data.id)
                 orderIds.applySubscriptionUpdate(update)
+                didMutate = true
             case .objectRemove:
                 break // unsupported (Not supported in middleware converter also)
             case .subscriptionCounters(let data):
@@ -138,15 +149,17 @@ actor SubscriptionStorage: SubscriptionStorageProtocol {
                 state.total = Int(data.total)
                 state.nextCount = Int(data.nextCount)
                 state.prevCount = Int(data.prevCount)
+                didMutate = true
             default:
                 break
             }
         }
-        
+
+        guard didMutate else { return }
+
         state.items = orderIds.compactMap { detailsStorage.get(id: $0) }
-        
+
         if oldState != state {
-            updateItemsCache()
             await update?(state)
             stateSubject.send(state)
         }

--- a/Modules/ProtobufMessages/Sources/Invocation.swift
+++ b/Modules/ProtobufMessages/Sources/Invocation.swift
@@ -51,11 +51,14 @@ public struct Invocation<Request, Response>: Sendable where Request: Message & S
         
         let result: Response
         
-        let requestId = await RequestIdStorage.shared.createId()
-    
-        var requestForLog = request
-        requestMask?(&requestForLog)
-        log(message: messageName, requestId: requestId, data: requestForLog)
+        let logEnabled = InvocationSettings.handler?.isLogEnabled ?? false
+        let requestId = logEnabled ? await RequestIdStorage.shared.createId() : 0
+
+        if logEnabled {
+            var requestForLog = request
+            requestMask?(&requestForLog)
+            log(message: messageName, requestId: requestId, data: requestForLog)
+        }
         
         try Task.checkCancellation()
         
@@ -75,10 +78,12 @@ public struct Invocation<Request, Response>: Sendable where Request: Message & S
             throw error
         }
         
-        var resultForLog = result
-        responseMask?(&resultForLog)
-        let errorForLog = result.error.isNull ? nil : result.error
-        log(message: messageName, requestId: requestId, data: resultForLog, error: errorForLog)
+        if logEnabled {
+            var resultForLog = result
+            responseMask?(&resultForLog)
+            let errorForLog = result.error.isNull ? nil : result.error
+            log(message: messageName, requestId: requestId, data: resultForLog, error: errorForLog)
+        }
         
         if !result.error.isNull {
             throw result.error
@@ -94,17 +99,19 @@ public struct Invocation<Request, Response>: Sendable where Request: Message & S
     }
     
     private func log(message: String, requestId: Int, data: Request?) {
+        guard let handler = InvocationSettings.handler, handler.isLogEnabled else { return }
         let message = InvocationMessage(
             name: "\(message)-Request-\(requestId)",
             requestJsonData: nil,
             responseJsonData: try? data?.jsonUTF8Data(),
             responseError: nil
         )
-        InvocationSettings.handler?.logHandler(message: message)
+        handler.logHandler(message: message)
     }
-    
+
     private func log(message: String, requestId: Int, data: Response?, error: Error?) {
-        
+        guard let handler = InvocationSettings.handler, handler.isLogEnabled else { return }
+
         let name: String
         if let data, !data.event.messages.isEmpty {
             let messageNames = (try? data.event.jsonUTF8Data())?.parseMessages() ?? ""
@@ -119,6 +126,6 @@ public struct Invocation<Request, Response>: Sendable where Request: Message & S
             responseJsonData: try? data?.jsonUTF8Data(),
             responseError: error
         )
-        InvocationSettings.handler?.logHandler(message: message)
+        handler.logHandler(message: message)
     }
 }

--- a/Modules/ProtobufMessages/Sources/InvocationMesagesHandlerProtocol.swift
+++ b/Modules/ProtobufMessages/Sources/InvocationMesagesHandlerProtocol.swift
@@ -8,6 +8,9 @@ public struct InvocationMessage {
 }
 
 public protocol InvocationMesagesHandlerProtocol: AnyObject {
+    // Checked before building InvocationMessage — protobuf→JSON encoding is
+    // too expensive to pay when logging is disabled.
+    var isLogEnabled: Bool { get }
     func logHandler(message: InvocationMessage)
     func eventHandler(event: Anytype_ResponseEvent) async
     func assertationHandler(message: String, domain: String, info: [String: String], file: StaticString, function: String, line: UInt)

--- a/Modules/ProtobufMessages/Sources/ServiceMessageHandlerAdapter.swift
+++ b/Modules/ProtobufMessages/Sources/ServiceMessageHandlerAdapter.swift
@@ -36,13 +36,22 @@ public class ServiceMessageHandlerAdapter: @unchecked Sendable {
         handlers.removeAll { $0.value == nil }
         handlers.append(WeakHandler(handler))
     }
-    
+
+    private func currentHandlers() -> [WeakHandler] {
+        lock.lock()
+        defer { lock.unlock() }
+        return handlers
+    }
+
     private func listen() {
         lock.lock()
         defer { lock.unlock() }
         listener = ServiceMessageHandler { [weak self] event in
             guard let self else { return }
-            for handler in handlers {
+            // Snapshot under the lock and release it before awaiting: reading
+            // `handlers` unsynchronized races with `addHandler`, and the lock
+            // must not be held across the suspension point.
+            for handler in currentHandlers() {
                 await handler.value?.handle(event)
             }
         }

--- a/Modules/ProtobufMessages/Sources/ServiceMessageHandlerAdapter.swift
+++ b/Modules/ProtobufMessages/Sources/ServiceMessageHandlerAdapter.swift
@@ -71,16 +71,17 @@ fileprivate final class ServiceMessageHandler: NSObject, Sendable, ServiceMessag
     }
     
     private func log(event: Anytype_Event) {
-        
+        guard let handler = InvocationSettings.handler, handler.isLogEnabled else { return }
+
         let responseJsonData = try? event.jsonUTF8Data()
         let messageNames = responseJsonData?.parseMessages() ?? ""
-        
+
         let message = InvocationMessage(
             name: "Events:\(messageNames)",
             requestJsonData: nil,
             responseJsonData: responseJsonData,
             responseError: nil
         )
-        InvocationSettings.handler?.logHandler(message: message)
+        handler.logHandler(message: message)
     }
 }

--- a/Modules/ProtobufMessages/Sources/ServiceMessageHandlerAdapter.swift
+++ b/Modules/ProtobufMessages/Sources/ServiceMessageHandlerAdapter.swift
@@ -52,25 +52,36 @@ public class ServiceMessageHandlerAdapter: @unchecked Sendable {
 
 /// Private `ServiceMessageHandlerProtocol` adoption.
 fileprivate final class ServiceMessageHandler: NSObject, Sendable, ServiceMessageHandlerProtocol {
-    
-    let handler: @Sendable (_ event: Anytype_Event) async -> Void
-    
+
+    // A Task per incoming chunk gives no FIFO guarantee — reordered events
+    // (e.g. subscriptionAdd after the amend that follows it) corrupt storages.
+    // Chunks are buffered in arrival order and drained by a single consumer.
+    private let continuation: AsyncStream<Data>.Continuation
+    private let consumer: Task<Void, Never>
+
     init(handler: @escaping @Sendable (_: Anytype_Event) async -> Void) {
-        self.handler = handler
-    }
-    
-    public func handle(_ data: Data?) {
-        Task {
-            guard let data = data,
-                  let event = try? Anytype_Event(serializedBytes: data)
-            else { return }
-            
-            log(event: event)
-            await handler(event)
+        let (stream, continuation) = AsyncStream.makeStream(of: Data.self)
+        self.continuation = continuation
+        self.consumer = Task {
+            for await data in stream {
+                guard let event = try? Anytype_Event(serializedBytes: data) else { continue }
+                Self.log(event: event)
+                await handler(event)
+            }
         }
     }
-    
-    private func log(event: Anytype_Event) {
+
+    deinit {
+        continuation.finish()
+        consumer.cancel()
+    }
+
+    public func handle(_ data: Data?) {
+        guard let data else { return }
+        continuation.yield(data)
+    }
+
+    private static func log(event: Anytype_Event) {
         guard let handler = InvocationSettings.handler, handler.isLogEnabled else { return }
 
         let responseJsonData = try? event.jsonUTF8Data()

--- a/Modules/Services/Sources/Models/Details/Storage/ObjectDetailsStorage+Events.swift
+++ b/Modules/Services/Sources/Models/Details/Storage/ObjectDetailsStorage+Events.swift
@@ -16,11 +16,14 @@ public extension ObjectDetailsStorage {
             return nil
         }
         
-        let currentDetails = get(id: id) ?? ObjectDetails(id: id)
-        let updatedDetails = currentDetails.updated(by: data.details.fields)
-        
+        // `Set` is an authoritative snapshot, not a patch. The proto requires the
+        // client to replace its state ("can not be a partial state") and the heart
+        // reference client rebuilds the entry from scratch; merging would leak keys
+        // the server has dropped.
+        let updatedDetails = ObjectDetails(id: id, values: data.details.fields)
+
         add(details: updatedDetails)
-        
+
         return updatedDetails
     }
     


### PR DESCRIPTION
## Summary
Hot-path fixes in the RPC/event pipeline. Independently committed; verified against anytype-heart source.

- **Lazy log encoding** — skip protobuf→JSON encode when middleware logging is off (wins in all builds).
- **FIFO events** — single-consumer `AsyncStream` replaces `Task`-per-chunk; events applied in arrival order (correctness).
- **`Object.Details.Set` replaces, not merges** — proto mandates replace; merge leaked server-dropped keys (correctness).
- **Gate tree walks** — run indentation/mention rebuilds only on block/detail events, not detail-only batches.
- **Skip unmatched subscription rebuilds** — no items rebuild when a bunch doesn't match the sub; drop duplicate rebuild.
- **Lock event-handler read** — fix pre-existing unlocked read racing with registration.