### PR TITLE
IOS-6581 IOS-6586 Chat: heal message gaps, harden attachment loading

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessageAttachmentsStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessageAttachmentsStorage.swift
@@ -14,15 +14,12 @@ struct ChatMessageAttachmentsStorage: Sendable {
     
     @discardableResult
     mutating func update(details: [ObjectDetails]) -> Bool {
-        let newAttachments = details
-            .reduce(into: [String: ObjectDetails]()) { $0[$1.id] = $1 }
-        
-        if attachmentsDetails != newAttachments {
-            attachmentsDetails.merge(newAttachments, uniquingKeysWith: { $1 })
-            return true
-        } else {
-            return false
+        var updated = false
+        for detail in details where attachmentsDetails[detail.id] != detail {
+            attachmentsDetails[detail.id] = detail
+            updated = true
         }
+        return updated
     }
     
     mutating func remove(ids: [String]) {

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
@@ -254,7 +254,7 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
     private func handle(events: EventsBunch) async {
         var updates: Set<ChatUpdate> = []
 
-        var updateRepliesAndAttachments = true
+        var updateRepliesAndAttachments = false
         var needsTailGapRefill = false
 
         for event in events.middlewareEvents {
@@ -279,6 +279,8 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
                 guard data.subIds.contains(subId) else { break }
                 if messages.chatDelete(data) {
                     updates.insert(.messages)
+                    // Trigger attachments cleanup for the removed message
+                    updateRepliesAndAttachments = true
                 }
                 lastMessages.chatDelete(data)
             case let .chatUpdate(data):
@@ -422,9 +424,14 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
     }
     
     private func updateAttachmentSubscription() async {
-        guard let subscriptionStartMessageId, let subscriptionEndMessageId,
-              let startMessageIndex = messages.index(messageId: subscriptionStartMessageId),
-              let endMessageIndex = messages.index(messageId: subscriptionEndMessageId)  else { return }
+        // Before the first visible-range callback there are no anchors yet — cover the
+        // whole window so attachment details that appear later (e.g. incoming files
+        // still syncing) still reach the UI.
+        let startAnchorId = subscriptionStartMessageId ?? messages.first?.id
+        let endAnchorId = subscriptionEndMessageId ?? messages.last?.id
+        guard let startAnchorId, let endAnchorId,
+              let startMessageIndex = messages.index(messageId: startAnchorId),
+              let endMessageIndex = messages.index(messageId: endAnchorId) else { return }
         
         let startIndex = startMessageIndex - Constants.subsctiptionMessageOverLimitForAttachments
         let endIndex = endMessageIndex + Constants.subsctiptionMessageOverLimitForAttachments

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
@@ -168,7 +168,13 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
         let loadedMessagesBefore = try await chatService.getMessages(chatObjectId: chatObjectId, beforeOrderId: replyMessage.orderID, limit: Constants.pageSize)
         let loadedMessagesAfter = try await chatService.getMessages(chatObjectId: chatObjectId, afterOrderId: replyMessage.orderID, limit: Constants.pageSize)
         
-        let allLoadedMessages = loadedMessagesBefore + [replyMessage] + loadedMessagesAfter
+        var allLoadedMessages = loadedMessagesBefore + [replyMessage] + loadedMessagesAfter
+        // Keep messages that events added during the fetches: when the fetch reached
+        // the current tail, anything newer than the fetched window is contiguous with it.
+        if loadedMessagesAfter.count < Constants.pageSize {
+            let fetchedMaxOrderId = allLoadedMessages.map(\.orderID).max() ?? ""
+            allLoadedMessages += messages.messages.filter { $0.orderID > fetchedMaxOrderId }
+        }
         messages.removeAll()
         
         await addNewMessages(messages: allLoadedMessages)
@@ -189,7 +195,13 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
             throw CommonError.undefined
         }
         
-        let allLoadedMessages = loadedMessagesBefore + loadedMessagesAfter
+        var allLoadedMessages = loadedMessagesBefore + loadedMessagesAfter
+        // Keep messages that events added during the fetches: when the fetch reached
+        // the current tail, anything newer than the fetched window is contiguous with it.
+        if loadedMessagesAfter.count < Constants.pageSize {
+            let fetchedMaxOrderId = allLoadedMessages.map(\.orderID).max() ?? ""
+            allLoadedMessages += messages.messages.filter { $0.orderID > fetchedMaxOrderId }
+        }
         messages.removeAll()
         
         await addNewMessages(messages: allLoadedMessages)
@@ -241,18 +253,28 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
     
     private func handle(events: EventsBunch) async {
         var updates: Set<ChatUpdate> = []
-        
+
         var updateRepliesAndAttachments = true
-        
+        var needsTailGapRefill = false
+
         for event in events.middlewareEvents {
             switch event.value {
             case let .chatAdd(data):
                 guard data.subIds.contains(subId) else { break }
+                let windowWasAtTail = messages.last?.id == lastMessages.last?.id
                 if messages.chatAdd(data) {
                     updates.insert(.messages)
                     updateRepliesAndAttachments = true
+                } else if windowWasAtTail, let last = messages.last, data.afterOrderID > last.orderID {
+                    // The new message references a predecessor we never received — an event
+                    // was missed. Refetch the tail instead of freezing the window: otherwise
+                    // every subsequent chatAdd fails the boundary check too.
+                    needsTailGapRefill = true
                 }
-                lastMessages.chatAdd(data)
+                if !lastMessages.chatAdd(data), let last = lastMessages.last, data.message.orderID > last.orderID {
+                    // lastMessages must always track the real tail, even across gaps
+                    lastMessages.add(data.message)
+                }
             case let .chatDelete(data):
                 guard data.subIds.contains(subId) else { break }
                 if messages.chatDelete(data) {
@@ -297,7 +319,13 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
         }
         
         lastMessages.cleanFirst(maxCache: Constants.lastMessagesMaxCacheSize)
-        
+
+        if needsTailGapRefill {
+            await refillTailGap()
+            updates.insert(.messages)
+            updateRepliesAndAttachments = true
+        }
+
         if updateRepliesAndAttachments {
             await loadReplies()
             await loadAttachments()
@@ -314,10 +342,18 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
     
     private func addNewMessages(messages newMessages: [ChatMessage]) async {
         messages.add(newMessages)
-        
+
         await loadReplies()
         await loadAttachments()
         await updateAttachmentSubscription()
+    }
+
+    private func refillTailGap() async {
+        guard let last = messages.last else { return }
+        guard let newMessages = try? await chatService.getMessages(chatObjectId: chatObjectId, afterOrderId: last.orderID, limit: Constants.pageSize),
+              newMessages.isNotEmpty else { return }
+        messages.add(newMessages)
+        messages.cleanFirst(maxCache: Constants.maxCacheSize)
     }
     
     private func loadAttachments() async {

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
@@ -165,7 +165,13 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
         let loadedMessagesBefore = try await chatService.getMessages(chatObjectId: chatObjectId, beforeOrderId: replyMessage.orderID, limit: Constants.pageSize)
         let loadedMessagesAfter = try await chatService.getMessages(chatObjectId: chatObjectId, afterOrderId: replyMessage.orderID, limit: Constants.pageSize)
 
-        let allLoadedMessages = loadedMessagesBefore + [replyMessage] + loadedMessagesAfter
+        var allLoadedMessages = loadedMessagesBefore + [replyMessage] + loadedMessagesAfter
+        // Keep messages that events added during the fetches: when the fetch reached
+        // the current tail, anything newer than the fetched window is contiguous with it.
+        if loadedMessagesAfter.count < Constants.pageSize {
+            let fetchedMaxOrderId = allLoadedMessages.map(\.orderID).max() ?? ""
+            allLoadedMessages += messages.messages.filter { $0.orderID > fetchedMaxOrderId }
+        }
         messages.removeAll()
 
         await addNewMessages(messages: allLoadedMessages)
@@ -186,7 +192,13 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
             throw CommonError.undefined
         }
 
-        let allLoadedMessages = loadedMessagesBefore + loadedMessagesAfter
+        var allLoadedMessages = loadedMessagesBefore + loadedMessagesAfter
+        // Keep messages that events added during the fetches: when the fetch reached
+        // the current tail, anything newer than the fetched window is contiguous with it.
+        if loadedMessagesAfter.count < Constants.pageSize {
+            let fetchedMaxOrderId = allLoadedMessages.map(\.orderID).max() ?? ""
+            allLoadedMessages += messages.messages.filter { $0.orderID > fetchedMaxOrderId }
+        }
         messages.removeAll()
 
         await addNewMessages(messages: allLoadedMessages)
@@ -248,16 +260,26 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
         var updates: Set<ChatUpdate> = []
 
         var updateRepliesAndAttachments = true
+        var needsTailGapRefill = false
 
         for event in events.middlewareEvents {
             switch event.value {
             case let .chatAdd(data):
                 guard data.subIds.contains(subId) else { break }
+                let windowWasAtTail = messages.last?.id == lastMessages.last?.id
                 if messages.chatAdd(data) {
                     updates.insert(.messages)
                     updateRepliesAndAttachments = true
+                } else if windowWasAtTail, let last = messages.last, data.afterOrderID > last.orderID {
+                    // The new message references a predecessor we never received — an event
+                    // was missed. Refetch the tail instead of freezing the window: otherwise
+                    // every subsequent chatAdd fails the boundary check too.
+                    needsTailGapRefill = true
                 }
-                lastMessages.chatAdd(data)
+                if !lastMessages.chatAdd(data), let last = lastMessages.last, data.message.orderID > last.orderID {
+                    // lastMessages must always track the real tail, even across gaps
+                    lastMessages.add(data.message)
+                }
             case let .chatDelete(data):
                 guard data.subIds.contains(subId) else { break }
                 if messages.chatDelete(data) {
@@ -307,6 +329,12 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
 
         lastMessages.cleanFirst(maxCache: Constants.lastMessagesMaxCacheSize)
 
+        if needsTailGapRefill {
+            await refillTailGap()
+            updates.insert(.messages)
+            updateRepliesAndAttachments = true
+        }
+
         if updateRepliesAndAttachments {
             await loadReplies()
             await loadAttachments()
@@ -327,6 +355,14 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
         await loadReplies()
         await loadAttachments()
         await updateAttachmentSubscription()
+    }
+
+    private func refillTailGap() async {
+        guard let last = messages.last else { return }
+        guard let newMessages = try? await chatService.getMessages(chatObjectId: chatObjectId, afterOrderId: last.orderID, limit: Constants.pageSize),
+              newMessages.isNotEmpty else { return }
+        messages.add(newMessages)
+        messages.cleanFirst(maxCache: Constants.maxCacheSize)
     }
 
     private func loadAttachments() async {

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
@@ -259,7 +259,7 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
     private func handle(events: EventsBunch) async {
         var updates: Set<ChatUpdate> = []
 
-        var updateRepliesAndAttachments = true
+        var updateRepliesAndAttachments = false
         var needsTailGapRefill = false
 
         for event in events.middlewareEvents {
@@ -284,6 +284,8 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
                 guard data.subIds.contains(subId) else { break }
                 if messages.chatDelete(data) {
                     updates.insert(.messages)
+                    // Trigger attachments cleanup for the removed message
+                    updateRepliesAndAttachments = true
                 }
                 lastMessages.chatDelete(data)
             case let .chatUpdate(data):
@@ -430,9 +432,14 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
     }
 
     private func updateAttachmentSubscription() async {
-        guard let subscriptionStartMessageId, let subscriptionEndMessageId,
-              let startMessageIndex = messages.index(messageId: subscriptionStartMessageId),
-              let endMessageIndex = messages.index(messageId: subscriptionEndMessageId)  else { return }
+        // Before the first visible-range callback there are no anchors yet — cover the
+        // whole window so attachment details that appear later (e.g. incoming files
+        // still syncing) still reach the UI.
+        let startAnchorId = subscriptionStartMessageId ?? messages.first?.id
+        let endAnchorId = subscriptionEndMessageId ?? messages.last?.id
+        guard let startAnchorId, let endAnchorId,
+              let startMessageIndex = messages.index(messageId: startAnchorId),
+              let endMessageIndex = messages.index(messageId: endAnchorId) else { return }
 
         let startIndex = startMessageIndex - Constants.subsctiptionMessageOverLimitForAttachments
         let endIndex = endMessageIndex + Constants.subsctiptionMessageOverLimitForAttachments


### PR DESCRIPTION
## Summary
- IOS-6581 — `chatAdd` gap detection: when the window is at the tail and an incoming message references a predecessor we never received, refetch the tail instead of silently dropping — previously one missed event made every subsequent `chatAdd` fail the boundary check, freezing the chat until reopen. `lastMessages` now always tracks the real tail, and `loadPagesTo` no longer wipes messages that events added during its fetch awaits.
- IOS-6586 — `updateRepliesAndAttachments` was initialized `true`, so every event bunch (even irrelevant ones) triggered `loadReplies`/`loadAttachments`/`updateAttachmentSubscription` RPC round-trips; now starts `false` (with delete-triggered cleanup kept). Attachment subscription falls back to the whole window before the first visible-range callback, so incoming attachments still syncing self-heal. `ChatMessageAttachmentsStorage.update` now detects real changes instead of comparing the whole storage against the incoming subset.

Both issues touch the same `handle()` hunk, hence one PR (IOS-6586 as a separate commit).

Applied to both `ChatMessagesStorage` and `DiscussionMessagesStorage`.

Linear: IOS-6581, IOS-6586