### PR TITLE
IOS-6579 Fix dormant Kanban implementation and enable it by default

### DIFF
--- a/AnyTypeTests/Kanban/SetKanbanCardMoveTests.swift
+++ b/AnyTypeTests/Kanban/SetKanbanCardMoveTests.swift
@@ -1,0 +1,261 @@
+import Testing
+import Foundation
+@testable import Anytype
+import Services
+import SwiftProtobuf
+import ProtobufMessages
+import AnytypeCore
+
+@Suite
+struct SetKanbanCardMoveTests {
+
+    // MARK: - Tag: read-modify-write
+
+    @Test func testTagMove_PreservesOtherTags() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["a", "b"],
+            sourceGroupValue: .tag(ids: ["a"]),
+            targetGroupValue: .tag(ids: ["c"]),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.ids(["b", "c"])))
+    }
+
+    @Test func testTagMove_FromCombinationColumn_RemovesAllSourceIds() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["a", "b", "c"],
+            sourceGroupValue: .tag(ids: ["a", "b"]),
+            targetGroupValue: .tag(ids: ["d"]),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.ids(["c", "d"])))
+    }
+
+    @Test func testTagMove_ToCombinationColumn_AddsAllTargetIds() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["a"],
+            sourceGroupValue: .tag(ids: ["a"]),
+            targetGroupValue: .tag(ids: ["b", "c"]),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.ids(["b", "c"])))
+    }
+
+    @Test func testTagMove_ToNoValueColumn_RemovesOnlySourceIds() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["a", "b"],
+            sourceGroupValue: .tag(ids: ["a"]),
+            targetGroupValue: .tag(ids: []),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.ids(["b"])))
+    }
+
+    @Test func testTagMove_FromNoValueColumn_AddsTargetIds() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: [],
+            sourceGroupValue: .tag(ids: []),
+            targetGroupValue: .tag(ids: ["c"]),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.ids(["c"])))
+    }
+
+    @Test func testTagMove_TargetAlreadyPresent_NoDuplicates() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["a", "c"],
+            sourceGroupValue: .tag(ids: ["a"]),
+            targetGroupValue: .tag(ids: ["c"]),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.ids(["c"])))
+    }
+
+    @Test func testTagMove_NoEffectiveChange_Ignored() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["c"],
+            sourceGroupValue: .tag(ids: []),
+            targetGroupValue: .tag(ids: ["c"]),
+            groupsLoaded: true
+        )
+
+        #expect(result == .ignore)
+    }
+
+    @Test func testTagMove_UnresolvedSource_AddsWithoutRemoving() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["a", "b"],
+            sourceGroupValue: nil,
+            targetGroupValue: .tag(ids: ["c"]),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.ids(["a", "b", "c"])))
+    }
+
+    @Test func testTagMove_UnresolvedSourceToNoValue_Ignored() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["a", "b"],
+            sourceGroupValue: nil,
+            targetGroupValue: .tag(ids: []),
+            groupsLoaded: true
+        )
+
+        #expect(result == .ignore)
+    }
+
+    @Test func testTagMove_UnresolvedSourceAndUnreadableCurrentValue_Ignored() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: [],
+            sourceGroupValue: nil,
+            targetGroupValue: .tag(ids: ["c"]),
+            groupsLoaded: true
+        )
+
+        #expect(result == .ignore)
+    }
+
+    // MARK: - Status: single-value replace
+
+    @Test func testStatusMove_ReplacesValue() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["old"],
+            sourceGroupValue: .status(id: "old"),
+            targetGroupValue: .status(id: "new"),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.ids(["new"])))
+    }
+
+    @Test func testStatusMove_ToNoValueColumn_Unsets() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["old"],
+            sourceGroupValue: .status(id: "old"),
+            targetGroupValue: .status(id: ""),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.unset))
+    }
+
+    // MARK: - Checkbox
+
+    @Test func testCheckboxMove_WritesTargetChecked() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: [],
+            sourceGroupValue: .checkbox(checked: false),
+            targetGroupValue: .checkbox(checked: true),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.checked(true)))
+    }
+
+    @Test func testCheckboxMove_WritesTargetUnchecked() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: [],
+            sourceGroupValue: .checkbox(checked: true),
+            targetGroupValue: .checkbox(checked: false),
+            groupsLoaded: true
+        )
+
+        #expect(result == .write(.checked(false)))
+    }
+
+    // MARK: - Guards
+
+    @Test func testMove_GroupsNotLoaded_Ignored() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["a"],
+            sourceGroupValue: .tag(ids: ["a"]),
+            targetGroupValue: .tag(ids: ["c"]),
+            groupsLoaded: false
+        )
+
+        #expect(result == .ignore)
+    }
+
+    @Test func testMove_UnresolvedTarget_Ignored() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["a"],
+            sourceGroupValue: .tag(ids: ["a"]),
+            targetGroupValue: nil,
+            groupsLoaded: true
+        )
+
+        #expect(result == .ignore)
+    }
+
+    @Test func testMove_DateTarget_Ignored() {
+        let result = SetKanbanCardMove.compute(
+            currentValue: ["a"],
+            sourceGroupValue: nil,
+            targetGroupValue: .date(Anytype_Model_Block.Content.Dataview.Date()),
+            groupsLoaded: true
+        )
+
+        #expect(result == .ignore)
+    }
+
+    // MARK: - Per-column create prefill
+
+    @Test func testPrefill_StatusColumn() {
+        let value = SetKanbanCardMove.prefilledValue(targetGroupValue: .status(id: "s1"))
+        #expect(value == ["s1"].protobufValue)
+    }
+
+    @Test func testPrefill_TagCombinationColumn() {
+        let value = SetKanbanCardMove.prefilledValue(targetGroupValue: .tag(ids: ["a", "b"]))
+        #expect(value == ["a", "b"].protobufValue)
+    }
+
+    @Test func testPrefill_CheckboxColumn() {
+        let value = SetKanbanCardMove.prefilledValue(targetGroupValue: .checkbox(checked: true))
+        #expect(value == true.protobufValue)
+    }
+
+    @Test func testPrefill_NoValueColumns_Nil() {
+        #expect(SetKanbanCardMove.prefilledValue(targetGroupValue: .tag(ids: [])) == nil)
+        #expect(SetKanbanCardMove.prefilledValue(targetGroupValue: .status(id: "")) == nil)
+        #expect(SetKanbanCardMove.prefilledValue(targetGroupValue: nil) == nil)
+    }
+
+    // MARK: - Current value parsing (scalar or list)
+
+    @Test func testStringList_ListValue() {
+        let value = ["a", "b"].protobufValue
+        #expect(SetKanbanCardMove.stringList(from: value) == ["a", "b"])
+    }
+
+    @Test func testStringList_ScalarValue() {
+        let value = "a".protobufValue
+        #expect(SetKanbanCardMove.stringList(from: value) == ["a"])
+    }
+
+    @Test func testStringList_NilOrEmpty() {
+        #expect(SetKanbanCardMove.stringList(from: nil) == [])
+        #expect(SetKanbanCardMove.stringList(from: Google_Protobuf_Value(nilLiteral: ())) == [])
+        #expect(SetKanbanCardMove.stringList(from: "".protobufValue) == [])
+    }
+}
+
+private extension DataviewGroupValue {
+    static func tag(ids: [String]) -> DataviewGroupValue {
+        .tag(.with { $0.ids = ids })
+    }
+
+    static func status(id: String) -> DataviewGroupValue {
+        .status(.with { $0.id = id })
+    }
+
+    static func checkbox(checked: Bool) -> DataviewGroupValue {
+        .checkbox(.with { $0.checked = checked })
+    }
+}

--- a/AnyTypeTests/Kanban/SetKanbanColumnHeaderTests.swift
+++ b/AnyTypeTests/Kanban/SetKanbanColumnHeaderTests.swift
@@ -1,0 +1,100 @@
+import Testing
+import Foundation
+@testable import Anytype
+import Services
+import SwiftProtobuf
+import ProtobufMessages
+import AnytypeCore
+
+@Suite
+struct SetKanbanColumnHeaderTests {
+
+    private let options: [String: ObjectDetails] = [
+        "opt-a": .mockOption(id: "opt-a", name: "To Do", color: "red"),
+        "opt-b": .mockOption(id: "opt-b", name: "Doing", color: "blue")
+    ]
+
+    private func header(for group: DataviewGroup) -> SetKanbanColumnHeaderType {
+        group.header(checkboxTitle: "Done", optionDetails: { options[$0] })
+    }
+
+    @Test func testStatusGroup_ResolvedOption() {
+        let group = DataviewGroup.mock(value: .status(.with { $0.id = "opt-a" }))
+
+        guard case let .status(statusOptions) = header(for: group) else {
+            Issue.record("Expected status header")
+            return
+        }
+        #expect(statusOptions.count == 1)
+        #expect(statusOptions.first?.text == "To Do")
+    }
+
+    @Test func testStatusGroup_UnresolvedOption_FallsBackToUncategorized() {
+        let group = DataviewGroup.mock(value: .status(.with { $0.id = "deleted-option" }))
+
+        guard case .uncategorized = header(for: group) else {
+            Issue.record("Expected uncategorized header, never a raw id")
+            return
+        }
+    }
+
+    @Test func testTagGroup_CombinationColumn_ResolvesAllIds() {
+        let group = DataviewGroup.mock(value: .tag(.with { $0.ids = ["opt-a", "opt-b"] }))
+
+        guard case let .tag(tagOptions) = header(for: group) else {
+            Issue.record("Expected tag header")
+            return
+        }
+        #expect(tagOptions.map(\.text) == ["To Do", "Doing"])
+    }
+
+    @Test func testTagGroup_EmptyIds_Uncategorized() {
+        let group = DataviewGroup.mock(value: .tag(.with { $0.ids = [] }))
+
+        guard case .uncategorized = header(for: group) else {
+            Issue.record("Expected uncategorized header")
+            return
+        }
+    }
+
+    @Test func testCheckboxGroup_UsesDisplayName() {
+        let group = DataviewGroup.mock(value: .checkbox(.with { $0.checked = true }))
+
+        guard case let .checkbox(title, isChecked) = header(for: group) else {
+            Issue.record("Expected checkbox header")
+            return
+        }
+        #expect(title == "Done")
+        #expect(isChecked == true)
+    }
+
+    @Test func testStatusGroup_BackgroundColorFromOption() {
+        let group = DataviewGroup.mock(value: .status(.with { $0.id = "opt-a" }))
+        let color = group.backgroundColor(optionDetails: { options[$0] })
+        #expect(color == MiddlewareColor.red.backgroundColor)
+    }
+
+    @Test func testStatusGroup_BackgroundColorUnresolved_Nil() {
+        let group = DataviewGroup.mock(value: .status(.with { $0.id = "deleted-option" }))
+        let color = group.backgroundColor(optionDetails: { options[$0] })
+        #expect(color == nil)
+    }
+}
+
+private extension DataviewGroup {
+    static func mock(value: DataviewGroupValue) -> DataviewGroup {
+        DataviewGroup.with {
+            $0.id = "group-id"
+            $0.value = value
+        }
+    }
+}
+
+private extension ObjectDetails {
+    static func mockOption(id: String, name: String, color: String) -> ObjectDetails {
+        ObjectDetails(id: id, values: [
+            BundledPropertyKey.name.rawValue: name.protobufValue,
+            BundledPropertyKey.relationOptionColor.rawValue: color.protobufValue
+        ])
+    }
+}

--- a/AnyTypeTests/Kanban/SetKanbanReorderTests.swift
+++ b/AnyTypeTests/Kanban/SetKanbanReorderTests.swift
@@ -1,0 +1,27 @@
+import Testing
+import Foundation
+@testable import Anytype
+
+@Suite
+struct SetKanbanReorderTests {
+
+    @Test func testPartiallyLoadedColumn_NotFullyLoaded() {
+        #expect(SetKanbanReorder.isColumnFullyLoaded(loadedCount: 20, totalCount: 120) == false)
+    }
+
+    @Test func testLoadedEqualsTotal_FullyLoaded() {
+        #expect(SetKanbanReorder.isColumnFullyLoaded(loadedCount: 20, totalCount: 20) == true)
+    }
+
+    @Test func testLoadedExceedsTotal_FullyLoaded() {
+        #expect(SetKanbanReorder.isColumnFullyLoaded(loadedCount: 21, totalCount: 20) == true)
+    }
+
+    @Test func testUnknownTotal_FailsClosed() {
+        #expect(SetKanbanReorder.isColumnFullyLoaded(loadedCount: 20, totalCount: nil) == false)
+    }
+
+    @Test func testEmptyColumn_FullyLoaded() {
+        #expect(SetKanbanReorder.isColumnFullyLoaded(loadedCount: 0, totalCount: 0) == true)
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/ScrollAxisLock.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/ScrollAxisLock.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import UIKit.UIGestureRecognizerSubclass
+
+extension View {
+    /// Locks the enclosing scroll view's pan gesture to a single axis.
+    ///
+    /// Apply to the scroll view's *content*, not to the `ScrollView` itself.
+    ///
+    /// A `UIScrollView` grabs any touch that lands on it while it is still decelerating, at a zero
+    /// movement threshold and whatever the direction of the drag that follows — that is how you
+    /// catch and re-flick moving content. With nested scroll views (kanban columns inside the
+    /// horizontally scrolling board) it also means a still-settling column swallows horizontal
+    /// swipes meant for the board. The lock makes the pan wait until the drag has a direction and
+    /// begin only for drags along `axis`, so cross-axis drags always reach the other scroll view.
+    func scrollAxisLock(_ axis: Axis) -> some View {
+        background(ScrollAxisLockView(axis: axis))
+    }
+}
+
+private struct ScrollAxisLockView: UIViewRepresentable {
+    let axis: Axis
+
+    func makeUIView(context: Context) -> UIView {
+        ScrollAxisLockUIView(axis: axis)
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}
+
+private final class ScrollAxisLockUIView: UIView {
+    private let gate: CrossAxisDragGate
+
+    // SwiftUI.Axis, not the UIView.Axis that wins name lookup inside a UIView subclass.
+    init(axis: SwiftUI.Axis) {
+        gate = CrossAxisDragGate(scrollAxis: axis)
+        super.init(frame: .zero)
+        isUserInteractionEnabled = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+
+        guard window != nil, let scrollView = enclosingScrollView, gate.view !== scrollView else { return }
+
+        scrollView.addGestureRecognizer(gate)
+        scrollView.panGestureRecognizer.require(toFail: gate)
+    }
+
+    private var enclosingScrollView: UIScrollView? {
+        var ancestor: UIView? = superview
+        while let current = ancestor {
+            if let scrollView = current as? UIScrollView { return scrollView }
+            ancestor = current.superview
+        }
+        return nil
+    }
+}
+
+/// Recognizes cross-axis drags and nothing else. While it is undecided the scroll view's pan is
+/// held back by `require(toFail:)`; once it recognizes, that pan is out for the whole touch. It
+/// never prevents other recognizers, so the drag still reaches the surrounding scroll view.
+private final class CrossAxisDragGate: UIGestureRecognizer {
+    private let scrollAxis: Axis
+    private var startLocation = CGPoint.zero
+
+    init(scrollAxis: Axis) {
+        self.scrollAxis = scrollAxis
+        super.init(target: nil, action: nil)
+        cancelsTouchesInView = false
+        delaysTouchesBegan = false
+        delaysTouchesEnded = false
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesBegan(touches, with: event)
+
+        guard let touch = touches.first, numberOfTouches == 1, canScrollAlongAxis else {
+            state = .failed
+            return
+        }
+        startLocation = touch.location(in: view)
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesMoved(touches, with: event)
+
+        guard state == .possible, let touch = touches.first else { return }
+
+        let location = touch.location(in: view)
+        let horizontal = abs(location.x - startLocation.x)
+        let vertical = abs(location.y - startLocation.y)
+        let (alongAxis, acrossAxis) = scrollAxis == .horizontal ? (horizontal, vertical) : (vertical, horizontal)
+
+        if alongAxis > acrossAxis, alongAxis > Constants.directionThreshold {
+            state = .failed
+        } else if acrossAxis > alongAxis, acrossAxis > Constants.directionThreshold {
+            state = .began
+        }
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesEnded(touches, with: event)
+        state = state == .began ? .ended : .failed
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesCancelled(touches, with: event)
+        state = state == .began ? .cancelled : .failed
+    }
+
+    // A gate that can't be the wrong gate: a scroll view with nothing to scroll along its axis
+    // needs no arbitration, and neither does one we attached to by mistake.
+    private var canScrollAlongAxis: Bool {
+        guard let scrollView = view as? UIScrollView else { return false }
+        switch scrollAxis {
+        case .horizontal:
+            return scrollView.contentSize.width > scrollView.bounds.width
+        case .vertical:
+            return scrollView.contentSize.height > scrollView.bounds.height
+        }
+    }
+
+    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+
+    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+}
+
+private extension CrossAxisDragGate {
+    enum Constants {
+        static let directionThreshold: CGFloat = 6
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Flows/EditorSetFlow/EditorSetCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/EditorSetFlow/EditorSetCoordinatorViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import Services
 import SwiftUI
 import AnytypeCore
+import SwiftProtobuf
 
 struct SetViewData: Identifiable {
     let id = UUID()
@@ -149,8 +150,8 @@ final class EditorSetCoordinatorViewModel:
     
     // MARK: - NavigationContext
     
-    func showCreateObject(document: some SetDocumentProtocol, setting: ObjectCreationSetting?) {
-        setObjectCreationCoordinator.startCreateObject(setDocument: document, mode: .internal, setting: setting, output: self, customAnalyticsRoute: nil)
+    func showCreateObject(document: some SetDocumentProtocol, setting: ObjectCreationSetting?, prefilledFields: [String: Google_Protobuf_Value]) {
+        setObjectCreationCoordinator.startCreateObject(setDocument: document, mode: .internal, setting: setting, prefilledFields: prefilledFields, output: self, customAnalyticsRoute: nil)
     }
     
     func showKanbanColumnSettings(

--- a/Anytype/Sources/PresentationLayer/TextEditor/Assembly/Set/EditorSetModuleOutput.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Assembly/Set/EditorSetModuleOutput.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Services
+import SwiftProtobuf
 
 @MainActor
 protocol EditorSetModuleOutput: AnyObject, ObjectHeaderModuleOutput {
@@ -12,7 +13,7 @@ protocol EditorSetModuleOutput: AnyObject, ObjectHeaderModuleOutput {
     func showQueries(document: some SetDocumentProtocol, selectedObjectId: String?, onSelect: @escaping (String) -> ())
 
     // NavigationContext
-    func showCreateObject(document: some SetDocumentProtocol, setting: ObjectCreationSetting?)
+    func showCreateObject(document: some SetDocumentProtocol, setting: ObjectCreationSetting?, prefilledFields: [String: Google_Protobuf_Value])
     func showKanbanColumnSettings(
         hideColumn: Bool,
         selectedColor: BlockBackgroundColor?,

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Creation/SetObjectCreationCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Creation/SetObjectCreationCoordinator.swift
@@ -1,5 +1,6 @@
 import Services
 import AnytypeCore
+import SwiftProtobuf
 
 enum SetObjectCreationMode {
     case `internal`
@@ -12,6 +13,7 @@ protocol SetObjectCreationCoordinatorProtocol {
         setDocument: some SetDocumentProtocol,
         mode: SetObjectCreationMode,
         setting: ObjectCreationSetting?,
+        prefilledFields: [String: Google_Protobuf_Value],
         output: (any SetObjectCreationCoordinatorOutput)?,
         customAnalyticsRoute: AnalyticsEventsRouteKind?
     )
@@ -31,23 +33,30 @@ final class SetObjectCreationCoordinator: SetObjectCreationCoordinatorProtocol {
     
     @Injected(\.setObjectCreationHelper)
     private var objectCreationHelper: any SetObjectCreationHelperProtocol
-    
+
+    // Shared across every create entry point of the screen so two fast taps make one object.
+    private var isCreatingObject = false
+
     nonisolated init() {}
-    
+
     func startCreateObject(
         setDocument: some SetDocumentProtocol,
         mode: SetObjectCreationMode,
         setting: ObjectCreationSetting?,
+        prefilledFields: [String: Google_Protobuf_Value],
         output: (any SetObjectCreationCoordinatorOutput)?,
         customAnalyticsRoute: AnalyticsEventsRouteKind?
     ) {
+        guard !isCreatingObject else { return }
+        isCreatingObject = true
         Task { @MainActor [weak self] in
             guard let self else { return }
-            
+            defer { isCreatingObject = false }
+
             self.output = output
             self.customAnalyticsRoute = customAnalyticsRoute
             do {
-                let action = try await objectCreationHelper.createObject(for: setDocument, setting: setting)
+                let action = try await objectCreationHelper.createObject(for: setDocument, setting: setting, prefilledFields: prefilledFields)
                 handleAction(action, mode: mode, setDocument: setDocument)
             } catch {
                 anytypeAssertionFailure("Cannot create object for set document", info: [
@@ -108,6 +117,16 @@ extension SetObjectCreationCoordinatorProtocol {
         output: (any SetObjectCreationCoordinatorOutput)?,
         customAnalyticsRoute: AnalyticsEventsRouteKind?
     ) {
-        startCreateObject(setDocument: setDocument, mode: mode, setting: nil, output: output, customAnalyticsRoute: customAnalyticsRoute)
+        startCreateObject(setDocument: setDocument, mode: mode, setting: nil, prefilledFields: [:], output: output, customAnalyticsRoute: customAnalyticsRoute)
+    }
+
+    func startCreateObject(
+        setDocument: some SetDocumentProtocol,
+        mode: SetObjectCreationMode,
+        setting: ObjectCreationSetting?,
+        output: (any SetObjectCreationCoordinatorOutput)?,
+        customAnalyticsRoute: AnalyticsEventsRouteKind?
+    ) {
+        startCreateObject(setDocument: setDocument, mode: mode, setting: setting, prefilledFields: [:], output: output, customAnalyticsRoute: customAnalyticsRoute)
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Creation/SetObjectCreationHelper.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Creation/SetObjectCreationHelper.swift
@@ -1,4 +1,5 @@
 import Services
+import SwiftProtobuf
 
 enum SetObjectCreationAction {
     case showObject(ObjectDetails, titleInputType: CreateObjectTitleInputType)
@@ -8,7 +9,9 @@ enum SetObjectCreationAction {
 
 protocol SetObjectCreationHelperProtocol: Sendable {
     func createObject(
-        for setDocument: some SetDocumentProtocol, setting: ObjectCreationSetting?
+        for setDocument: some SetDocumentProtocol,
+        setting: ObjectCreationSetting?,
+        prefilledFields: [String: Google_Protobuf_Value]
     ) async throws -> SetObjectCreationAction
 }
 
@@ -24,7 +27,8 @@ final class SetObjectCreationHelper: SetObjectCreationHelperProtocol, Sendable {
 
     func createObject(
         for setDocument: some SetDocumentProtocol,
-        setting: ObjectCreationSetting?
+        setting: ObjectCreationSetting?,
+        prefilledFields: [String: Google_Protobuf_Value]
     ) async throws -> SetObjectCreationAction {
         let collectionId = setDocument.isCollection() ? setDocument.objectId : nil
 
@@ -33,19 +37,20 @@ final class SetObjectCreationHelper: SetObjectCreationHelperProtocol, Sendable {
         } else if isChatObject(setDocument: setDocument, setting: setting) {
             return .showChatCreation(spaceId: setDocument.spaceId, collectionId: collectionId)
         } else if setDocument.isCollection() {
-            return try await createObjectForCollection(for: setDocument, setting: setting)
+            return try await createObjectForCollection(for: setDocument, setting: setting, prefilledFields: prefilledFields)
         } else if setDocument.isSetByRelation() {
-            return try await createObjectForRelationSet(for: setDocument, setting: setting)
+            return try await createObjectForRelationSet(for: setDocument, setting: setting, prefilledFields: prefilledFields)
         } else {
-            return try await createObjectForRegularSet(for: setDocument, setting: setting)
+            return try await createObjectForRegularSet(for: setDocument, setting: setting, prefilledFields: prefilledFields)
         }
     }
-    
+
     // MARK: - Private
-    
+
     private func createObjectForCollection(
         for setDocument: some SetDocumentProtocol,
-        setting: ObjectCreationSetting?
+        setting: ObjectCreationSetting?,
+        prefilledFields: [String: Google_Protobuf_Value]
     ) async throws -> SetObjectCreationAction {
         let objectType = objectType(for: setDocument, setting: setting)
         let templateId = setting?.templateId ?? defaultTemplateId(for: objectType, setDocument: setDocument)
@@ -55,6 +60,7 @@ final class SetObjectCreationHelper: SetObjectCreationHelperProtocol, Sendable {
             type: objectType,
             relationsDetails: [],
             templateId: templateId,
+            prefilledFields: prefilledFields,
             createdInContext: setDocument.objectId
         )
 
@@ -67,10 +73,11 @@ final class SetObjectCreationHelper: SetObjectCreationHelperProtocol, Sendable {
 
         return result
     }
-    
+
     private func createObjectForRelationSet(
         for setDocument: some SetDocumentProtocol,
-        setting: ObjectCreationSetting?
+        setting: ObjectCreationSetting?,
+        prefilledFields: [String: Google_Protobuf_Value]
     ) async throws -> SetObjectCreationAction {
         let relationsDetails = setDocument.dataViewRelationsDetails.filter { detail in
             guard let source = setDocument.details?.filteredSetOf else { return false }
@@ -83,13 +90,15 @@ final class SetObjectCreationHelper: SetObjectCreationHelperProtocol, Sendable {
             setDocument: setDocument,
             type: objectType,
             relationsDetails: relationsDetails,
-            templateId: templateId
+            templateId: templateId,
+            prefilledFields: prefilledFields
         )
     }
-    
+
     private func createObjectForRegularSet(
         for setDocument: some SetDocumentProtocol,
-        setting: ObjectCreationSetting?
+        setting: ObjectCreationSetting?,
+        prefilledFields: [String: Google_Protobuf_Value]
     ) async throws -> SetObjectCreationAction {
         let objectTypeId = setDocument.details?.filteredSetOf.first ?? ""
         let objectType = try objectTypeProvider.objectType(id: objectTypeId)
@@ -98,33 +107,37 @@ final class SetObjectCreationHelper: SetObjectCreationHelperProtocol, Sendable {
             setDocument: setDocument,
             type: objectType,
             relationsDetails: [],
-            templateId: templateId
+            templateId: templateId,
+            prefilledFields: prefilledFields
         )
     }
-    
+
     private func createObject(
         setDocument: some SetDocumentProtocol,
         type: ObjectType?,
         relationsDetails: [PropertyDetails],
         templateId: String?,
+        prefilledFields: [String: Google_Protobuf_Value],
         createdInContext: String = "",
         createdInContextRef: String = ""
     ) async throws -> SetObjectCreationAction {
-        let details = try await dataviewService.addRecord(
+        let filterFields = prefilledFieldsBuilder.buildPrefilledFields(from: setDocument.activeViewFilters, relationsDetails: relationsDetails)
+        let details = ObjectDetails(id: filterFields.id, values: filterFields.values.merging(prefilledFields) { $1 })
+        let createdDetails = try await dataviewService.addRecord(
             typeUniqueKey: type?.uniqueKey,
             templateId: templateId ?? "",
             spaceId: setDocument.spaceId,
-            details: prefilledFieldsBuilder.buildPrefilledFields(from: setDocument.activeViewFilters, relationsDetails: relationsDetails),
+            details: details,
             createdInContext: createdInContext,
             createdInContextRef: createdInContextRef
         )
         if let type, type.isNoteLayout {
-            guard let newBlockId = try? await blockService.addFirstBlock(contextId: details.id, info: .emptyText) else {
-                return .showObject(details, titleInputType: .none)
+            guard let newBlockId = try? await blockService.addFirstBlock(contextId: createdDetails.id, info: .emptyText) else {
+                return .showObject(createdDetails, titleInputType: .none)
             }
-            return .showObject(details, titleInputType: .writeToBlock(blockId: newBlockId))
+            return .showObject(createdDetails, titleInputType: .writeToBlock(blockId: newBlockId))
         } else {
-            return .showObject(details, titleInputType: .writeToRelationName)
+            return .showObject(createdDetails, titleInputType: .writeToRelationName)
         }
     }
     
@@ -169,6 +182,6 @@ final class SetObjectCreationHelper: SetObjectCreationHelperProtocol, Sendable {
 
 extension SetObjectCreationHelperProtocol {
     func createObject(for setDocument: some SetDocumentProtocol) async throws -> SetObjectCreationAction {
-        return try await createObject(for: setDocument, setting: nil)
+        return try await createObject(for: setDocument, setting: nil, prefilledFields: [:])
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel+DragAndDropDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel+DragAndDropDelegate.swift
@@ -7,8 +7,10 @@ struct SetDragAndDropConfiguration {
 
 @MainActor
 protocol SetDragAndDropDelegate {
+    var canDragCards: Bool { get }
     func onDrag(from: SetDragAndDropConfiguration, to: SetDragAndDropConfiguration)
     func onDrop(configurationId: String, fromGroupId: String, toGroupId: String) -> Bool
+    func onDragCancelled()
 }
 
 extension EditorSetViewModel: SetDragAndDropDelegate {
@@ -29,37 +31,55 @@ extension EditorSetViewModel: SetDragAndDropDelegate {
         }
     }
     
+    func onDragCancelled() {
+        revertOptimisticCardMoves()
+    }
+
     func onDrop(configurationId: String, fromGroupId: String, toGroupId: String) -> Bool {
+        guard canDragCards else {
+            revertOptimisticCardMoves()
+            return false
+        }
+
         if fromGroupId == toGroupId,
             let configurations = configurationsDict[fromGroupId]
         {
+            // ObjectOrderUpdate replaces the whole (viewId, groupId) list; persisting a
+            // partially loaded column would destroy the order of the unloaded cards.
+            guard isGroupFullyLoaded(fromGroupId) else {
+                revertOptimisticCardMoves()
+                return false
+            }
             let groupObjectIds = GroupObjectIds(
                 groupId: fromGroupId,
                 objectIds: configurations.map { $0.id }
             )
             objectOrderUpdate(with: [groupObjectIds])
         } else if fromGroupId != toGroupId,
-                  let fromConfigurations = configurationsDict[fromGroupId],
-                  let toConfigurations = configurationsDict[toGroupId]
+                  configurationsDict[fromGroupId].isNotNil,
+                  configurationsDict[toGroupId].isNotNil
         {
-            updateObjectDetails(
+            let moved = updateObjectDetails(
                 configurationId,
-                groupId: toGroupId
+                fromGroupId: fromGroupId,
+                toGroupId: toGroupId
             )
+            guard moved else { return false }
 
-            let fromGroupObjectIds = GroupObjectIds(
-                groupId: fromGroupId,
-                objectIds: fromConfigurations.map { $0.id }
-            )
-            let toGroupObjectIds = GroupObjectIds(
-                groupId: toGroupId,
-                objectIds: toConfigurations.map { $0.id }
-            )
-            objectOrderUpdate(with: [fromGroupObjectIds, toGroupObjectIds])
+            var groupObjectIds = [GroupObjectIds]()
+            if isGroupFullyLoaded(fromGroupId), let fromConfigurations = configurationsDict[fromGroupId] {
+                groupObjectIds.append(GroupObjectIds(groupId: fromGroupId, objectIds: fromConfigurations.map { $0.id }))
+            }
+            if isGroupFullyLoaded(toGroupId), let toConfigurations = configurationsDict[toGroupId] {
+                groupObjectIds.append(GroupObjectIds(groupId: toGroupId, objectIds: toConfigurations.map { $0.id }))
+            }
+            if groupObjectIds.isNotEmpty {
+                objectOrderUpdate(with: groupObjectIds)
+            }
         } else {
             return false
         }
-        
+
         return true
     }
     
@@ -88,18 +108,16 @@ extension EditorSetViewModel: SetDragAndDropDelegate {
             return
         }
 
-        var toIndex = 0
+        var toIndex = toConfigurations.count
         if let toConfigurationId = to.configurationId {
-            toIndex = toConfigurations.index(id: toConfigurationId) ?? 0
+            toIndex = toConfigurations.index(id: toConfigurationId) ?? toConfigurations.count
         }
 
         withAnimation(.slowIteractiveSpring) {
             let fromConfiguration = fromConfigurations[fromIndex]
             fromConfigurations.remove(at: fromIndex)
 
-            let dropAfter = toIndex > fromIndex
-            let dropIndex = dropAfter ? toIndex + 1 : toIndex
-            toConfigurations.insert(fromConfiguration, at: dropIndex)
+            toConfigurations.insert(fromConfiguration, at: toIndex)
 
             configurationsDict[from.groupId] = fromConfigurations
             configurationsDict[to.groupId] = toConfigurations

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel.swift
@@ -3,6 +3,7 @@ import Services
 import AnytypeCore
 import SwiftUI
 import OrderedCollections
+import SwiftProtobuf
 
 
 @MainActor
@@ -27,6 +28,7 @@ final class EditorSetViewModel: ObservableObject {
     private var externalActiveViewId: String?
     
     private var recordsDict: OrderedDictionary<String, [ObjectDetails]> = [:]
+    private var totalsDict: [String: Int] = [:]
     private var groups: [DataviewGroup] = []
     
     @MainActor
@@ -40,6 +42,8 @@ final class EditorSetViewModel: ObservableObject {
     )
     @Published var configurationsDict: OrderedDictionary<String, [SetContentViewItemConfiguration]> = [:]
     @Published var pagitationDataDict: OrderedDictionary<String, EditorSetPaginationData> = [:]
+    @Published private(set) var boardState: SetKanbanBoardState = .loading
+    @Published private(set) var groupOptionDetails: [String: ObjectDetails] = [:]
     
     @Published var syncStatusData = SyncStatusData(status: .offline, networkId: "", isHidden: true)
     
@@ -112,7 +116,10 @@ final class EditorSetViewModel: ObservableObject {
     
     var showEmptyState: Bool {
         (isEmptyQuery && !setDocument.isCollection()) ||
-        (recordsDict.values.first { $0.isNotEmpty } == nil && setDocument.activeViewFilters.isEmpty)
+        // A board with columns is never empty: emptiness is columns.isEmpty, not cards.isEmpty.
+        // Collapsing an all-empty board into the generic screen would also hide the columns
+        // needed to create the first card.
+        (!activeView.type.hasGroups && recordsDict.values.first { $0.isNotEmpty } == nil && setDocument.activeViewFilters.isEmpty)
     }
     
     var emptyStateMode: EditorSetEmptyMode {
@@ -144,7 +151,26 @@ final class EditorSetViewModel: ObservableObject {
     
     func headerType(for groupId: String) -> SetKanbanColumnHeaderType {
         guard let group = groups.first(where: { $0.id == groupId }) else { return .uncategorized }
-        return group.header(with: activeView.groupRelationKey, document: setDocument.document)
+        return group.header(checkboxTitle: groupRelationDisplayName, optionDetails: { [weak self] optionId in
+            self?.optionDetails(for: optionId)
+        })
+    }
+
+    func columnCount(for groupId: String) -> Int {
+        totalsDict[groupId] ?? 0
+    }
+
+    private var groupRelationDisplayName: String {
+        let relationDetails = try? propertyDetailsStorage.relationsDetails(key: activeView.groupRelationKey, spaceId: setDocument.spaceId)
+        return relationDetails?.name ?? activeView.groupRelationKey.capitalized
+    }
+
+    // Live options first (rename/recolor arrive there), then per-column dependency
+    // details, then the document storage as a last resort.
+    private func optionDetails(for optionId: String) -> ObjectDetails? {
+        groupOptionDetails[optionId]
+            ?? subscriptionStorages.values.compactMap { $0.detailsStorage.get(id: optionId) }.first
+            ?? setDocument.document.detailsStorage.get(id: optionId)
     }
     
     func contextMenuItems(for relation: Property) -> [PropertyValueViewModel.MenuItem] {
@@ -190,7 +216,10 @@ final class EditorSetViewModel: ObservableObject {
     }
     
     private func groupFirstOptionBackgroundColor(for groupId: String) -> BlockBackgroundColor {
-        guard let backgroundColor = groups.first(where: { $0.id == groupId })?.backgroundColor(document: setDocument.document) else {
+        let group = groups.first { $0.id == groupId }
+        guard let backgroundColor = group?.backgroundColor(optionDetails: { [weak self] optionId in
+            self?.optionDetails(for: optionId)
+        }) else {
             return BlockBackgroundColor.gray
         }
         return backgroundColor
@@ -231,6 +260,9 @@ final class EditorSetViewModel: ObservableObject {
     
     private var subscriptions = [AnyCancellable]()
     private var subscriptionStorages = [String: any SubscriptionStorageProtocol]()
+    private var startSubscriptionsByGroupsTask: Task<Void, Never>?
+    private var boardSubscriptionsEpoch = 0
+    private var cardIdsWithPendingMove = Set<String>()
     private var titleSubscription: AnyCancellable?
     private var descriptionSubscription: AnyCancellable?
     private var chatPreviews: [ChatMessagePreview] = []
@@ -329,6 +361,7 @@ final class EditorSetViewModel: ObservableObject {
     }
     
     func onDisappear() {
+        boardSubscriptionsEpoch += 1
         Task {
             await stopAllSubscriptionStorages()
             try await groupsSubscriptionsHandler.stopAllSubscriptions()
@@ -385,24 +418,100 @@ final class EditorSetViewModel: ObservableObject {
         }
         
         if activeView.type.hasGroups {
-            try? await setupGroupsSubscription(forceUpdate: forceUpdate)
+            do {
+                try await setupGroupsSubscription(forceUpdate: forceUpdate)
+                if boardState != .ready {
+                    boardState = .ready
+                }
+            } catch {
+                boardState = .error(message: error.localizedDescription)
+            }
         } else {
             setupPaginationDataIfNeeded(groupId: setSubscriptionDataBuilder.subscriptionId)
-            await startSubscriptionIfNeeded(with: setSubscriptionDataBuilder.subscriptionId)
+            await startSubscriptionIfNeeded(subscriptionId: setSubscriptionDataBuilder.subscriptionId, groupId: setSubscriptionDataBuilder.subscriptionId)
         }
     }
     
-    func updateObjectDetails(_ detailsId: String, groupId: String) {
-        guard let group = groups.first(where: { $0.id == groupId }),
-        let value = group.value else { return }
+    @discardableResult
+    func updateObjectDetails(_ detailsId: String, fromGroupId: String, toGroupId: String) -> Bool {
+        let relationKey = activeView.groupRelationKey
+        let move = SetKanbanCardMove.compute(
+            currentValue: groupRelationValue(for: detailsId, relationKey: relationKey, groupId: fromGroupId),
+            sourceGroupValue: groups.first { $0.id == fromGroupId }?.value,
+            targetGroupValue: groups.first { $0.id == toGroupId }?.value,
+            groupsLoaded: groups.isNotEmpty
+        )
+
+        // Reverts rebuild every column, not just the two involved: an earlier optimistic
+        // move may have stripped the card from a third column's configurations.
+        guard case let .write(value) = move else {
+            revertOptimisticCardMoves()
+            return false
+        }
+
+        // The RMW reads the backend value; a second move of the same card before the
+        // first write round-trips would compute against stale data and resurrect tags.
+        guard !cardIdsWithPendingMove.contains(detailsId) else {
+            revertOptimisticCardMoves()
+            return false
+        }
+        cardIdsWithPendingMove.insert(detailsId)
 
         Task {
-            try await detailsService.updateDetails(
-                contextId: detailsId,
-                relationKey: activeView.groupRelationKey,
-                value: value
-            )
+            defer { cardIdsWithPendingMove.remove(detailsId) }
+            do {
+                try await propertiesService.updateProperty(
+                    objectId: detailsId,
+                    propertyKey: relationKey,
+                    value: value.protobufValue
+                )
+                logCardMove(relationKey: relationKey, value: value)
+            } catch {
+                revertOptimisticCardMoves()
+                output?.showFailureToast(message: error.localizedDescription)
+            }
         }
+        return true
+    }
+
+    private func logCardMove(relationKey: String, value: SetKanbanCardMoveValue) {
+        guard let relationDetails = try? propertyDetailsStorage.relationsDetails(key: relationKey, spaceId: setDocument.spaceId) else { return }
+        AnytypeAnalytics.instance().logChangeOrDeleteRelationValue(
+            isEmpty: value == .unset || value == .ids([]),
+            format: relationDetails.format,
+            type: .dataview,
+            key: relationDetails.analyticsKey
+        )
+    }
+
+    private func groupRelationValue(for detailsId: String, relationKey: String, groupId: String) -> [String] {
+        let details = subscriptionStorage(for: groupId)?.detailsStorage.get(id: detailsId)
+            ?? subscriptionStorages.values.compactMap { $0.detailsStorage.get(id: detailsId) }.first
+        return SetKanbanCardMove.stringList(from: details?.values[relationKey])
+    }
+
+    private func subscriptionStorage(for groupId: String) -> (any SubscriptionStorageProtocol)? {
+        subscriptionStorages[groupId] ?? subscriptionStorages[recordsSubscriptionId(for: groupId)]
+    }
+
+    func isGroupFullyLoaded(_ groupId: String) -> Bool {
+        SetKanbanReorder.isColumnFullyLoaded(
+            loadedCount: recordsDict[groupId]?.count ?? 0,
+            totalCount: totalsDict[groupId]
+        )
+    }
+
+    var canDragCards: Bool {
+        activeView.type.hasGroups && setDocument.setPermissions.canMoveCards
+    }
+
+    func revertOptimisticCardMoves() {
+        updateConfigurations(with: Array(recordsDict.keys))
+    }
+
+    func onBoardErrorRetryTap() async {
+        boardState = .loading
+        await startSubscriptionIfNeeded(forceUpdate: true)
     }
     
     func pagitationData(by groupId: String? = nil) -> EditorSetPaginationData {
@@ -521,54 +630,141 @@ final class EditorSetViewModel: ObservableObject {
         let hasGroupDiff = await groupsSubscriptionsHandler.hasGroupsSubscriptionDataDiff(with: data)
         if hasGroupDiff {
             try await groupsSubscriptionsHandler.stopAllSubscriptions()
-            groups = try await startGroupsSubscription(with: data)
+            groups = []
+            let snapshot = try await startGroupsSubscription(with: data)
+            // Group events can race the subscribe RPC; the callback already applied them
+            // to `groups`, so merge instead of overwriting with the snapshot.
+            let racedGroups = groups.filter { raced in !snapshot.contains { $0.id == raced.id } }
+            groups = snapshot + racedGroups
         }
 
-        let groupOrderUpdates = await checkGroupOrderUpdates()
-            
+        await startOptionsSubscription()
+
+        let groupOrderUpdates = checkGroupOrderUpdates()
+
         if forceUpdate || groupOrderUpdates || hasGroupDiff {
             await startSubscriptionsByGroups()
         }
     }
-    
-    private func checkGroupOrderUpdates() async -> Bool {
+
+    private func checkGroupOrderUpdates() -> Bool {
         let groupOrder = setDocument.dataView.groupOrders.first { [weak self] in $0.viewID == self?.activeView.id }
         let visibleViewGroups = groupOrder?.viewGroups.filter { !$0.hidden }
         let newVisible = visibleViewGroups?.first { [weak self] in self?.recordsDict[$0.groupID] == nil }
-        
+
         let hiddenViewGroups = groupOrder?.viewGroups.filter { $0.hidden } ?? []
-        var hasNewHidden = false
-        for group in hiddenViewGroups {
-            if recordsDict[group.groupID] != nil {
-                hasNewHidden = true
-                recordsDict[group.groupID] = nil
-                configurationsDict[group.groupID] = nil
-                try? await subscriptionStorages[group.groupID]?.stopSubscription()
-            }
-        }
-        
+        let hasNewHidden = hiddenViewGroups.contains { recordsDict[$0.groupID] != nil }
+
         return newVisible != nil || hasNewHidden
     }
-    
+
     private func startGroupsSubscription(with data: GroupsSubscriptionData) async throws -> [DataviewGroup] {
         try await groupsSubscriptionsHandler.startGroupsSubscription(data: data) { [weak self] group, remove in
             guard let self else { return }
-            if remove {
-                self.groups = self.groups.filter { $0 != group }
-            } else {
-                self.groups.append(group)
-            }
+            let otherGroups = self.groups.filter { $0.id != group.id }
+            self.groups = remove ? otherGroups : otherGroups + [group]
             await startSubscriptionsByGroups()
         }
     }
-    
+
+    // Interleaved invocations (a dataview update racing a group add/remove event) can
+    // interleave across await points and stop a column the other run just started;
+    // serialize FIFO so each run sees settled state. The epoch check keeps a link that
+    // was queued before teardown (onDisappear/clearState) from re-subscribing after it.
     private func startSubscriptionsByGroups() async {
-        for group in sortedVisibleGroups() {
-            let groupFilter = group.filter(with: self.activeView.groupRelationKey)
-            let subscriptionId = group.id
-            setupPaginationDataIfNeeded(groupId: group.id)
-            await startSubscriptionIfNeeded(with: subscriptionId, groupFilter: groupFilter)
+        let epoch = boardSubscriptionsEpoch
+        let previousTask = startSubscriptionsByGroupsTask
+        let task = Task { [weak self] in
+            await previousTask?.value
+            guard let self, self.boardSubscriptionsEpoch == epoch else { return }
+            await self.startSubscriptionsByGroupsSerialized()
         }
+        startSubscriptionsByGroupsTask = task
+        await task.value
+    }
+
+    private func startSubscriptionsByGroupsSerialized() async {
+        let visibleGroups = sortedVisibleGroups()
+        await stopStaleGroupSubscriptions(activeGroupIds: visibleGroups.map(\.id))
+        for group in visibleGroups {
+            let groupFilter = group.filter(with: self.activeView.groupRelationKey)
+            setupPaginationDataIfNeeded(groupId: group.id)
+            await startSubscriptionIfNeeded(subscriptionId: recordsSubscriptionId(for: group.id), groupId: group.id, groupFilter: groupFilter)
+        }
+    }
+
+    // Board record subscriptions are namespaced per screen: backend group ids are
+    // deterministic (option id / md5 of option ids), so two open sets grouped by the
+    // same relation would otherwise collide on the shared subscription registry.
+    private func recordsSubscriptionId(for groupId: String) -> String {
+        "\(setSubscriptionDataBuilder.subscriptionId)-Group-\(groupId)"
+    }
+
+    private var optionsSubscriptionId: String {
+        "\(setSubscriptionDataBuilder.subscriptionId)-Options"
+    }
+
+    // Column headers must follow option rename/recolor live; per-column dependency
+    // details cover only options referenced by loaded records, so an empty column
+    // would otherwise have no resolvable header.
+    private func startOptionsSubscription() async {
+        let relationKey = activeView.groupRelationKey
+        guard relationKey.isNotEmpty else { return }
+
+        let data = SubscriptionData.search(
+            SubscriptionData.Search(
+                identifier: optionsSubscriptionId,
+                spaceId: setDocument.spaceId,
+                filters: [
+                    SearchHelper.layoutFilter([.relationOption]),
+                    SearchHelper.relationKey(relationKey),
+                    SearchHelper.isDeletedFilter(isDeleted: false),
+                    SearchHelper.isArchivedFilter(isArchived: false)
+                ],
+                limit: 0,
+                keys: [
+                    BundledPropertyKey.id.rawValue,
+                    BundledPropertyKey.name.rawValue,
+                    BundledPropertyKey.relationOptionColor.rawValue
+                ],
+                noDepSubscription: true
+            )
+        )
+
+        let subscription = subscriptionStorages[optionsSubscriptionId] ?? subscriptionStorageProvider.createSubscriptionStorage(subId: optionsSubscriptionId)
+        subscriptionStorages[optionsSubscriptionId] = subscription
+
+        try? await subscription.startOrUpdateSubscription(data: data) { [weak self] state in
+            await self?.updateGroupOptionDetails(with: state)
+        }
+    }
+
+    private func updateGroupOptionDetails(with state: SubscriptionStorageState) {
+        groupOptionDetails = Dictionary(uniqueKeysWithValues: state.items.map { ($0.id, $0) })
+    }
+
+    // Cancelling the client-side stream does not cancel the server-side subscription;
+    // stale ids must be stopped explicitly before the tracked set is overwritten.
+    private func stopStaleGroupSubscriptions(activeGroupIds: [String]) async {
+        let activeSubscriptionIds = Set(activeGroupIds.map { recordsSubscriptionId(for: $0) } + [setSubscriptionDataBuilder.subscriptionId, optionsSubscriptionId])
+        let flatSubscriptionId = setSubscriptionDataBuilder.subscriptionId
+        let staleSubscriptionIds = subscriptionStorages.keys.filter { !activeSubscriptionIds.contains($0) }
+        for subscriptionId in staleSubscriptionIds {
+            try? await subscriptionStorages[subscriptionId]?.stopSubscription()
+            subscriptionStorages[subscriptionId] = nil
+        }
+
+        let activeGroupIdsSet = Set(activeGroupIds)
+        let staleGroupIds = recordsDict.keys.filter { $0 != flatSubscriptionId && !activeGroupIdsSet.contains($0) }
+        guard !staleGroupIds.isEmpty else { return }
+        for groupId in staleGroupIds {
+            recordsDict[groupId] = nil
+            totalsDict[groupId] = nil
+            pagitationDataDict[groupId] = nil
+        }
+        var configurations = configurationsDict
+        staleGroupIds.forEach { configurations[$0] = nil }
+        configurationsDict = configurations
     }
     
     private func setupPaginationDataIfNeeded(groupId: String) {
@@ -576,8 +772,8 @@ final class EditorSetViewModel: ObservableObject {
         pagitationDataDict[groupId] = EditorSetPaginationData.empty
     }
     
-    private func startSubscriptionIfNeeded(with subscriptionId: String, groupFilter: DataviewFilter? = nil) async {
-        let pagitationData = pagitationData(by: subscriptionId)
+    private func startSubscriptionIfNeeded(subscriptionId: String, groupId: String, groupFilter: DataviewFilter? = nil) async {
+        let pagitationData = pagitationData(by: groupId)
         let currentPage: Int
         let numberOfRowsPerPage: Int
         if activeView.type.hasGroups {
@@ -587,7 +783,7 @@ final class EditorSetViewModel: ObservableObject {
             numberOfRowsPerPage = userDefaults.rowsPerPageInSet
             currentPage = max(pagitationData.selectedPage, 1)
         }
-        
+
         guard setDocument.canStartSubscription() else { return }
 
         let subscriptionData = SetSubscriptionData(
@@ -597,23 +793,27 @@ final class EditorSetViewModel: ObservableObject {
             currentPage: currentPage,
             numberOfRowsPerPage: numberOfRowsPerPage,
             collectionId: setDocument.isCollection() ? objectId : nil,
-            objectOrderIds: setDocument.objectOrderIds(for: subscriptionId),
+            objectOrderIds: setDocument.objectOrderIds(for: groupId),
             spaceType: spaceView?.spaceType
         )
         let data = setSubscriptionDataBuilder.set(subscriptionData)
-        
+
         let subscription = subscriptionStorages[data.identifier] ?? subscriptionStorageProvider.createSubscriptionStorage(subId: data.identifier)
         subscriptionStorages[data.identifier] = subscription
 
         try? await subscription.startOrUpdateSubscription(data: data) { [weak self] state in
-            await self?.updateData(with: subscriptionId, numberOfRowsPerPage: numberOfRowsPerPage, state: state)
+            await self?.updateData(with: groupId, numberOfRowsPerPage: numberOfRowsPerPage, state: state)
         }
     }
 
     private func updateData(with groupId: String, numberOfRowsPerPage: Int, state: SubscriptionStorageState) {
+        // A stopped column's storage can still deliver an in-flight update; accepting it
+        // would resurrect the removed column.
+        guard subscriptionStorage(for: groupId) != nil else { return }
         let pagesCount = numberOfRowsPerPage > 0 ? Int(ceil(Float(state.total) / Float(numberOfRowsPerPage))) : 0
         updatePageCount(pagesCount, groupId: groupId, ignorePageLimit: activeView.type.hasGroups)
         recordsDict[groupId] = state.items
+        totalsDict[groupId] = state.total
         updateConfigurations(with: [groupId])
     }
     
@@ -624,7 +824,7 @@ final class EditorSetViewModel: ObservableObject {
     private func updateConfigurations(with groupIds: [String]) {
         var tempConfigurationsDict = configurationsDict
         for groupId in groupIds {
-            guard let subscription = subscriptionStorages[groupId] else {
+            guard let subscription = subscriptionStorage(for: groupId) else {
                 anytypeAssertionFailure("Subscription not started for group")
                 continue
             }
@@ -715,10 +915,14 @@ final class EditorSetViewModel: ObservableObject {
     }
     
     private func clearState() async {
+        boardSubscriptionsEpoch += 1
         recordsDict = [:]
+        totalsDict = [:]
         configurationsDict = [:]
         pagitationDataDict = [:]
         groups = []
+        groupOptionDetails = [:]
+        boardState = .loading
         await stopAllSubscriptionStorages()
         try? await groupsSubscriptionsHandler.stopAllSubscriptions()
     }
@@ -744,7 +948,21 @@ final class EditorSetViewModel: ObservableObject {
     }
     
     private func createObject(setting: ObjectCreationSetting? = nil) {
-        output?.showCreateObject(document: setDocument, setting: setting)
+        output?.showCreateObject(document: setDocument, setting: setting, prefilledFields: [:])
+    }
+
+    var canCreateCardInColumn: Bool {
+        setDocument.setPermissions.canCreateObject
+    }
+
+    func onCreateObjectInColumnTap(_ groupId: String) {
+        guard setDocument.setPermissions.canCreateObject else { return }
+        let groupValue = groups.first { $0.id == groupId }?.value
+        var prefilledFields = [String: Google_Protobuf_Value]()
+        if let value = SetKanbanCardMove.prefilledValue(targetGroupValue: groupValue) {
+            prefilledFields[activeView.groupRelationKey] = value
+        }
+        output?.showCreateObject(document: setDocument, setting: nil, prefilledFields: prefilledFields)
     }
 
     private func defaultSubscriptionDetailsStorage(file: StaticString = #file, function: String = #function, line: UInt = #line) -> ObjectDetailsStorage? {
@@ -812,15 +1030,21 @@ extension EditorSetViewModel {
     func objectOrderUpdate(with groupObjectIds: [GroupObjectIds]) {
         Task { [weak self] in
             guard let self else { return }
-            try await self.dataviewService.objectOrderUpdate(
-                objectId: setDocument.objectId,
-                blockId: setDocument.blockId,
-                order: groupObjectIds.map { DataviewObjectOrder(viewID: self.activeView.id, groupID: $0.groupId, objectIds: $0.objectIds) }
-            )
+            do {
+                try await self.dataviewService.objectOrderUpdate(
+                    objectId: setDocument.objectId,
+                    blockId: setDocument.blockId,
+                    order: groupObjectIds.map { DataviewObjectOrder(viewID: self.activeView.id, groupID: $0.groupId, objectIds: $0.objectIds) }
+                )
+            } catch {
+                revertOptimisticCardMoves()
+                output?.showFailureToast(message: error.localizedDescription)
+            }
         }
     }
     
     func showKanbanColumnSettings(for groupId: String) {
+        guard setDocument.setPermissions.canEditView else { return }
         let groupOrder = setDocument.dataView.groupOrders.first { [weak self] in $0.viewID == self?.activeView.id }
         let viewGroup = groupOrder?.viewGroups.first { $0.groupID == groupId }
         let selectedColor = MiddlewareColor(rawValue: viewGroup?.backgroundColor ?? "")?.backgroundColor

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/Builders/SetPermissionsBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/Builders/SetPermissionsBuilder.swift
@@ -26,7 +26,8 @@ final class SetPermissionsBuilder: SetPermissionsBuilderProtocol {
             canEditRelationValuesInView: canEdit && canEditRelationValuesInView(setDocument: setDocument),
             canEditTitle: canEdit,
             canEditDescription: canEdit,
-            canEditSetObjectIcon: canEdit
+            canEditSetObjectIcon: canEdit,
+            canMoveCards: canEdit
         )
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/SetPermissions.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Models/SetPermissions.swift
@@ -11,4 +11,5 @@ struct SetPermissions {
     var canEditTitle: Bool = false
     var canEditDescription: Bool = false
     var canEditSetObjectIcon: Bool = false
+    var canMoveCards: Bool = false
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionData.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionData.swift
@@ -10,6 +10,7 @@ struct SetSubscriptionData: Hashable {
     let options: [DataviewRelationOption]
     let currentPage: Int
     let coverRelationKey: String
+    let groupRelationKey: String?
     let numberOfRowsPerPage: Int
     let collectionId: String?
     let spaceId: String
@@ -88,6 +89,7 @@ struct SetSubscriptionData: Hashable {
         self.options = view.options
         self.currentPage = currentPage
         self.coverRelationKey = view.coverRelationKey
+        self.groupRelationKey = view.type.hasGroups && view.groupRelationKey.isNotEmpty ? view.groupRelationKey : nil
         self.numberOfRowsPerPage = numberOfRowsPerPage
         self.collectionId = collectionId
         self.spaceId = document.spaceId

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionDataBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Subscriptions/Set/SetSubscriptionDataBuilder.swift
@@ -74,7 +74,10 @@ final class SetSubscriptionDataBuilder: SetSubscriptionDataBuilderProtocol, Send
         
         keys.append(contentsOf: data.options.map { $0.key })
         keys.append(data.coverRelationKey)
-        
+        if let groupRelationKey = data.groupRelationKey {
+            keys.append(groupRelationKey)
+        }
+
         return keys
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Collection/Cell/SetGalleryViewCell.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Collection/Cell/SetGalleryViewCell.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct SetGalleryViewCell: View {
-    @State private var width: CGFloat = .zero
     let configuration: SetContentViewItemConfiguration
     
     var body: some View {
@@ -26,7 +25,6 @@ struct SetGalleryViewCell: View {
         .overlay(
             RoundedRectangle(cornerRadius: Constants.cornerRadius).stroke(Color.Shape.primary, lineWidth: 0.5)
         )
-        .readSize { width = $0.width }
     }
     
     private var infoContent: some View {
@@ -52,12 +50,17 @@ struct SetGalleryViewCell: View {
     @ViewBuilder
     private var coverContent: some View {
         if configuration.hasCover, let coverType = configuration.coverType {
-            let defaultHeight = configuration.isSmallCardSize ? Constants.smallItemHeight : Constants.largeItemHeight
-            let height: CGFloat = configuration.shouldIncreaseCoverHeight ? width : defaultHeight
-            ObjectHeaderCoverView(objectCover: coverType, fitImage: configuration.coverFit)
-                .frame(height: height)
-                .frame(maxWidth: .infinity)
-                .background(Color.Shape.transparentSecondary)
+            let cover = ObjectHeaderCoverView(objectCover: coverType, fitImage: configuration.coverFit)
+            Group {
+                if configuration.shouldIncreaseCoverHeight {
+                    // Cover-only cards are square: height == card width
+                    cover.aspectRatio(1, contentMode: .fit)
+                } else {
+                    cover.frame(height: configuration.isSmallCardSize ? Constants.smallItemHeight : Constants.largeItemHeight)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .background(Color.Shape.transparentSecondary)
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Services
+import DesignKit
 
 struct SetKanbanView: View {
     @ObservedObject var model: EditorSetViewModel
@@ -43,9 +44,35 @@ struct SetKanbanView: View {
             EmptyView()
         } else {
             Section(header: compoundHeader) {
-                boardContent
+                switch model.boardState {
+                case .loading:
+                    loadingView
+                case .error:
+                    errorView
+                case .ready:
+                    boardContent
+                }
             }
         }
+    }
+
+    private var loadingView: some View {
+        DotsView()
+            .frame(width: 50, height: 6)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 60)
+    }
+
+    private var errorView: some View {
+        EmptyStateView(
+            title: Loc.Content.Common.error,
+            style: .error,
+            buttonData: EmptyStateView.ButtonData(title: Loc.tryAgain) {
+                await model.onBoardErrorRetryTap()
+            }
+        )
+        .frame(maxWidth: .infinity)
+        .padding(.top, 60)
     }
     
     private var boardContent: some View {
@@ -56,6 +83,7 @@ struct SetKanbanView: View {
                         SetKanbanColumn(
                             groupId: groupId,
                             headerType: model.headerType(for: groupId),
+                            count: model.columnCount(for: groupId),
                             configurations: configurations,
                             isGroupBackgroundColors: model.isGroupBackgroundColors,
                             backgroundColor: model.groupBackgroundColor(for: groupId),
@@ -67,7 +95,10 @@ struct SetKanbanView: View {
                             },
                             onSettingsTap: {
                                 model.showKanbanColumnSettings(for: groupId)
-                            }
+                            },
+                            onCreateTap: model.canCreateCardInColumn ? {
+                                model.onCreateObjectInColumnTap(groupId)
+                            } : nil
                         )
                     }
                 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
@@ -4,55 +4,39 @@ import DesignKit
 
 struct SetKanbanView: View {
     @ObservedObject var model: EditorSetViewModel
-    
+
     @Binding var tableHeaderSize: CGSize
     @Binding var offset: CGPoint
-    
+
     @State private var dropData = SetCardDropData()
-    
+
     var headerMinimizedSize: CGSize
 
     var body: some View {
-        OffsetAwareScrollView(
-            axes: [.vertical],
-            showsIndicators: false,
-            offsetChanged: { offset.y = $0.y }
-        ) {
-            Spacer.fixedHeight(tableHeaderSize.height)
-            content
-            Spacer()
+        VStack(spacing: 0) {
+            Spacer.fixedHeight(max(tableHeaderSize.height - headerMinimizedSize.height, 0))
+            if !model.isEmptyViews {
+                compoundHeader
+                boardView
+            }
         }
-        .frame(maxHeight: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .onAppear {
+            // The board doesn't scroll vertically as a whole, so the shared
+            // offset must be reset after switching from a scrolled view type.
+            offset = .zero
+        }
     }
 
-    // MARK: List view
-    
-    private var content: some View {
-        LazyVStack(
-            alignment: .center,
-            spacing: 0,
-            pinnedViews: [.sectionHeaders]
-        ) {
-            boardView
-        }
-        .padding(.top, -headerMinimizedSize.height)
-    }
-    
     @ViewBuilder
     private var boardView: some View {
-        if model.isEmptyViews {
-            EmptyView()
-        } else {
-            Section(header: compoundHeader) {
-                switch model.boardState {
-                case .loading:
-                    loadingView
-                case .error:
-                    errorView
-                case .ready:
-                    boardContent
-                }
-            }
+        switch model.boardState {
+        case .loading:
+            loadingView
+        case .error:
+            errorView
+        case .ready:
+            boardContent
         }
     }
 
@@ -74,10 +58,10 @@ struct SetKanbanView: View {
         .frame(maxWidth: .infinity)
         .padding(.top, 60)
     }
-    
+
     private var boardContent: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(alignment: .top, spacing: 8) {
+            LazyHStack(alignment: .top, spacing: 8) {
                 ForEach(model.configurationsDict.keys, id: \.self) { groupId in
                     if let configurations = model.configurationsDict[groupId] {
                         SetKanbanColumn(
@@ -104,6 +88,7 @@ struct SetKanbanView: View {
                 }
             }
             .padding(.horizontal, 20)
+            .scrollAxisLock(.horizontal)
         }
     }
 
@@ -114,7 +99,7 @@ struct SetKanbanView: View {
         }
         .background(Color.Background.primary)
     }
-    
+
     private var headerSettingsView: some View {
         HStack {
             SetHeaderSettingsView(model: model.headerSettingsViewModel)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct SetKanbanColumn: View {
     let groupId: String
     let headerType: SetKanbanColumnHeaderType
+    let count: Int
     let configurations: [SetContentViewItemConfiguration]
     let isGroupBackgroundColors: Bool
     let backgroundColor: BlockBackgroundColor
@@ -14,6 +15,7 @@ struct SetKanbanColumn: View {
     
     let onShowMoreTap: () -> Void
     let onSettingsTap: () -> Void
+    let onCreateTap: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -56,8 +58,37 @@ struct SetKanbanColumn: View {
             if showPagingView {
                 pagingView
             }
+            if let onCreateTap {
+                createView(onCreateTap)
+            }
         }
         .frame(width: 254)
+    }
+
+    private func createView(_ onTap: @escaping () -> Void) -> some View {
+        SetDragAndDropView(
+            dropData: $dropData,
+            configuration: nil,
+            groupId: groupId,
+            dragAndDropDelegate: dragAndDropDelegate,
+            content: {
+                Button {
+                    onTap()
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(asset: .X24.plus)
+                            .foregroundStyle(Color.Control.secondary)
+                        AnytypeText(Loc.new, style: .caption1Medium)
+                            .foregroundStyle(Color.Text.secondary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 10)
+                    .frame(height: 40)
+                    .fixTappableArea()
+                }
+                .buttonStyle(LightDimmingButtonStyle())
+            }
+        )
     }
     
     private var header: some View {
@@ -102,9 +133,13 @@ struct SetKanbanColumn: View {
                     .foregroundStyle(Color.Text.secondary)
                 }
             }
-            
+
+            Spacer.fixedWidth(8)
+            AnytypeText("\(count)", style: .relation2Regular)
+                .foregroundStyle(Color.Text.secondary)
+
             Spacer()
-            
+
             Image(asset: .X24.more).foregroundStyle(Color.Control.secondary)
         }
         .padding(.horizontal, 10)

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
@@ -19,31 +19,59 @@ struct SetKanbanColumn: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            content
-            if configurations.isEmpty {
-                emptyDroppableArea
-            }
-        }
-    }
-    
-    private var content: some View {
-        VStack(spacing: 0) {
             header
-            column
+                .padding(.horizontal, 8)
+                .background(
+                    columnBackgroundColor,
+                    in: .rect(topLeadingRadius: 4, topTrailingRadius: 4)
+                )
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 0) {
+                    column
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, configurations.isEmpty ? 0 : Constants.contentInset)
+                        .background(
+                            columnBackgroundColor,
+                            in: .rect(bottomLeadingRadius: 4, bottomTrailingRadius: 4)
+                        )
+                    if configurations.isEmpty {
+                        emptyDroppableArea
+                    }
+                    // Room to scroll the last card and the create button clear of the floating
+                    // home panel, whose blur intercepts touches across the full width.
+                    AnytypeNavigationSpacer()
+                }
+                .scrollAxisLock(.vertical)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .overlay(alignment: .top) { topFade }
         }
-        .padding(.horizontal, 8)
-        .padding(.bottom, configurations.isEmpty ? 0 : 8)
-        .background(
-            isGroupBackgroundColors ?
-            backgroundColor.swiftColor.opacity(0.5) :
-            Color.Background.primary
-        )
-        .clipShape(.rect(cornerRadius: 4))
         .frame(width: 270)
     }
-    
+
+    private var columnBackgroundColor: Color {
+        isGroupBackgroundColors ?
+        backgroundColor.swiftColor.opacity(0.5) :
+        Color.Background.primary
+    }
+
+    // Softens the hard clip under the header: cards dissolve into the column's own color instead
+    // of being cut off. The group tint is translucent, so the fade has to be its composite over
+    // the board background - fading to the tint alone would leave cards showing through it.
+    private var topFade: some View {
+        ZStack {
+            Color.Background.primary
+            columnBackgroundColor
+        }
+        .frame(height: Constants.contentInset)
+        .mask(
+            LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
+        )
+        .allowsHitTesting(false)
+    }
+
     private var column: some View {
-        VStack(spacing: 8) {
+        LazyVStack(spacing: 8) {
             ForEach(configurations) { configuration in
                 SetDragAndDropView(
                     dropData: $dropData,
@@ -181,5 +209,13 @@ struct SetKanbanColumn: View {
                     .frame(height: 44)
             }
         )
+    }
+}
+
+extension SetKanbanColumn {
+    enum Constants {
+        // Doubles as the fade height, so at rest the fade covers only the inset and is fully
+        // transparent by the first card's top edge.
+        static let contentInset: CGFloat = 8
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/SetKanbanBoardState.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/SetKanbanBoardState.swift
@@ -1,0 +1,5 @@
+enum SetKanbanBoardState: Equatable {
+    case loading
+    case ready
+    case error(message: String)
+}

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/DataviewGroup+Filter.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/DataviewGroup+Filter.swift
@@ -26,36 +26,36 @@ extension DataviewGroup {
         }
     }
     
-    func backgroundColor(document: some BaseDocumentProtocol) -> BlockBackgroundColor? {
+    func backgroundColor(optionDetails: (String) -> ObjectDetails?) -> BlockBackgroundColor? {
         switch value {
         case .tag(let tag):
             guard let firstTagId = tag.ids.first,
-                  let details = document.detailsStorage.get(id: firstTagId) else { return nil }
+                  let details = optionDetails(firstTagId) else { return nil }
             return MiddlewareColor(rawValue: details.relationOptionColor)?.backgroundColor
         case .status(let status):
-            guard let details = document.detailsStorage.get(id: status.id) else { return nil }
+            guard let details = optionDetails(status.id) else { return nil }
             return MiddlewareColor(rawValue: details.relationOptionColor)?.backgroundColor
         default:
             return nil
         }
     }
-    
-    func header(with groupRelationKey: String, document: some BaseDocumentProtocol) -> SetKanbanColumnHeaderType {
+
+    func header(checkboxTitle: String, optionDetails: (String) -> ObjectDetails?) -> SetKanbanColumnHeaderType {
         switch value {
         case .tag(let tag):
             let tags = tag.ids
-                .compactMap { document.detailsStorage.get(id: $0) }
+                .compactMap { optionDetails($0) }
                 .map { PropertyOption(details: $0) }
                 .map { Property.Tag.Option(option: $0) }
             return tags.isEmpty ? .uncategorized : .tag(tags)
         case .status(let status):
-            guard let optionDetails = document.detailsStorage.get(id: status.id) else {
+            guard let details = optionDetails(status.id) else {
                 return .uncategorized
             }
-            let option = PropertyOption(details: optionDetails)
+            let option = PropertyOption(details: details)
             return .status([Property.Status.Option(option: option)])
         case .checkbox(let checkbox):
-            return .checkbox(title: groupRelationKey.capitalized, isChecked: checkbox.checked)
+            return .checkbox(title: checkboxTitle, isChecked: checkbox.checked)
         default:
             return .uncategorized
         }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetCardDropData.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetCardDropData.swift
@@ -1,13 +1,16 @@
+import Foundation
 import ProtobufMessages
 
 struct SetCardDropData {
+    var dragSessionId: UUID?
     var initialFromGroupId: String?
     var fromGroupId: String?
     var toGroupId: String?
     var draggingCard: SetContentViewItemConfiguration?
     var droppingCard: SetContentViewItemConfiguration?
-    
+
     mutating func clear() {
+        dragSessionId = nil
         initialFromGroupId = nil
         fromGroupId = nil
         toGroupId = nil

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetKanbanCardMove.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetKanbanCardMove.swift
@@ -1,0 +1,88 @@
+import Services
+import SwiftProtobuf
+import AnytypeCore
+
+enum SetKanbanCardMoveValue: Equatable {
+    case ids([String])
+    case checked(Bool)
+    case unset
+
+    var protobufValue: Google_Protobuf_Value {
+        switch self {
+        case .ids(let ids):
+            return ids.protobufValue
+        case .checked(let checked):
+            return checked.protobufValue
+        case .unset:
+            return Google_Protobuf_Value(nilLiteral: ())
+        }
+    }
+}
+
+enum SetKanbanCardMove: Equatable {
+    case write(SetKanbanCardMoveValue)
+    case ignore
+
+    static func compute(
+        currentValue: [String],
+        sourceGroupValue: DataviewGroupValue?,
+        targetGroupValue: DataviewGroupValue?,
+        groupsLoaded: Bool
+    ) -> SetKanbanCardMove {
+        guard groupsLoaded, let targetGroupValue else { return .ignore }
+
+        switch targetGroupValue {
+        case .status(let status):
+            return status.id.isEmpty ? .write(.unset) : .write(.ids([status.id]))
+        case .checkbox(let checkbox):
+            return .write(.checked(checkbox.checked))
+        case .tag(let tag):
+            let sourceIds: [String]
+            if case let .tag(sourceTag)? = sourceGroupValue {
+                sourceIds = sourceTag.ids
+            } else if sourceGroupValue == nil {
+                // An unresolved source column means the card's real tags couldn't be
+                // cross-checked; with an empty current read the write would replace the
+                // card's whole tag set blind — the exact loss this type exists to prevent.
+                guard currentValue.isNotEmpty, tag.ids.isNotEmpty else { return .ignore }
+                sourceIds = []
+            } else {
+                sourceIds = []
+            }
+            var newIds = currentValue.filter { !sourceIds.contains($0) }
+            for id in tag.ids where !newIds.contains(id) {
+                newIds.append(id)
+            }
+            guard newIds != currentValue else { return .ignore }
+            return .write(.ids(newIds))
+        default:
+            return .ignore
+        }
+    }
+
+    static func prefilledValue(targetGroupValue: DataviewGroupValue?) -> Google_Protobuf_Value? {
+        // No ternaries here: Google_Protobuf_Value is ExpressibleByNilLiteral, so a
+        // `nil` branch would silently become an explicit protobuf NULL_VALUE.
+        switch targetGroupValue {
+        case .status(let status):
+            guard status.id.isNotEmpty else { return nil }
+            return [status.id].protobufValue
+        case .checkbox(let checkbox):
+            return checkbox.checked.protobufValue
+        case .tag(let tag):
+            guard tag.ids.isNotEmpty else { return nil }
+            return tag.ids.protobufValue
+        default:
+            return nil
+        }
+    }
+
+    static func stringList(from value: Google_Protobuf_Value?) -> [String] {
+        guard let value else { return [] }
+        if case let .listValue(list) = value.kind {
+            return list.values.map(\.stringValue).filter(\.isNotEmpty)
+        }
+        let single = value.stringValue
+        return single.isEmpty ? [] : [single]
+    }
+}

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetKanbanReorder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetKanbanReorder.swift
@@ -1,0 +1,6 @@
+enum SetKanbanReorder {
+    static func isColumnFullyLoaded(loadedCount: Int, totalCount: Int?) -> Bool {
+        guard let totalCount else { return false }
+        return loadedCount >= totalCount
+    }
+}

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/SetDragAndDropView/SetDragAndDropView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/SetDragAndDropView/SetDragAndDropView.swift
@@ -27,24 +27,23 @@ struct SetDragAndDropView<Content>: View where Content: View {
     
     var body: some View {
         content()
-            .if(FeatureFlags.dndOnCollectionsAndSets) {
+            .if(FeatureFlags.dndOnCollectionsAndSets && dragAndDropDelegate.canDragCards) {
                 $0.ifLet(configuration) { view, configuration in
                     view
                         .onDrag {
                             UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
                             updateDropData(with: configuration, groupId: groupId)
+                            let sessionId = dropData.dragSessionId
                             let provider = DragItemProvider(object: SetItemProviderObject())
                             provider.didEnd = {
-                                defer { dropData.clear() }
-                                guard let fromGroupId = dropData.initialFromGroupId,
-                                      let toGroupId = dropData.toGroupId else {
-                                    return
-                                }
-                                let _ = dragAndDropDelegate.onDrop(
-                                    configurationId: configuration.id,
-                                    fromGroupId: fromGroupId,
-                                    toGroupId: toGroupId
-                                )
+                                // performDrop clears dropData before didEnd fires; state still
+                                // present here means the drag ended outside any drop target.
+                                // The session check keeps a stale provider's deferred deinit
+                                // from cancelling a newer drag.
+                                guard dropData.initialFromGroupId != nil,
+                                      dropData.dragSessionId == sessionId else { return }
+                                dropData.clear()
+                                dragAndDropDelegate.onDragCancelled()
                             }
                             return provider
                         }
@@ -58,6 +57,7 @@ struct SetDragAndDropView<Content>: View where Content: View {
     }
     
     private func updateDropData(with configuration: SetContentViewItemConfiguration, groupId: String) {
+        dropData.dragSessionId = UUID()
         dropData.draggingCard = configuration
         dropData.initialFromGroupId = groupId
         dropData.fromGroupId = groupId

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -69,8 +69,8 @@ public extension FeatureDescription {
     
     static let setKanbanView = FeatureDescription(
         title: "Set kanban view",
-        category: .productFeature(author: "joe_pusya@anytype.io", targetRelease: "?"),
-        defaultValue: false
+        category: .productFeature(author: "requilence@gmail.com", targetRelease: "0.49.0"),
+        defaultValue: true
     )
     
     static let fullInlineSetImpl = FeatureDescription(
@@ -80,9 +80,9 @@ public extension FeatureDescription {
     )
     
     static let dndOnCollectionsAndSets = FeatureDescription(
-        title: "Dnd on collections and sets (wating for the middle)",
-        category: .productFeature(author: "joe_pusya@anytype.io", targetRelease: "?"),
-        defaultValue: false
+        title: "Dnd on collections and sets (kanban only)",
+        category: .productFeature(author: "requilence@gmail.com", targetRelease: "0.49.0"),
+        defaultValue: true
     )
     
     static let matchedTransitionSource = FeatureDescription(

--- a/docs/plans/20260714-ios-6579-kanban-scroll-fps-handoff.md
+++ b/docs/plans/20260714-ios-6579-kanban-scroll-fps-handoff.md
@@ -1,0 +1,310 @@
+# Handoff — Kanban Board Scroll FPS Investigation (IOS-6579)
+
+## Context
+
+Branch: `ios-6579-kanban-view-audit-and-fix-dormant-implementation-enable-by`
+Base commit under investigation: `70480c386e` "IOS-6579 Fix dormant Kanban implementation and
+enable it by default" (only this commit touches Kanban files vs `develop`).
+
+The Kanban view (`Set` object, Board layout) was a dormant/rarely-used implementation that got
+turned on by default. User reports **janky scroll FPS** on the board. A real-device Instruments
+trace was captured: `/Users/roma/Documents/ios-kanban-scroll.trace` (CPU Profiler template,
+23s recording, iPhone 17 Pro, iOS 26.5.1). This doc summarizes what the trace + code review found,
+and — important — **an attempted fix (Lazy stacks) broke layout and was reverted.** Working tree
+is currently clean (identical to `70480c386e` for the Kanban folder). Do not re-attempt the exact
+same Lazy-stack swap without reading the "What was tried and why it failed" section below.
+
+## How the trace was analyzed
+
+`xctrace export` was used to pull specific tables out of the `.trace` bundle as XML (the GUI
+wasn't used/available in this session). Useful invocations:
+
+```bash
+# Table of contents — lists every table schema available in the trace
+xcrun xctrace export --input ios-kanban-scroll.trace --toc --output toc.xml
+
+# Frame lifetime / hitch data (the "Hitches" instrument equivalent) — small, human-readable
+xcrun xctrace export --input ios-kanban-scroll.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="coreanimation-lifetime-interval"]' \
+  --output lifetime.xml
+
+# Raw vsync swap timestamps (for manual frame-delta math)
+xcrun xctrace export --input ios-kanban-scroll.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="display-surface-swap"]' \
+  --output swaps.xml
+
+# Full CPU profile w/ symbolicated callstacks — LARGE (~100MB), took ~10s to export
+xcrun xctrace export --input ios-kanban-scroll.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="cpu-profile"]' \
+  --output cpu.xml
+```
+
+`cpu.xml` is too big to parse with a plain DOM load — use `xml.etree.ElementTree.iterparse` in
+streaming mode, and note the export format uses an id/ref interning scheme (repeated values like
+thread names, thread-state, frame names/binaries are defined once with an `id=` attribute and
+referenced elsewhere via `ref=`) — you must build lookup caches for `thread`, `thread-state`, and
+`frame`/`binary` elements, or you'll silently get `None` for most rows (this bit us once — the
+first parse pass mis-read `thread-state` because ref'd elements have no `fmt` attribute of their
+own). Filter to `Main Thread` rows via the thread `fmt` string containing `"Main Thread"`.
+
+All intermediate exports/scripts from this session live under a session-scoped scratchpad dir that
+will not persist — regenerate with the commands above if you need to re-analyze.
+
+## Findings
+
+### 1. Frame timing (from `coreanimation-lifetime-interval`, i.e. Instruments' own Hitch computation)
+
+- 916 total frames over the 23s recording.
+- **182 frames (~20%) hitched**, for **5.7s of cumulative hitch time** — roughly a quarter of the
+  recording was spent in dropped/late frames.
+- Two hitch signatures dominate (from the `narrative`/`type-label` columns), and **both are
+  GPU/compositor-bound, not CPU-bound**:
+  - `"waiting on GPU and VSync"` — the CPU-side (main thread) work for that frame finished in
+    ~9-14ms, comfortably inside budget, but the frame still landed 40-140ms late because the GPU/
+    compositor hadn't caught up. Example: frame 487 at t=10.429s — 9.98ms of actual CPU work,
+    141.69ms hitch.
+  - `"in render server"` — the system compositor process itself is reported spending 85-155ms
+    rendering a single frame. Example: frame 156 at t=4.111s — 155.93ms in render server, 133.36ms
+    hitch.
+- Worst hitches cluster in two windows: **t≈9.5–17s** and **t≈19–23s** (consistent with sustained
+  horizontal drag/scroll through the board, as opposed to the isolated multi-hundred-ms spikes
+  earlier in the trace at t=0.5s/3.3s/5.5s which look like initial view load, not scroll).
+
+### 2. Main-thread CPU profile (from `cpu-profile`, filtered to Main Thread, `Running` samples,
+   windows t=9.5–17s and t=19–23s)
+
+Top cycle-weighted leaf/hot frames:
+
+```
+AttributeGraph::Graph::propagate_dirty(AttributeID)
+AttributeGraph::Graph::UpdateStack::update()
+SwiftUICore specialized find1<A>(_:key:filter:)
+AttributeGraph::Subgraph::update(unsigned int)
+AttributeGraph::Subgraph::foreach_ancestor<...propagate_dirty_flags()::$_0>(...)
+```
+
+This is SwiftUI's dependency-graph invalidation/propagation machinery and its preference-key
+lookup (`find1`) running hot. This pattern shows up when the **live view tree is much larger than
+what's actually on screen** — every state change has to walk/re-diff a bloated AttributeGraph, and
+every preference-key read (see finding #4 below) has to search/merge across that same oversized
+tree. It is corroborating evidence for, not contradicting, the GPU-bound hitch finding above: the
+main thread isn't "slow" in the sense of blowing the 16.7/8.3ms budget outright, but it's doing
+much more graph/preference work than a properly virtualized list would need, and it's feeding an
+oversized real layer tree to the compositor, which is what actually blows the frame deadline.
+
+### 3. Root cause in code: eager (non-lazy) stacks for both scroll axes
+
+`Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift:78-84`
+(`boardContent`):
+
+```swift
+ScrollView(.horizontal, showsIndicators: false) {
+    HStack(alignment: .top, spacing: 8) {
+        ForEach(model.configurationsDict.keys, id: \.self) { groupId in
+            ...
+            SetKanbanColumn(...)
+        }
+    }
+}
+```
+
+`Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift:45-47`
+(`column`):
+
+```swift
+VStack(spacing: 8) {
+    ForEach(configurations) { configuration in
+        SetDragAndDropView(..., content: { SetGalleryViewCell(configuration: configuration) })
+    }
+    ...
+}
+```
+
+Neither the columns (`HStack`) nor the cards within a column (`VStack`) are lazy. Every column and
+every card in every column is built, laid out, and composited as a real live view/CALayer
+regardless of horizontal scroll position — nothing is virtualized. `git show 70480c386e` confirms
+this shape predates the "enable by default" commit (that commit only added loading/error states, a
+card counter, and a create-card button) — i.e. this is pre-existing dormant code that was never
+exercised at realistic board sizes before now.
+
+### 4. Compounding per-cell cost
+
+`Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Collection/Cell/SetGalleryViewCell.swift:16-30`
+— every card's `content` attaches:
+- `.readSize { width = $0.width }` →
+  `Modules/DesignKit/Sources/DesignKit/SystemExtensions/View+ReadSize.swift` — this is
+  `background(GeometryReader { ... }.onPreferenceChange(SizeCatcherKey.self) { ... })`, i.e. a
+  `GeometryReader` + `PreferenceKey` round-trip on **every card**.
+- `.clipShape(.rect(cornerRadius: 12))`
+- `.overlay(RoundedRectangle(cornerRadius: 12).stroke(...))`
+
+Each of these is legitimate per-cell layout/compositing cost, but because of finding #3 it runs for
+**every card that has ever existed in the board**, not just the visible ones — this is what's
+flooding both the AttributeGraph/preference-key churn on the main thread (finding #2) and the
+render-server/GPU load (finding #1).
+
+## What was tried and why it failed
+
+**Attempted fix:** swap `HStack` → `LazyHStack` in `SetKanbanView.boardContent`, and `VStack` →
+`LazyVStack` in `SetKanbanColumn.column`.
+
+**Result: broke layout.** On-device screenshot after applying both changes showed the board
+"trimmed" — each column rendered only ~1 card even though the column header showed the correct
+count (e.g. "Action 2", "Evaluating 5"), followed by a large blank/black area below where the rest
+of the board should have been.
+
+Reverting just the card-level change (`SetKanbanColumn` back to plain `VStack`, keeping
+`SetKanbanView`'s `LazyHStack` for columns) **did not fix it** — user reported "still trimmed the
+same way." Both changes were then fully reverted; `git diff` against `70480c386e` for the Kanban
+folder is now clean.
+
+**Working hypothesis for why (not yet verified/isolated):** the view hierarchy above the board is
+unusual:
+
+```
+OffsetAwareScrollView (native vertical ScrollView; wraps content in a plain VStack +
+                        a 0×0 GeometryReader/PreferenceKey pair used only for offset tracking)
+  → SetKanbanView.content:
+      LazyVStack(pinnedViews: [.sectionHeaders])     ← wraps a SINGLE Section. Only present to
+        → Section(header: compoundHeader) {            get sticky/pinned-header behavior for
+            boardContent                                the column headers; provides zero
+          }                                             virtualization value since it has one child.
+            → boardContent: ScrollView(.horizontal) { HStack/LazyHStack { columns } }
+                → SetKanbanColumn: VStack { header; column }
+                    → column: VStack/LazyVStack { cards }
+```
+
+Both attempts (lazy columns, lazy cards) produced the *same* symptom — first item(s) render, then
+a fixed-size blank region — regardless of which axis/level was made lazy. That's a signal this is
+structural rather than incidental to one specific `Lazy*Stack` call. The suspect is the
+**pre-existing single-item outer `LazyVStack(pinnedViews: [.sectionHeaders])`**: `ScrollView`'s
+cross-axis size is intrinsic/content-driven (a `ScrollView(.horizontal)` has to ask its content
+"how tall are you" since it doesn't constrain height itself), and a `Lazy*Stack` can only answer
+that honestly by measuring content it hasn't necessarily built yet. Nesting another lazy container
+(even a single-child one) above that ambiguous measurement appears to freeze/collapse the proposed
+size early, before the rest of the board's real content height is known — consistent with "only
+what fit the first (wrong) size guess got drawn, everything else is clipped blank."
+
+This has **not been confirmed** — it's the leading hypothesis based on the symptom matching on both
+attempts, not a verified root cause. Treat it as a starting point, not a conclusion.
+
+## Suggested next steps (untried)
+
+1. **Isolate the outer-LazyVStack hypothesis first**, cheaply: temporarily replace
+   `SetKanbanView.content`'s `LazyVStack(pinnedViews: [.sectionHeaders])` with a plain `VStack`
+   (accepting loss of the sticky header for this experiment only) and retry `LazyHStack` for
+   columns. If the board renders fully, the hypothesis is confirmed and the real fix is about
+   restructuring how the pinned header is achieved, not about avoiding Lazy stacks altogether.
+2. **If sticky header must be preserved**, look at achieving it without wrapping the entire board
+   in a single-item pinned `LazyVStack` — e.g. pin the header via `.safeAreaInset(edge: .top)` or a
+   custom offset-driven header that reads the same `offset` binding `SetKanbanView` already tracks,
+   instead of relying on SwiftUI's `pinnedViews` mechanism.
+3. **Consider giving each column its own vertical `ScrollView` + `LazyVStack`** for cards (instead
+   of the current fixed/paginated "Show more" `VStack`) — this would give the card list a direct,
+   unambiguous vertical `ScrollView` ancestor (matching axis, no intermediate lazy/section
+   ambiguity), sidestepping the cross-axis sizing problem entirely. This is a bigger UX change
+   (independent per-column vertical scrolling vs. the current pagination-button model) — needs a
+   product call.
+4. **Independent of the Lazy-stack question**, finding #4 (per-cell `readSize`/GeometryReader/
+   PreferenceKey + `clipShape` + `overlay`) is a real, measured contributor and safe to address
+   without touching the container laziness at all:
+   - `shouldIncreaseCoverHeight` is the only consumer of the measured `width` in
+     `SetGalleryViewCell.swift:56` — check whether it can use the already-known, constant column
+     width (`SetKanbanColumn` cards are always laid out at `.frame(width: 254)`,
+     `SetKanbanColumn.swift:65`) instead of re-measuring per cell at runtime via `GeometryReader`.
+     That would remove one `GeometryReader`+`PreferenceKey` round-trip per card unconditionally.
+   - Consider whether `.clipShape` + `.overlay(...stroke)` can be collapsed into a single shape
+     pass (e.g. a custom `ButtonStyle`/background shape) to avoid the extra offscreen-render layer
+     per card.
+5. Whatever is tried, **verify on a real device** (GPU/compositor timing on Simulator is not
+   representative) and re-run the trace export commands above (or capture a fresh trace) to confirm
+   the `"waiting on GPU and VSync"` / `"in render server"` hitch counts actually drop before
+   declaring victory — don't rely on subjective smoothness alone given how easy it was to
+   accidentally break layout while "fixing" this.
+
+## Update (2026-07-14, later session) — root cause sharpened, fix implemented
+
+**The "outer pinned LazyVStack" hypothesis was close but not the real blocker.** Both lazy
+attempts failed for a structural reason that no rearrangement of `Lazy*Stack` calls can fix while
+the whole board scrolls vertically as one sheet:
+
+1. **Columns can't be lazy**: board height must equal the tallest column's height. A `LazyHStack`
+   can only measure columns it has already built, so it reports an underestimate at first layout —
+   and everything below that wrong height was silently clipped by `SetKanbanColumn`'s
+   `.clipShape(.rect(cornerRadius: 4))`, which is exactly the observed "header with correct count,
+   ~1 card, then blank" symptom. This holds with or without the outer pinned `LazyVStack`, so
+   suggested step #1 above was skipped — it tests the wrong variable.
+2. **Cards can't be lazy**: a lazy container only virtualizes against the viewport of its nearest
+   *same-axis* ancestor ScrollView. The cards' nearest ScrollView ancestor is the horizontal one,
+   so a `LazyVStack` of cards can never track the outer vertical viewport.
+
+**Implemented fix** (both parts, this branch, uncommitted):
+
+- `SetGalleryViewCell.swift`: deleted `@State width` + `.readSize` (GeometryReader/PreferenceKey
+  per card — the measured `find1`/AttributeGraph hot path, and a double-layout on insertion).
+  `shouldIncreaseCoverHeight` means "cover-only card is square", so the cover now uses
+  `.aspectRatio(1, contentMode: .fit)` instead of a measured `frame(height: width)`. Safe because
+  `ObjectHeaderCoverView` is a `GeometryReader` at its root and always fills its proposal. Also
+  benefits the gallery view, which shares the cell.
+- `SetKanbanView.swift`: replaced `OffsetAwareScrollView` + single-section
+  `LazyVStack(pinnedViews:)` + negative-padding scaffolding with a plain `VStack`: top spacer
+  (`tableHeaderSize.height - headerMinimizedSize.height`, replicating the old resting geometry),
+  always-visible settings header, then `ScrollView(.horizontal) { LazyHStack { columns } }`.
+  `offset` is reset to `.zero` in `onAppear` so the overlaid `SetFullHeader` recovers after
+  switching from a scrolled table/gallery.
+- `SetKanbanColumn.swift`: column = fixed header + own `ScrollView(.vertical) { LazyVStack }` of
+  cards (Trello/Linear model). Every lazy container now sits directly inside a matching-axis
+  ScrollView with concrete size proposals — virtualization works by construction. The old
+  `background + clipShape` pair became two `background(_, in:)` shape fills (top-rounded header,
+  bottom-rounded content) so the tint still hugs content; `.scrollBounceBehavior(.basedOnSize)`
+  keeps short columns from rubber-banding.
+
+**Accepted UX changes** (user approved "both parts now"): columns scroll vertically independently;
+column headers and the settings row are always visible; the object title header is static (never
+collapses on scroll, since there is no whole-board vertical offset anymore).
+
+**Still to do**: build in Xcode, verify on a real device, and capture a fresh trace comparing
+"waiting on GPU and VSync" / "in render server" hitch counts per step #5 above. Known cosmetic
+nit: an empty column with no create button has square bottom corners on the header tint (4pt
+radius, barely visible).
+
+### Follow-up: nested-scroll gesture arbitration (the "deceleration catch")
+
+Device testing of the restructure surfaced the expected side effect of nesting scroll views:
+**horizontal board swipes were swallowed while a column was still decelerating.** A `UIScrollView`
+that is decelerating grabs the next touch at a *zero* movement threshold (that's how you catch and
+re-flick moving content), and once its pan owns the touch, direction no longer matters — the
+column consumes a horizontal drag it cannot act on and the board never sees it. At rest, UIKit's
+own arbitration already routes cross-axis drags to the parent correctly, which is why this only
+misbehaves mid-settle. There is no SwiftUI API for this.
+
+**Fix**: `Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/ScrollAxisLock.swift` —
+a `.scrollAxisLock(_ axis:)` modifier, applied to the scroll view's *content* (not the ScrollView
+itself, or the superview walk finds the wrong scroll view). It walks up to the enclosing
+`UIScrollView`, attaches a `CrossAxisDragGate` (a bare `UIGestureRecognizer` that recognizes on
+cross-axis-dominant movement and fails on along-axis-dominant movement, 6pt threshold), and calls
+`scrollView.panGestureRecognizer.require(toFail: gate)`. Net effect: the pan can't begin until the
+drag reveals a direction, and only begins for drags along its own axis — the zero-threshold catch
+is gone in the cross-axis direction while the normal one survives.
+
+Applied symmetrically: `.scrollAxisLock(.vertical)` on the column content, `.scrollAxisLock(.horizontal)`
+on the board's `LazyHStack`, giving strict axis arbitration in both directions (a vertical drag
+while the *board* is decelerating reaches the column too — the mirror bug).
+
+Details that matter if you touch this:
+- The gate overrides `canPrevent`/`canBePrevented` to `false`, so it only ever gates the pan it is
+  wired to and never blocks the other scroll view's pan (default UIKit behavior would).
+- `canScrollAlongAxis` makes it self-disabling: a scroll view with no overflow along its axis (or
+  one we attached to by mistake) gets no gating at all.
+- `cancelsTouchesInView = false`, so card taps and `.onDrag` drag-and-drop are unaffected.
+- No extra dead zone for normal scrolling: the gate resolves at 6pt, below `UIPanGestureRecognizer`'s
+  own ~10pt begin threshold. The 6pt threshold is the knob to tune if the feel is off.
+
+## Key files
+
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift`
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift`
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Collection/Cell/SetGalleryViewCell.swift`
+- `Modules/DesignKit/Sources/DesignKit/SystemExtensions/View+ReadSize.swift`
+- `Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/OffsetAwareScrollView.swift`
+- Trace file: `/Users/roma/Documents/ios-kanban-scroll.trace`


### PR DESCRIPTION
## Summary
- Fix the write paths of the dormant 2022 Kanban board and enable it by default (`setKanbanView` + `dndOnCollectionsAndSets`): cross-column drag is now a format-aware read-modify-write (a multi-tag card keeps its other tags; status writes `[id]`/unset), card-order persistence is gated on fully loaded columns so partial pages can never truncate the backend `ObjectOrder`, and all board mutations (move/reorder/column settings/per-column create) are permission-gated fail-closed, with failed or cancelled drags reverting the optimistic move.
- Fix the board's data plumbing: per-column subscription ids are namespaced per screen (bare backend group ids collided across screens), stale column subscriptions are cancelled and ghost columns cleaned up, column headers follow live option renames/recolors via a dedicated options subscription (they previously resolved from a storage that never contains options) and show backend totals, and the board gets loading/error states while an all-empty board keeps its columns instead of collapsing into the generic empty screen.
- Add per-column "+ New" prefilled with the column's group value (double-tap safe), and 36 unit tests over the extracted pure logic (card-move RMW matrix, reorder gating, header mapping, create prefill). Card drag is kanban-only; grid/gallery/list behavior is unchanged.