### PR TITLE
IOS-6585 Chat: surface upload/send failures, unstick send button

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatAttachmentHandler.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatAttachmentHandler.swift
@@ -125,6 +125,9 @@ final class ChatAttachmentHandler: ChatAttachmentHandlerProtocol {
     
     func setLinkedObjects(_ objects: [ChatLinkedObject]) {
         state.setLinkedObjects(objects)
+        // Keep photos items in sync — otherwise a removed/converted photo would be re-added on the next picker update
+        let localPhotosHashes = Set(objects.compactMap { $0.localPhotosFile?.photosPickerItemHash })
+        state.removePhotosItems { !localPhotosHashes.contains($0.hashValue) }
     }
 
     func getPhotosItems() -> [PhotosPickerItem] {

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatInputPanel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatInputPanel.swift
@@ -78,8 +78,8 @@ struct ChatInputPanel: View {
         .task(id: model.mentionSearchState) {
             try? await model.updateMentionState()
         }
-        .throwingTask(id: model.sendMessageTaskInProgress) {
-            try await model.sendMessageTask()
+        .task(id: model.sendMessageTaskInProgress) {
+            await model.sendMessageTask()
         }
         .onChange(of: model.message) {
             model.messageDidChanged()

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
@@ -303,7 +303,7 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
         sendMessageTaskInProgress = true
     }
     
-    func sendMessageTask() async throws {
+    func sendMessageTask() async {
         guard sendMessageTaskInProgress else { return }
         guard message.string.trimmingCharacters(in: .whitespacesAndNewlines).isNotEmpty || linkedObjects.isNotEmpty else {
             sendMessageTaskInProgress = false
@@ -314,40 +314,48 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
             try Task.checkCancellation()
             sendButtonIsLoading = true
         }
-        mentionSearchState = .finish
-        if let editMessage {
-            try await chatActionService.updateMessage(
-                chatId: chatId,
-                spaceId: spaceId,
-                messageId: editMessage.id,
-                message: message.sendable(),
-                linkedObjects: linkedObjects,
-                replyToMessageId: replyToMessage?.id,
-                useBlocksFormat: useBlocksFormat
-            )
-            clearInput()
-        } else if chatMessageLimits.canSendMessage() {
-            let messageId = try await chatActionService.createMessage(
-                chatId: chatId,
-                spaceId: spaceId,
-                message: message.sendable(),
-                linkedObjects: linkedObjects,
-                replyToMessageId: replyToMessage?.id,
-                useBlocksFormat: useBlocksFormat
-            )
-            let type: SentMessageType = linkedObjects.isNotEmpty ? (message.string.isNotEmpty ? .mixed : .attachment) : .text
-            AnytypeAnalytics.instance().logSentMessage(type: type, chatId: chatId)
-            collectionViewScrollProxy.scrollTo(itemId: messageId, position: .bottom, animated: true)
-            chatMessageLimits.markSentMessage()
-            clearInput()
-            await donateShareSuggestion()
-        } else {
-            keyboardDismiss?()
-            showSendLimitAlert = true
+        // Reset on every exit path — a thrown error must not leave the send button stuck
+        defer {
+            loadingTask.cancel()
+            sendButtonIsLoading = false
+            sendMessageTaskInProgress = false
         }
-        loadingTask.cancel()
-        sendButtonIsLoading = false
-        sendMessageTaskInProgress = false
+        mentionSearchState = .finish
+        do {
+            if let editMessage {
+                try await chatActionService.updateMessage(
+                    chatId: chatId,
+                    spaceId: spaceId,
+                    messageId: editMessage.id,
+                    message: message.sendable(),
+                    linkedObjects: linkedObjects,
+                    replyToMessageId: replyToMessage?.id,
+                    useBlocksFormat: useBlocksFormat
+                )
+                clearInput()
+            } else if chatMessageLimits.canSendMessage() {
+                let messageId = try await chatActionService.createMessage(
+                    chatId: chatId,
+                    spaceId: spaceId,
+                    message: message.sendable(),
+                    linkedObjects: linkedObjects,
+                    replyToMessageId: replyToMessage?.id,
+                    useBlocksFormat: useBlocksFormat
+                )
+                let type: SentMessageType = linkedObjects.isNotEmpty ? (message.string.isNotEmpty ? .mixed : .attachment) : .text
+                AnytypeAnalytics.instance().logSentMessage(type: type, chatId: chatId)
+                collectionViewScrollProxy.scrollTo(itemId: messageId, position: .bottom, animated: true)
+                chatMessageLimits.markSentMessage()
+                clearInput()
+                await donateShareSuggestion()
+            } else {
+                keyboardDismiss?()
+                showSendLimitAlert = true
+            }
+        } catch {
+            // Keep the input intact so the user can retry
+            toastBarData = ToastBarData(error.localizedDescription, type: .failure)
+        }
     }
     
     func onTapRemoveLinkedObject(linkedObject: ChatLinkedObject) {

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
@@ -354,6 +354,10 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
             }
         } catch {
             // Keep the input intact so the user can retry
+            if let sendError = error as? ChatActionSendError {
+                // Reuse already uploaded attachments on retry instead of re-uploading them
+                attachmentHandler.setLinkedObjects(sendError.updatedLinkedObjects)
+            }
             toastBarData = ToastBarData(error.localizedDescription, type: .failure)
         }
     }

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageAttachmentDetails.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Subviews/Message/MessageAttachmentDetails.swift
@@ -39,6 +39,29 @@ extension MessageAttachmentDetails {
         )
     }
     
+    init(fileDetails: FileDetails) {
+        let resolvedLayoutValue: DetailsLayout = switch fileDetails.fileContentType {
+        case .file: .file
+        case .image: .image
+        case .video: .video
+        case .audio: .audio
+        case .none: .basic
+        }
+        self = MessageAttachmentDetails(
+            id: fileDetails.id,
+            title: fileDetails.fileName,
+            description: "",
+            sizeInBytes: fileDetails.sizeInBytes,
+            resolvedLayoutValue: resolvedLayoutValue,
+            objectIconImage: .object(.file(mimeType: fileDetails.fileMimeType, name: fileDetails.name)),
+            source: nil,
+            syncStatus: nil,
+            syncError: nil,
+            downloadingState: false,
+            uploadTimeMs: nil
+        )
+    }
+
     static func placeholder(tagetId: String) -> Self {
         MessageAttachmentDetails(
             id: tagetId,

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionView.swift
@@ -210,8 +210,8 @@ struct DiscussionView: View {
         .task(id: model.mentionSearchState) {
             try? await model.updateMentionState()
         }
-        .throwingTask(id: model.sendMessageTaskInProgress) {
-            try await model.sendMessageTask()
+        .task(id: model.sendMessageTaskInProgress) {
+            await model.sendMessageTask()
         }
         .onChange(of: model.message) {
             model.messageDidChanged()

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -317,7 +317,7 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
         sendMessageTaskInProgress = true
     }
 
-    func sendMessageTask() async throws {
+    func sendMessageTask() async {
         guard sendMessageTaskInProgress else { return }
         guard message.string.trimmingCharacters(in: .whitespacesAndNewlines).isNotEmpty || linkedObjects.isNotEmpty else {
             sendMessageTaskInProgress = false
@@ -328,25 +328,30 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
             try Task.checkCancellation()
             sendButtonIsLoading = true
         }
+        // Reset on every exit path — a thrown error must not leave the send button stuck
+        defer {
+            loadingTask.cancel()
+            sendButtonIsLoading = false
+            sendMessageTaskInProgress = false
+        }
         mentionSearchState = .finish
-        if let editMessage {
-            guard let chatId else {
-                anytypeAssertionFailure("Edit message without chatId")
-                sendMessageTaskInProgress = false
-                return
-            }
-            try await chatActionService.updateMessage(
-                chatId: chatId,
-                spaceId: spaceId,
-                messageId: editMessage.id,
-                message: message.sendable(),
-                linkedObjects: linkedObjects,
-                replyToMessageId: replyToMessage?.id,
-                useBlocksFormat: true
-            )
-            clearInput()
-        } else if discussionMessageLimits.canSendMessage() {
-            do {
+        do {
+            if let editMessage {
+                guard let chatId else {
+                    anytypeAssertionFailure("Edit message without chatId")
+                    return
+                }
+                try await chatActionService.updateMessage(
+                    chatId: chatId,
+                    spaceId: spaceId,
+                    messageId: editMessage.id,
+                    message: message.sendable(),
+                    linkedObjects: linkedObjects,
+                    replyToMessageId: replyToMessage?.id,
+                    useBlocksFormat: true
+                )
+                clearInput()
+            } else if discussionMessageLimits.canSendMessage() {
                 let isFirstComment = chatId == nil
                 let resolvedChatId = try await createDiscussionIfNeeded()
                 let messageId = try await chatActionService.createMessage(
@@ -362,16 +367,14 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
                 discussionMessageLimits.markSentMessage()
                 clearInput()
                 await donateShareSuggestion()
-            } catch {
-                toastBarData = ToastBarData(error.localizedDescription, type: .failure)
+            } else {
+                keyboardDismiss?()
+                showSendLimitAlert = true
             }
-        } else {
-            keyboardDismiss?()
-            showSendLimitAlert = true
+        } catch {
+            // Keep the input intact so the user can retry
+            toastBarData = ToastBarData(error.localizedDescription, type: .failure)
         }
-        loadingTask.cancel()
-        sendButtonIsLoading = false
-        sendMessageTaskInProgress = false
     }
 
     private func logDiscussionAnalytics(isFirstComment: Bool) {

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -373,6 +373,10 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
             }
         } catch {
             // Keep the input intact so the user can retry
+            if let sendError = error as? ChatActionSendError {
+                // Reuse already uploaded attachments on retry instead of re-uploading them
+                attachmentHandler.setLinkedObjects(sendError.updatedLinkedObjects)
+            }
             toastBarData = ToastBarData(error.localizedDescription, type: .failure)
         }
     }

--- a/Anytype/Sources/ServiceLayer/ChatActionService/ChatActionService.swift
+++ b/Anytype/Sources/ServiceLayer/ChatActionService/ChatActionService.swift
@@ -39,7 +39,7 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
         replyToMessageId: String?,
         useBlocksFormat: Bool
     ) async throws -> String {
-        let chatMessage = await makeMessage(chatId: chatId, spaceId: spaceId, message: message, linkedObjects: linkedObjects, replyToMessageId: replyToMessageId, useBlocksFormat: useBlocksFormat)
+        let chatMessage = try await makeMessage(chatId: chatId, spaceId: spaceId, message: message, linkedObjects: linkedObjects, replyToMessageId: replyToMessageId, useBlocksFormat: useBlocksFormat)
         return try await chatService.addMessage(chatObjectId: chatId, message: chatMessage)
     }
 
@@ -52,7 +52,7 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
         replyToMessageId: String?,
         useBlocksFormat: Bool
     ) async throws {
-        var chatMessage = await makeMessage(chatId: chatId, spaceId: spaceId, message: message, linkedObjects: linkedObjects, replyToMessageId: replyToMessageId, useBlocksFormat: useBlocksFormat)
+        var chatMessage = try await makeMessage(chatId: chatId, spaceId: spaceId, message: message, linkedObjects: linkedObjects, replyToMessageId: replyToMessageId, useBlocksFormat: useBlocksFormat)
         chatMessage.id = messageId
         try await chatService.updateMessage(chatObjectId: chatId, message: chatMessage)
     }
@@ -66,7 +66,7 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
         linkedObjects: [ChatLinkedObject],
         replyToMessageId: String?,
         useBlocksFormat: Bool
-    ) async -> ChatMessage {
+    ) async throws -> ChatMessage {
 
         var chatMessage = ChatMessage()
         let content = chatInputConverter.convert(message: message.value)
@@ -101,7 +101,8 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
                 }
             case .localPhotosFile(let chatLocalFile):
                 guard let data = chatLocalFile.data else { continue }
-                guard let fileDetails = try? await uploadFile(spaceId: spaceId, data: data.data, preloadFileId: chatLocalFile.data?.preloadFileId, createdInContext: chatId) else { continue }
+                // A failed upload must fail the send — silently dropping the attachment loses user data
+                let fileDetails = try await uploadFile(spaceId: spaceId, data: data.data, preloadFileId: chatLocalFile.data?.preloadFileId, createdInContext: chatId)
                 if useBlocksFormat {
                     var linkBlock = ChatMessage.MessageBlockLink()
                     linkBlock.targetObjectID = fileDetails.id
@@ -115,7 +116,7 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
                     chatMessage.attachments.append(attachment)
                 }
             case .localBinaryFile(let binaryFile):
-                guard let fileDetails = try? await uploadFile(spaceId: spaceId, data: binaryFile.data, preloadFileId: binaryFile.preloadFileId, createdInContext: chatId) else { continue }
+                let fileDetails = try await uploadFile(spaceId: spaceId, data: binaryFile.data, preloadFileId: binaryFile.preloadFileId, createdInContext: chatId)
                 if useBlocksFormat {
                     var linkBlock = ChatMessage.MessageBlockLink()
                     linkBlock.targetObjectID = fileDetails.id
@@ -132,14 +133,14 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
                 guard let url = AnytypeURL(string: data.url) else { continue }
                 let type = try? typeProvider.objectType(uniqueKey: ObjectTypeUniqueKey.bookmark, spaceId: spaceId)
 
-                guard let bookmark = try? await bookmarkService.createBookmarkObject(
+                let bookmark = try await bookmarkService.createBookmarkObject(
                     spaceId: spaceId,
                     url: url,
                     templateId: type?.defaultTemplateId,
                     origin: .none,
                     createdInContext: chatId,
                     createdInContextRef: ""
-                ) else { continue }
+                )
 
                 if useBlocksFormat {
                     var linkBlock = ChatMessage.MessageBlockLink()

--- a/Anytype/Sources/ServiceLayer/ChatActionService/ChatActionService.swift
+++ b/Anytype/Sources/ServiceLayer/ChatActionService/ChatActionService.swift
@@ -2,6 +2,15 @@ import Services
 import UIKit
 import AnytypeCore
 
+struct ChatActionSendError: Error, LocalizedError {
+    let underlyingError: any Error
+    /// Input linked objects with successfully uploaded ones replaced by `.uploadedObject`,
+    /// so a retry reuses the created objects instead of re-uploading and orphaning them
+    let updatedLinkedObjects: [ChatLinkedObject]
+
+    var errorDescription: String? { underlyingError.localizedDescription }
+}
+
 protocol ChatActionServiceProtocol: AnyObject, Sendable {
     func createMessage(
         chatId: String,
@@ -39,8 +48,12 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
         replyToMessageId: String?,
         useBlocksFormat: Bool
     ) async throws -> String {
-        let chatMessage = try await makeMessage(chatId: chatId, spaceId: spaceId, message: message, linkedObjects: linkedObjects, replyToMessageId: replyToMessageId, useBlocksFormat: useBlocksFormat)
-        return try await chatService.addMessage(chatObjectId: chatId, message: chatMessage)
+        let (chatMessage, updatedLinkedObjects) = try await makeMessage(chatId: chatId, spaceId: spaceId, message: message, linkedObjects: linkedObjects, replyToMessageId: replyToMessageId, useBlocksFormat: useBlocksFormat)
+        do {
+            return try await chatService.addMessage(chatObjectId: chatId, message: chatMessage)
+        } catch {
+            throw ChatActionSendError(underlyingError: error, updatedLinkedObjects: updatedLinkedObjects)
+        }
     }
 
     func updateMessage(
@@ -52,9 +65,14 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
         replyToMessageId: String?,
         useBlocksFormat: Bool
     ) async throws {
-        var chatMessage = try await makeMessage(chatId: chatId, spaceId: spaceId, message: message, linkedObjects: linkedObjects, replyToMessageId: replyToMessageId, useBlocksFormat: useBlocksFormat)
+        let (madeMessage, updatedLinkedObjects) = try await makeMessage(chatId: chatId, spaceId: spaceId, message: message, linkedObjects: linkedObjects, replyToMessageId: replyToMessageId, useBlocksFormat: useBlocksFormat)
+        var chatMessage = madeMessage
         chatMessage.id = messageId
-        try await chatService.updateMessage(chatObjectId: chatId, message: chatMessage)
+        do {
+            try await chatService.updateMessage(chatObjectId: chatId, message: chatMessage)
+        } catch {
+            throw ChatActionSendError(underlyingError: error, updatedLinkedObjects: updatedLinkedObjects)
+        }
     }
     
     // MARK: - Private
@@ -66,7 +84,7 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
         linkedObjects: [ChatLinkedObject],
         replyToMessageId: String?,
         useBlocksFormat: Bool
-    ) async throws -> ChatMessage {
+    ) async throws -> (message: ChatMessage, updatedLinkedObjects: [ChatLinkedObject]) {
 
         var chatMessage = ChatMessage()
         let content = chatInputConverter.convert(message: message.value)
@@ -83,81 +101,91 @@ final class ChatActionService: ChatActionServiceProtocol, Sendable {
         }
         chatMessage.replyToMessageID = replyToMessageId ?? ""
 
-        for linkedObject in linkedObjects {
-            switch linkedObject {
-            case .uploadedObject(let objectDetails):
-                if useBlocksFormat {
-                    var linkBlock = ChatMessage.MessageBlockLink()
-                    linkBlock.targetObjectID = objectDetails.id
-                    linkBlock.type = objectDetails.resolvedLayoutValue.blockLinkType
-                    var block = ChatMessage.MessageBlock()
-                    block.content = .link(linkBlock)
-                    chatMessage.blocks.append(block)
-                } else {
-                    var attachment = ChatMessageAttachment()
-                    attachment.target = objectDetails.id
-                    attachment.type = .link
-                    chatMessage.attachments.append(attachment)
-                }
-            case .localPhotosFile(let chatLocalFile):
-                guard let data = chatLocalFile.data else { continue }
-                // A failed upload must fail the send — silently dropping the attachment loses user data
-                let fileDetails = try await uploadFile(spaceId: spaceId, data: data.data, preloadFileId: chatLocalFile.data?.preloadFileId, createdInContext: chatId)
-                if useBlocksFormat {
-                    var linkBlock = ChatMessage.MessageBlockLink()
-                    linkBlock.targetObjectID = fileDetails.id
-                    linkBlock.type = fileDetails.blockLinkType
-                    var block = ChatMessage.MessageBlock()
-                    block.content = .link(linkBlock)
-                    chatMessage.blocks.append(block)
-                } else {
-                    var attachment = ChatMessageAttachment()
-                    attachment.target = fileDetails.id
-                    chatMessage.attachments.append(attachment)
-                }
-            case .localBinaryFile(let binaryFile):
-                let fileDetails = try await uploadFile(spaceId: spaceId, data: binaryFile.data, preloadFileId: binaryFile.preloadFileId, createdInContext: chatId)
-                if useBlocksFormat {
-                    var linkBlock = ChatMessage.MessageBlockLink()
-                    linkBlock.targetObjectID = fileDetails.id
-                    linkBlock.type = fileDetails.blockLinkType
-                    var block = ChatMessage.MessageBlock()
-                    block.content = .link(linkBlock)
-                    chatMessage.blocks.append(block)
-                } else {
-                    var attachment = ChatMessageAttachment()
-                    attachment.target = fileDetails.id
-                    chatMessage.attachments.append(attachment)
-                }
-            case .localBookmark(let data):
-                guard let url = AnytypeURL(string: data.url) else { continue }
-                let type = try? typeProvider.objectType(uniqueKey: ObjectTypeUniqueKey.bookmark, spaceId: spaceId)
+        var updatedLinkedObjects = linkedObjects
 
-                let bookmark = try await bookmarkService.createBookmarkObject(
-                    spaceId: spaceId,
-                    url: url,
-                    templateId: type?.defaultTemplateId,
-                    origin: .none,
-                    createdInContext: chatId,
-                    createdInContextRef: ""
-                )
+        do {
+            for (index, linkedObject) in linkedObjects.enumerated() {
+                switch linkedObject {
+                case .uploadedObject(let objectDetails):
+                    if useBlocksFormat {
+                        var linkBlock = ChatMessage.MessageBlockLink()
+                        linkBlock.targetObjectID = objectDetails.id
+                        linkBlock.type = objectDetails.resolvedLayoutValue.blockLinkType
+                        var block = ChatMessage.MessageBlock()
+                        block.content = .link(linkBlock)
+                        chatMessage.blocks.append(block)
+                    } else {
+                        var attachment = ChatMessageAttachment()
+                        attachment.target = objectDetails.id
+                        attachment.type = .link
+                        chatMessage.attachments.append(attachment)
+                    }
+                case .localPhotosFile(let chatLocalFile):
+                    guard let data = chatLocalFile.data else { continue }
+                    // A failed upload must fail the send — silently dropping the attachment loses user data
+                    let fileDetails = try await uploadFile(spaceId: spaceId, data: data.data, preloadFileId: chatLocalFile.data?.preloadFileId, createdInContext: chatId)
+                    updatedLinkedObjects[index] = .uploadedObject(MessageAttachmentDetails(fileDetails: fileDetails))
+                    if useBlocksFormat {
+                        var linkBlock = ChatMessage.MessageBlockLink()
+                        linkBlock.targetObjectID = fileDetails.id
+                        linkBlock.type = fileDetails.blockLinkType
+                        var block = ChatMessage.MessageBlock()
+                        block.content = .link(linkBlock)
+                        chatMessage.blocks.append(block)
+                    } else {
+                        var attachment = ChatMessageAttachment()
+                        attachment.target = fileDetails.id
+                        chatMessage.attachments.append(attachment)
+                    }
+                case .localBinaryFile(let binaryFile):
+                    let fileDetails = try await uploadFile(spaceId: spaceId, data: binaryFile.data, preloadFileId: binaryFile.preloadFileId, createdInContext: chatId)
+                    updatedLinkedObjects[index] = .uploadedObject(MessageAttachmentDetails(fileDetails: fileDetails))
+                    if useBlocksFormat {
+                        var linkBlock = ChatMessage.MessageBlockLink()
+                        linkBlock.targetObjectID = fileDetails.id
+                        linkBlock.type = fileDetails.blockLinkType
+                        var block = ChatMessage.MessageBlock()
+                        block.content = .link(linkBlock)
+                        chatMessage.blocks.append(block)
+                    } else {
+                        var attachment = ChatMessageAttachment()
+                        attachment.target = fileDetails.id
+                        chatMessage.attachments.append(attachment)
+                    }
+                case .localBookmark(let data):
+                    guard let url = AnytypeURL(string: data.url) else { continue }
+                    let type = try? typeProvider.objectType(uniqueKey: ObjectTypeUniqueKey.bookmark, spaceId: spaceId)
 
-                if useBlocksFormat {
-                    var linkBlock = ChatMessage.MessageBlockLink()
-                    linkBlock.targetObjectID = bookmark.id
-                    linkBlock.type = .bookmark
-                    var block = ChatMessage.MessageBlock()
-                    block.content = .link(linkBlock)
-                    chatMessage.blocks.append(block)
-                } else {
-                    var attachment = ChatMessageAttachment()
-                    attachment.target = bookmark.id
-                    chatMessage.attachments.append(attachment)
+                    let bookmark = try await bookmarkService.createBookmarkObject(
+                        spaceId: spaceId,
+                        url: url,
+                        templateId: type?.defaultTemplateId,
+                        origin: .none,
+                        createdInContext: chatId,
+                        createdInContextRef: ""
+                    )
+                    updatedLinkedObjects[index] = .uploadedObject(MessageAttachmentDetails(details: bookmark))
+
+                    if useBlocksFormat {
+                        var linkBlock = ChatMessage.MessageBlockLink()
+                        linkBlock.targetObjectID = bookmark.id
+                        linkBlock.type = .bookmark
+                        var block = ChatMessage.MessageBlock()
+                        block.content = .link(linkBlock)
+                        chatMessage.blocks.append(block)
+                    } else {
+                        var attachment = ChatMessageAttachment()
+                        attachment.target = bookmark.id
+                        chatMessage.attachments.append(attachment)
+                    }
                 }
             }
+        } catch {
+            // A failure on one item must not lose the objects already created for the previous ones
+            throw ChatActionSendError(underlyingError: error, updatedLinkedObjects: updatedLinkedObjects)
         }
 
-        return chatMessage
+        return (chatMessage, updatedLinkedObjects)
     }
 
     private func uploadFile(spaceId: String, data: FileData, preloadFileId: String?, createdInContext: String) async throws -> FileDetails {


### PR DESCRIPTION
## Summary
- `ChatActionService.makeMessage` no longer silently drops attachments whose upload failed (`try? ... else { continue }`) — an upload or bookmark-creation failure now fails the send, so the user keeps their input and sees an error instead of losing data.
- `sendMessageTask` in `ChatViewModel`/`DiscussionViewModel` resets `sendButtonIsLoading`/`sendMessageTaskInProgress` in a `defer` and reports errors via toast — previously a thrown error (swallowed by `.throwingTask`) left the send/attach buttons disabled until screen reopen; the Discussion edit path had no error handling at all.

Linear: IOS-6585