### PR TITLE
IOS-6582 Chat: register event listeners before subscribe RPC, don't regress state from response

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
@@ -103,22 +103,28 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
             return
         }
 
+        // Register the bus subscription before the RPC so events emitted right after
+        // the middleware-side subscription goes live land in the stream buffer
+        // instead of being lost while the Task is still starting.
+        let eventStream = await EventBunchSubscribtion.default.stream()
         subscription = Task { [weak self] in
-            for await events in await EventBunchSubscribtion.default.stream() {
+            for await events in eventStream {
                 if events.contextId == self?.chatObjectId {
                     await self?.handle(events: events)
                 }
             }
         }
-        
+
         let response = try await chatService.subscribeLastMessages(chatObjectId: chatObjectId, subId: subId, limit: Constants.pageSize)
 
-        // Setup chat state as first
-        chatState = response.chatState
-        
+        // Events processed while awaiting the response may already hold a newer state — don't regress it
+        if (chatState?.order ?? -1) < response.chatState.order {
+            chatState = response.chatState
+        }
+
         lastMessages.add(response.messages)
-        
-        let unreadOrderId = response.chatState.messages.oldestOrderID
+
+        let unreadOrderId = (chatState ?? response.chatState).messages.oldestOrderID
         if unreadOrderId.isNotEmpty {
             // Load messages for unred bounce
             _ = try? await loadPagesTo(orderId: unreadOrderId)

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/DiscussionMessageCountObserver.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/DiscussionMessageCountObserver.swift
@@ -49,7 +49,10 @@ actor DiscussionMessageCountObserver: DiscussionMessageCountObserverProtocol {
         do {
             // limit must be > 0; the middleware treats 0 as "no limit" and returns every message.
             let response = try await chatService.subscribeLastMessages(chatObjectId: chatId, subId: subId, limit: 1)
-            emit(count: Int(response.messageCount), for: chatId)
+            // An event processed while awaiting the response may already hold a newer count — don't regress it
+            if lastEmittedCount == nil {
+                emit(count: Int(response.messageCount), for: chatId)
+            }
         } catch {
             // Clear state so a subsequent startObserving(sameChatId) actually retries
             // instead of being short-circuited by the `current?.chatId == chatId` guard.

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
@@ -102,8 +102,12 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
             return
         }
 
+        // Register the bus subscription before the RPC so events emitted right after
+        // the middleware-side subscription goes live land in the stream buffer
+        // instead of being lost while the Task is still starting.
+        let eventStream = await EventBunchSubscribtion.default.stream()
         subscription = Task { [weak self] in
-            for await events in await EventBunchSubscribtion.default.stream() {
+            for await events in eventStream {
                 if events.contextId == self?.chatObjectId {
                     await self?.handle(events: events)
                 }
@@ -112,12 +116,17 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
 
         let response = try await chatService.subscribeLastMessages(chatObjectId: chatObjectId, subId: subId, limit: Constants.pageSize)
 
-        chatState = response.chatState
-        messageCount = Int(response.messageCount)
+        // Events processed while awaiting the response may already hold newer values — don't regress them
+        if (chatState?.order ?? -1) < response.chatState.order {
+            chatState = response.chatState
+        }
+        if messageCount == nil {
+            messageCount = Int(response.messageCount)
+        }
 
         lastMessages.add(response.messages)
 
-        let unreadOrderId = response.chatState.messages.oldestOrderID
+        let unreadOrderId = (chatState ?? response.chatState).messages.oldestOrderID
         if unreadOrderId.isNotEmpty {
             _ = try? await loadPagesTo(orderId: unreadOrderId)
         } else {


### PR DESCRIPTION
## Summary
- Register the `EventBunchSubscribtion` stream before the `subscribeLastMessages` RPC in `ChatMessagesStorage` / `DiscussionMessagesStorage` — previously the listener was registered inside an unstructured Task racing the RPC, so events pushed right after the middleware-side subscription went live could be lost (then the chatAdd boundary check freezes the chat, IOS-6581).
- Guard state assignment after the RPC await: a newer `chatStateUpdate` / message-count event processed during the await is no longer overwritten by the older response value (chat state order guard, `messageCount`/`lastEmittedCount` nil checks); the unread bounce now uses the freshest state.
- Same nil-check fix in `DiscussionMessageCountObserver`, which already had the register-before-RPC pattern.

Linear: IOS-6582