### PR TITLE
IOS-6584 Chat: markAsRead with fresh lastStateID, coalesced and observable

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesStorage.swift
@@ -59,7 +59,9 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
     private var subscriptionStartMessageId: String?
     private var subscriptionEndMessageId: String?
     private var subscribedAttachmentIds = Set<String>()
-    
+    private var markAsReadRunning = false
+    private var pendingMarkAsReadRange: (start: String, end: String)?
+
     // MARK: - Message State
     private var attachments = ChatMessageAttachmentsStorage()
     private var messages = ChatInternalMessageStorage()
@@ -88,8 +90,8 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
         let currentStartMessageIndex = subscriptionStartMessageId.map { messages.index(messageId: $0) ?? notFoundValue } ?? notFoundValue
         let currentEndMessageIndex = subscriptionEndMessageId.map { messages.index(messageId: $0) ?? notFoundValue } ?? notFoundValue
         
-        try? await markAsRead(startMessageId: startMessageId, endMessageId: endMessageId)
-        
+        await markAsRead(startMessageId: startMessageId, endMessageId: endMessageId)
+
         guard abs(startMessageIndex - currentStartMessageIndex) > Constants.subscriptionMessageIntervalForAttachments
                 || abs(endMessageIndex - currentEndMessageIndex) > Constants.subscriptionMessageIntervalForAttachments else { return }
         
@@ -417,41 +419,67 @@ actor ChatMessagesStorage: ChatMessagesStorageProtocol {
         await mediaCacheHeatingService.updateVisibleMedia(attachmentDetails: details)
     }
     
-    private func markAsRead(startMessageId: String, endMessageId: String) async throws {
-        guard let chatState,
-              let afterOrderId = messages.message(id: startMessageId)?.orderID,
+    private func markAsRead(startMessageId: String, endMessageId: String) async {
+        // Coalesce: overlapping calls ack with the same captured lastStateID and race
+        // each other. Keep only the latest requested range, process one at a time.
+        pendingMarkAsReadRange = (startMessageId, endMessageId)
+        guard !markAsReadRunning else { return }
+        markAsReadRunning = true
+        defer { markAsReadRunning = false }
+        while let range = pendingMarkAsReadRange {
+            pendingMarkAsReadRange = nil
+            await performMarkAsRead(startMessageId: range.start, endMessageId: range.end)
+        }
+    }
+
+    private func performMarkAsRead(startMessageId: String, endMessageId: String) async {
+        guard let afterOrderId = messages.message(id: startMessageId)?.orderID,
               let beforeOrderId = messages.message(id: endMessageId)?.orderID
               else { return }
-        
-        if chatState.messages.oldestOrderID.isNotEmpty,
+
+        // Re-read chatState before every request: the middleware ignores acks carrying
+        // a stale lastStateID, which would leave the unread counter stuck.
+        if let chatState, chatState.messages.oldestOrderID.isNotEmpty,
             chatState.messages.oldestOrderID <= beforeOrderId {
-            try? await chatService.readMessages(
-                chatObjectId: chatObjectId,
-                afterOrderId: afterOrderId,
-                beforeOrderId: beforeOrderId,
-                type: .messages,
-                lastStateId: chatState.lastStateID
-            )
-        }
-        
-        if chatState.mentions.oldestOrderID.isNotEmpty,
-           chatState.mentions.oldestOrderID <= beforeOrderId {
-            try? await chatService.readMessages(
-                chatObjectId: chatObjectId,
-                afterOrderId: afterOrderId,
-                beforeOrderId: beforeOrderId,
-                type: .mentions,
-                lastStateId: chatState.lastStateID
-            )
+            do {
+                try await chatService.readMessages(
+                    chatObjectId: chatObjectId,
+                    afterOrderId: afterOrderId,
+                    beforeOrderId: beforeOrderId,
+                    type: .messages,
+                    lastStateId: chatState.lastStateID
+                )
+            } catch {
+                anytypeAssertionFailure("Chat mark-as-read failed (messages)", info: ["error": error.localizedDescription])
+            }
         }
 
-        if chatState.unreadReactionOrderID.isNotEmpty,
+        if let chatState, chatState.mentions.oldestOrderID.isNotEmpty,
+           chatState.mentions.oldestOrderID <= beforeOrderId {
+            do {
+                try await chatService.readMessages(
+                    chatObjectId: chatObjectId,
+                    afterOrderId: afterOrderId,
+                    beforeOrderId: beforeOrderId,
+                    type: .mentions,
+                    lastStateId: chatState.lastStateID
+                )
+            } catch {
+                anytypeAssertionFailure("Chat mark-as-read failed (mentions)", info: ["error": error.localizedDescription])
+            }
+        }
+
+        if let chatState, chatState.unreadReactionOrderID.isNotEmpty,
            chatState.unreadReactionOrderID >= afterOrderId,
            chatState.unreadReactionOrderID <= beforeOrderId {
-            try? await chatService.readReactions(
-                chatObjectId: chatObjectId,
-                orderId: chatState.unreadReactionOrderID
-            )
+            do {
+                try await chatService.readReactions(
+                    chatObjectId: chatObjectId,
+                    orderId: chatState.unreadReactionOrderID
+                )
+            } catch {
+                anytypeAssertionFailure("Chat mark-as-read failed (reactions)", info: ["error": error.localizedDescription])
+            }
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
@@ -458,7 +458,7 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
                     lastStateId: chatState.lastStateID
                 )
             } catch {
-                anytypeAssertionFailure("Discussion mark-as-read failed (messages): \(error)")
+                anytypeAssertionFailure("Discussion mark-as-read failed (messages)", info: ["error": error.localizedDescription])
             }
         }
 
@@ -473,7 +473,7 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
                     lastStateId: chatState.lastStateID
                 )
             } catch {
-                anytypeAssertionFailure("Discussion mark-as-read failed (mentions): \(error)")
+                anytypeAssertionFailure("Discussion mark-as-read failed (mentions)", info: ["error": error.localizedDescription])
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/Services/DiscussionMessagesStorage.swift
@@ -55,6 +55,8 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
     private var subscriptionStartMessageId: String?
     private var subscriptionEndMessageId: String?
     private var subscribedAttachmentIds = Set<String>()
+    private var markAsReadRunning = false
+    private var pendingMarkAsReadRange: (start: String, end: String)?
 
     // MARK: - Message State
     private var attachments = ChatMessageAttachmentsStorage()
@@ -87,7 +89,7 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
         let currentStartMessageIndex = subscriptionStartMessageId.map { messages.index(messageId: $0) ?? notFoundValue } ?? notFoundValue
         let currentEndMessageIndex = subscriptionEndMessageId.map { messages.index(messageId: $0) ?? notFoundValue } ?? notFoundValue
 
-        try? await markAsRead(startMessageId: startMessageId, endMessageId: endMessageId)
+        await markAsRead(startMessageId: startMessageId, endMessageId: endMessageId)
 
         guard abs(startMessageIndex - currentStartMessageIndex) > Constants.subscriptionMessageIntervalForAttachments
                 || abs(endMessageIndex - currentEndMessageIndex) > Constants.subscriptionMessageIntervalForAttachments else { return }
@@ -425,13 +427,27 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
         await mediaCacheHeatingService.updateVisibleMedia(attachmentDetails: details)
     }
 
-    private func markAsRead(startMessageId: String, endMessageId: String) async throws {
-        guard let chatState,
-              let afterOrderId = messages.message(id: startMessageId)?.orderID,
+    private func markAsRead(startMessageId: String, endMessageId: String) async {
+        // Coalesce: overlapping calls ack with the same captured lastStateID and race
+        // each other. Keep only the latest requested range, process one at a time.
+        pendingMarkAsReadRange = (startMessageId, endMessageId)
+        guard !markAsReadRunning else { return }
+        markAsReadRunning = true
+        defer { markAsReadRunning = false }
+        while let range = pendingMarkAsReadRange {
+            pendingMarkAsReadRange = nil
+            await performMarkAsRead(startMessageId: range.start, endMessageId: range.end)
+        }
+    }
+
+    private func performMarkAsRead(startMessageId: String, endMessageId: String) async {
+        guard let afterOrderId = messages.message(id: startMessageId)?.orderID,
               let beforeOrderId = messages.message(id: endMessageId)?.orderID
               else { return }
 
-        if chatState.messages.oldestOrderID.isNotEmpty,
+        // Re-read chatState before every request: the middleware ignores acks carrying
+        // a stale lastStateID, which would leave the unread counter stuck.
+        if let chatState, chatState.messages.oldestOrderID.isNotEmpty,
             chatState.messages.oldestOrderID <= beforeOrderId {
             do {
                 try await chatService.readMessages(
@@ -446,7 +462,7 @@ actor DiscussionMessagesStorage: DiscussionMessagesStorageProtocol {
             }
         }
 
-        if chatState.mentions.oldestOrderID.isNotEmpty,
+        if let chatState, chatState.mentions.oldestOrderID.isNotEmpty,
            chatState.mentions.oldestOrderID <= beforeOrderId {
             do {
                 try await chatService.readMessages(


### PR DESCRIPTION
## Summary
- `markAsRead` now coalesces overlapping calls (scrolling fires it on every visible-range change) — only the latest requested range is processed, one at a time, instead of concurrent RPCs racing with the same captured `lastStateID`.
- `chatState` is re-read before every read ack — the middleware ignores acks with a stale `lastStateID`, which previously left the unread badge stuck until reopen when the state advanced mid-call.
- Failures are reported via `anytypeAssertionFailure` instead of being swallowed by `try?` (matching the Discussion variant).

Applied to both `ChatMessagesStorage` and `DiscussionMessagesStorage`.

Linear: IOS-6584