### PR TITLE
IOS-6580 Chat: lossless update notifications (AsyncUpdateStream)

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
@@ -17,7 +17,7 @@ protocol ChatMessagesStorageProtocol: AnyObject, Sendable {
     func message(id: String) async -> ChatMessage?
     func updateVisibleRange(startMessageId: String, endMessageId: String) async
     func markAsReadAll() async throws -> ChatMessage
-    var updateStream: AnyAsyncSequence<[ChatUpdate]> { get }
+    var updateStream: AnyAsyncSequence<Set<ChatUpdate>> { get }
     var fullMessages: [FullChatMessage]? { get async }
     var chatState: ChatState? { get async }
 }
@@ -69,14 +69,17 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
     private(set) var fullMessages: [FullChatMessage]?
     private(set) var chatState: ChatState?
     
-    private let syncStream = AsyncToManyStream<[ChatUpdate]>()
+    // Delta updates must never be dropped: a lost .messages tick leaves the chat
+    // stale until reopen. AsyncUpdateStream unions pending updates for busy
+    // subscribers and seeds new subscribers with a full refresh.
+    private let syncStream = AsyncUpdateStream<ChatUpdate>(seed: Set(ChatUpdate.allCases))
     
     init(spaceId: String, chatObjectId: String) {
         self.spaceId = spaceId
         self.chatObjectId = chatObjectId
     }
     
-    nonisolated var updateStream: AnyAsyncSequence<[ChatUpdate]> {
+    nonisolated var updateStream: AnyAsyncSequence<Set<ChatUpdate>> {
         syncStream.eraseToAnyAsyncSequence()
     }
     
@@ -128,7 +131,7 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
             updateFullMessages()
         }
         
-        syncStream.send(ChatUpdate.allCases)
+        syncStream.send(Set(ChatUpdate.allCases))
         subscriptionStarted = true
     }
     
@@ -308,7 +311,7 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
             updateFullMessages(notify: false)
         }
         if subscriptionStarted {
-            syncStream.send(Array(updates))
+            syncStream.send(updates)
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
@@ -17,7 +17,7 @@ protocol DiscussionMessagesStorageProtocol: AnyObject, Sendable {
     func message(id: String) async -> ChatMessage?
     func updateVisibleRange(startMessageId: String, endMessageId: String) async
     func markAsReadAll() async throws -> ChatMessage
-    var updateStream: AnyAsyncSequence<[ChatUpdate]> { get }
+    var updateStream: AnyAsyncSequence<Set<ChatUpdate>> { get }
     var fullMessages: [FullChatMessage]? { get async }
     var chatState: ChatState? { get async }
     var messageCount: Int? { get async }
@@ -65,14 +65,17 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
     private(set) var chatState: ChatState?
     private(set) var messageCount: Int?
 
-    private let syncStream = AsyncToManyStream<[ChatUpdate]>()
+    // Delta updates must never be dropped: a lost .messages tick leaves the chat
+    // stale until reopen. AsyncUpdateStream unions pending updates for busy
+    // subscribers and seeds new subscribers with a full refresh.
+    private let syncStream = AsyncUpdateStream<ChatUpdate>(seed: Set(ChatUpdate.allCases))
 
     init(spaceId: String, chatObjectId: String) {
         self.spaceId = spaceId
         self.chatObjectId = chatObjectId
     }
 
-    nonisolated var updateStream: AnyAsyncSequence<[ChatUpdate]> {
+    nonisolated var updateStream: AnyAsyncSequence<Set<ChatUpdate>> {
         syncStream.eraseToAnyAsyncSequence()
     }
 
@@ -125,7 +128,7 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
             updateFullMessages()
         }
 
-        syncStream.send(ChatUpdate.allCases)
+        syncStream.send(Set(ChatUpdate.allCases))
         subscriptionStarted = true
     }
 
@@ -317,7 +320,7 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
             updateFullMessages(notify: false)
         }
         if subscriptionStarted {
-            syncStream.send(Array(updates))
+            syncStream.send(updates)
         }
     }
 

--- a/Modules/AsyncTools/Sources/AsyncTools/AsyncUpdateStream.swift
+++ b/Modules/AsyncTools/Sources/AsyncTools/AsyncUpdateStream.swift
@@ -1,0 +1,123 @@
+import Foundation
+import os
+
+/// A multi-subscriber stream of update sets that never loses updates.
+///
+/// Unlike an `AsyncStream` with `bufferingNewest(1)`, values sent while a subscriber
+/// is busy are not dropped — they are merged (set union) into the subscriber's pending
+/// set and delivered on its next iteration. This makes it safe to send *deltas*
+/// ("messages changed", "state changed"): a slow consumer receives the union of
+/// everything it missed instead of only the newest value.
+///
+/// Every new subscriber starts with `seed` as its pending set, so a late subscriber
+/// always performs a full refresh instead of waiting for the next send.
+///
+/// Empty sends are no-ops. Each iterator is single-consumer.
+public final class AsyncUpdateStream<T: Hashable & Sendable>: AsyncSequence, @unchecked Sendable {
+
+    public typealias Element = Set<T>
+
+    private struct Subscriber {
+        var pending: Set<T>
+        var continuation: CheckedContinuation<Set<T>?, Never>?
+    }
+
+    private let lock = OSAllocatedUnfairLock()
+    private var subscribers: [UUID: Subscriber] = [:]
+    private let seed: Set<T>
+
+    public init(seed: Set<T> = []) {
+        self.seed = seed
+    }
+
+    public func send(_ updates: Set<T>) {
+        guard !updates.isEmpty else { return }
+
+        lock.lock()
+        var resumes = [(CheckedContinuation<Set<T>?, Never>, Set<T>)]()
+        for id in subscribers.keys {
+            subscribers[id]?.pending.formUnion(updates)
+            if let continuation = subscribers[id]?.continuation, let pending = subscribers[id]?.pending {
+                subscribers[id]?.pending = []
+                subscribers[id]?.continuation = nil
+                resumes.append((continuation, pending))
+            }
+        }
+        lock.unlock()
+
+        for (continuation, pending) in resumes {
+            continuation.resume(returning: pending)
+        }
+    }
+
+    public func makeAsyncIterator() -> Iterator {
+        let id = UUID()
+        lock.lock()
+        subscribers[id] = Subscriber(pending: seed, continuation: nil)
+        lock.unlock()
+        return Iterator(stream: self, id: id)
+    }
+
+    public final class Iterator: AsyncIteratorProtocol {
+
+        private let stream: AsyncUpdateStream<T>
+        private let id: UUID
+
+        fileprivate init(stream: AsyncUpdateStream<T>, id: UUID) {
+            self.stream = stream
+            self.id = id
+        }
+
+        deinit {
+            stream.remove(id: id)
+        }
+
+        public func next() async -> Set<T>? {
+            let stream = stream
+            let id = id
+            return await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    stream.suspend(id: id, continuation: continuation)
+                }
+            } onCancel: {
+                stream.remove(id: id)
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func suspend(id: UUID, continuation: CheckedContinuation<Set<T>?, Never>) {
+        lock.lock()
+
+        guard var subscriber = subscribers[id] else {
+            lock.unlock()
+            continuation.resume(returning: nil)
+            return
+        }
+
+        if !subscriber.pending.isEmpty {
+            let pending = subscriber.pending
+            subscriber.pending = []
+            subscribers[id] = subscriber
+            lock.unlock()
+            continuation.resume(returning: pending)
+        } else if subscriber.continuation != nil {
+            // Concurrent next() calls on one iterator are not supported
+            lock.unlock()
+            continuation.resume(returning: nil)
+        } else {
+            subscriber.continuation = continuation
+            subscribers[id] = subscriber
+            lock.unlock()
+        }
+    }
+
+    private func remove(id: UUID) {
+        lock.lock()
+        let continuation = subscribers[id]?.continuation
+        subscribers.removeValue(forKey: id)
+        lock.unlock()
+        continuation?.resume(returning: nil)
+    }
+}

--- a/Modules/AsyncTools/Tests/AsyncToolsTests/AsyncUpdateStreamTests.swift
+++ b/Modules/AsyncTools/Tests/AsyncToolsTests/AsyncUpdateStreamTests.swift
@@ -1,0 +1,123 @@
+import Testing
+@testable import AsyncTools
+
+private enum Update: Hashable, CaseIterable, Sendable {
+    case messages
+    case state
+    case messageCount
+}
+
+struct AsyncUpdateStreamTests {
+
+    @Test func seedIsDeliveredToNewSubscriber() async {
+        let stream = AsyncUpdateStream<Update>(seed: Set(Update.allCases))
+        let iterator = stream.makeAsyncIterator()
+
+        let first = await iterator.next()
+
+        #expect(first == Set(Update.allCases))
+    }
+
+    @Test func emptySendIsNoOp() async {
+        let stream = AsyncUpdateStream<Update>()
+        let iterator = stream.makeAsyncIterator()
+
+        stream.send([])
+        stream.send([.messages])
+
+        let first = await iterator.next()
+        #expect(first == [.messages])
+    }
+
+    @Test func pendingUpdatesAreUnioned() async {
+        let stream = AsyncUpdateStream<Update>()
+        let iterator = stream.makeAsyncIterator()
+
+        // Sent while the subscriber is not awaiting — must merge, not overwrite
+        stream.send([.messages])
+        stream.send([.state])
+        stream.send([])
+
+        let first = await iterator.next()
+        #expect(first == [.messages, .state])
+    }
+
+    @Test func sendResumesAwaitingSubscriber() async {
+        let stream = AsyncUpdateStream<Update>()
+        let iterator = stream.makeAsyncIterator()
+
+        async let value = iterator.next()
+        // Give next() a chance to suspend before sending
+        await Task.yield()
+        stream.send([.state])
+
+        let received = await value
+        #expect(received == [.state])
+    }
+
+    @Test func subscribersAreIndependent() async {
+        let stream = AsyncUpdateStream<Update>()
+        let fast = stream.makeAsyncIterator()
+        let slow = stream.makeAsyncIterator()
+
+        stream.send([.messages])
+        let fastFirst = await fast.next()
+        #expect(fastFirst == [.messages])
+
+        stream.send([.state])
+        let fastSecond = await fast.next()
+        #expect(fastSecond == [.state])
+
+        // The slow subscriber gets the union of both sends
+        let slowFirst = await slow.next()
+        #expect(slowFirst == [.messages, .state])
+    }
+
+    @Test func pendingIsClearedAfterDelivery() async {
+        let stream = AsyncUpdateStream<Update>(seed: [.messages])
+        let iterator = stream.makeAsyncIterator()
+
+        _ = await iterator.next()
+        stream.send([.state])
+
+        let second = await iterator.next()
+        #expect(second == [.state])
+    }
+
+    @Test func cancellationFinishesIteration() async {
+        let stream = AsyncUpdateStream<Update>()
+
+        let task = Task {
+            var received = [Set<Update>]()
+            for await updates in stream {
+                received.append(updates)
+            }
+            return received
+        }
+
+        await Task.yield()
+        task.cancel()
+
+        let received = await task.value
+        #expect(received.isEmpty)
+    }
+
+    @Test func noUpdatesLostUnderConcurrentSends() async {
+        let stream = AsyncUpdateStream<Int>()
+        let iterator = stream.makeAsyncIterator()
+
+        await withTaskGroup(of: Void.self) { group in
+            for value in 0..<100 {
+                group.addTask {
+                    stream.send([value])
+                }
+            }
+        }
+
+        var received = Set<Int>()
+        while received.count < 100, let updates = await iterator.next() {
+            received.formUnion(updates)
+        }
+        #expect(received == Set(0..<100))
+    }
+}


### PR DESCRIPTION
## Summary
- New `AsyncUpdateStream` primitive in AsyncTools: unions pending update sets per subscriber instead of dropping them (`bufferingNewest(1)` lost intermediate `[.messages]` deltas while the ViewModel was busy → incoming messages not rendered until chat reopen), seeds new subscribers with a full refresh, treats empty sends as no-ops.
- `ChatMessagesStorage` / `DiscussionMessagesStorage` switched from `AsyncToManyStream<[ChatUpdate]>` to `AsyncUpdateStream<ChatUpdate>`; ViewModels unchanged.
- 9 unit tests covering union-while-busy, seed delivery, subscriber independence, cancellation and concurrent-send loss.

Linear: IOS-6580