### PR TITLE
IOS-6587 Chat: restart message previews subscription across logout/login

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesPreviewsStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesPreviewsStorage.swift
@@ -84,7 +84,6 @@ actor ChatMessagesPreviewsStorage: ChatMessagesPreviewsStorageProtocol {
         subscription = nil
         previewsBySpace.removeAll()
         previewsStream.send([])
-        guard basicUserInfoStorage.usersId.isNotEmpty else { return }
         try? await chatService.unsubscribeFromMessagePreviews()
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesPreviewsStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/Services/ChatMessagesPreviewsStorage.swift
@@ -4,6 +4,8 @@ import AnytypeCore
 import AsyncTools
 
 protocol ChatMessagesPreviewsStorageProtocol: AnyObject, Sendable {
+    func startSubscription() async
+    func stopSubscriptionAndClean() async
     func previews() async -> [ChatMessagePreview]
     var previewsSequence: AnyAsyncSequence<[ChatMessagePreview]> { get async }
     var previewsSequenceWithEmpty: AnyAsyncSequence<[ChatMessagePreview]> { get async }
@@ -28,9 +30,7 @@ actor ChatMessagesPreviewsStorage: ChatMessagesPreviewsStorageProtocol {
     private var previewsBySpace = [ChatMessagePreviewKey: ChatMessagePreview]()
     private let previewsStream = AsyncToManyStream<[ChatMessagePreview]>()
     
-    init() {
-        Task { await startSubscription() }
-    }
+    init() {}
     
     var previewsSequence: AnyAsyncSequence<[ChatMessagePreview]> {
         previewsStream.throttle(milliseconds: 300).eraseToAnyAsyncSequence()
@@ -44,33 +44,30 @@ actor ChatMessagesPreviewsStorage: ChatMessagesPreviewsStorageProtocol {
         Array(previewsBySpace.values)
     }
     
-    deinit {
-        subscription?.cancel()
-        subscription = nil
-        // Implemented in swift 6.1 https://github.com/swiftlang/swift-evolution/blob/main/proposals/0371-isolated-synchronous-deinit.md
-        Task { [chatService, basicUserInfoStorage] in
-            guard basicUserInfoStorage.usersId.isNotEmpty else { return }
-            try await chatService.unsubscribeFromMessagePreviews()
-        }
-    }
-    
-    // MARK: - Private
-    
-    private func startSubscription() async {
+    // Lifecycle is managed by LoginStateService: started after login, stopped on logout.
+    // Without an explicit restart the middleware-side subscription is gone after
+    // logout/login and previews stay dead until app restart.
+    func startSubscription() async {
+        guard subscription == nil else { return }
         guard basicUserInfoStorage.usersId.isNotEmpty else {
             return
         }
-        
+
+        // Register the bus subscription before the RPC so events emitted right after
+        // the middleware-side subscription goes live land in the stream buffer.
+        let eventStream = await EventBunchSubscribtion.default.stream()
         subscription = Task { [weak self] in
-            for await events in await EventBunchSubscribtion.default.stream() {
+            for await events in eventStream {
                 await self?.handle(events: events)
             }
         }
-        
-        do {
 
+        do {
             let response = try await chatService.subscribeToMessagePreviews(subId: subscriptionId)
-            
+
+            // Stopped while awaiting the response — don't resurrect old previews
+            guard subscription != nil else { return }
+
             for preview in response.previews {
                 handleChatState(spaceId: preview.spaceID, chatId: preview.chatObjectID, state: preview.state)
                 await handleChatLastMessage(spaceId: preview.spaceID, chatId: preview.chatObjectID, message: preview.message, dependencies: preview.dependencies.compactMap(\.asDetails))
@@ -81,6 +78,22 @@ actor ChatMessagesPreviewsStorage: ChatMessagesPreviewsStorageProtocol {
             anytypeAssertionFailure("Subscribe to messages previews error", info: ["previewsError": error.localizedDescription])
         }
     }
+
+    func stopSubscriptionAndClean() async {
+        subscription?.cancel()
+        subscription = nil
+        previewsBySpace.removeAll()
+        previewsStream.send([])
+        guard basicUserInfoStorage.usersId.isNotEmpty else { return }
+        try? await chatService.unsubscribeFromMessagePreviews()
+    }
+
+    deinit {
+        subscription?.cancel()
+        subscription = nil
+    }
+
+    // MARK: - Private
     
     private func handle(events: EventsBunch) async {
         var hasChanges = false

--- a/Anytype/Sources/ServiceLayer/Auth/LoginStateService.swift
+++ b/Anytype/Sources/ServiceLayer/Auth/LoginStateService.swift
@@ -46,6 +46,7 @@ final class LoginStateService: LoginStateServiceProtocol, Sendable {
     private let spaceIconForNotificationsHandler: any SpaceIconForNotificationsHandlerProtocol = Container.shared.spaceIconForNotificationsHandler()
     private let spaceFileUploadService: any SpaceFileUploadServiceProtocol = Container.shared.spaceFileUploadService()
     private let appIconBadgeService: any AppIconBadgeServiceProtocol = Container.shared.appIconBadgeService()
+    private let chatMessagesPreviewsStorage: any ChatMessagesPreviewsStorageProtocol = Container.shared.chatMessagesPreviewsStorage()
     private let thermalProfilerTrigger: any ThermalProfilerTriggerProtocol = Container.shared.thermalProfilerTrigger()
     private let memoryPressureProfilerTrigger: any MemoryPressureProfilerTriggerProtocol = Container.shared.memoryPressureProfilerTrigger()
     private let debugProfileEventHandler: any DebugProfileEventHandlerProtocol = Container.shared.debugProfileEventHandler()
@@ -92,6 +93,7 @@ final class LoginStateService: LoginStateServiceProtocol, Sendable {
     private func startSubscriptions() async {
         await workspacesStorage.startSubscription()
         await chatDetailsStorage.startSubscription()
+        await chatMessagesPreviewsStorage.startSubscription()
         await accountParticipantsStorage.startSubscription()
         await objectsWithUnreadDiscussionsSubscription.startSubscription()
         await participantSpacesStorage.startSubscription()
@@ -114,6 +116,7 @@ final class LoginStateService: LoginStateServiceProtocol, Sendable {
     private func stopSubscriptions() async {
         await workspacesStorage.stopSubscription()
         await chatDetailsStorage.stopSubscription()
+        await chatMessagesPreviewsStorage.stopSubscriptionAndClean()
         await propertyDetailsStorage.stopSubscription()
         await objectTypeProvider.stopSubscription()
         await accountParticipantsStorage.stopSubscription()

--- a/Anytype/Sources/ServiceLayer/Badge/AppIconBadgeService.swift
+++ b/Anytype/Sources/ServiceLayer/Badge/AppIconBadgeService.swift
@@ -14,8 +14,7 @@ protocol AppIconBadgeServiceProtocol: AnyObject, Sendable {
 
 actor AppIconBadgeService: AppIconBadgeServiceProtocol {
 
-    // LazyInjected to avoid creating ChatMessagesPreviewsStorage before auth
-    // (when basicUserInfoStorage.usersId is empty, its subscription silently skips)
+    // ChatMessagesPreviewsStorage subscription lifecycle is managed by LoginStateService
     @LazyInjected(\.chatMessagesPreviewsStorage)
     private var chatMessagesPreviewsStorage: any ChatMessagesPreviewsStorageProtocol
     @Injected(\.spaceViewsStorage)


### PR DESCRIPTION
## Summary
- `ChatMessagesPreviewsStorage` no longer auto-subscribes in `init`; `LoginStateService` starts it after login and stops it on logout like the other storages — previously the singleton subscribed once per process, so after logout/login the middleware-side subscription was gone and chat previews, the unread widget and the app icon badge stayed dead until app restart (and `previewsBySpace` leaked the previous account's data).
- `stopSubscriptionAndClean` cancels the event task, clears previews (publishing an empty list) and unsubscribes; the register-listener-before-RPC fix from IOS-6582 is applied here too, plus a guard against applying a stale subscribe response after stop.

Linear: IOS-6587