### PR TITLE
IOS-6589 Report networkId on path changes; fix stale network/device-state reports

### DIFF
--- a/Anytype/Sources/ServiceLayer/NetworkConnection/NetworkConnectionDaemon.swift
+++ b/Anytype/Sources/ServiceLayer/NetworkConnection/NetworkConnectionDaemon.swift
@@ -1,6 +1,8 @@
 import Foundation
 import ProtobufMessages
 import Network
+import AnytypeCore
+import Logger
 
 
 // Monitors network connection and sends it to middleware
@@ -9,45 +11,94 @@ protocol NetworkConnectionStatusDaemonProtocol: Sendable {
     func stop() async
 }
 
-final class NetworkConnectionStatusDaemon: NetworkConnectionStatusDaemonProtocol, Sendable {
-    private let nwPathMonitor = NWPathMonitor()
-    
-    nonisolated init() { }
-    
+actor NetworkConnectionStatusDaemon: NetworkConnectionStatusDaemonProtocol {
+
+    private static let log = EventLogger(category: "NetworkConnectionStatusDaemon")
+
+    private let monitorQueue = DispatchQueue(label: "io.anytype.netmonitor")
+    private var nwPathMonitor: NWPathMonitor?
+    private var pathContinuation: AsyncStream<NWPath>.Continuation?
+    private var reportingTask: Task<Void, Never>?
+
+    init() { }
+
     func start() async {
-        setup()
-        nwPathMonitor.start(queue: .main)
-    }
-    
-    func stop() async {
-        nwPathMonitor.cancel()
-    }
-    
-    private func setup() {
-        nwPathMonitor.pathUpdateHandler = { path in
-            let networkType: Anytype_Model_DeviceNetworkType
-            
-            switch path.status {
-            case .satisfied:
-                if path.usesInterfaceType(.wifi) {
-                    networkType = .wifi
-                } else if path.usesInterfaceType(.cellular) {
-                    networkType = .cellular
-                } else {
-                    networkType = .wifi // fallback
-                }
-            case .requiresConnection, .unsatisfied:
-                networkType = .notConnected
-            @unknown default:
-                networkType = .notConnected
-            }
-            
-            Task {
-                try await ClientCommands.deviceNetworkStateSet(.with {
-                    $0.deviceNetworkType = networkType
-                }).invoke()
+        guard nwPathMonitor.isNil else { return }
+
+        // cancel() is terminal for NWPathMonitor, so every start needs a new instance.
+        let monitor = NWPathMonitor()
+        let (paths, continuation) = AsyncStream<NWPath>.makeStream(bufferingPolicy: .unbounded)
+
+        // Middleware coalesces bursts itself and treats duplicates as no-ops, so every callback is
+        // reported without debounce. Reports go through one task because invocations run on a
+        // concurrent queue: parallel tasks could leave middleware holding a stale path as the last seen one.
+        reportingTask = Task {
+            for await path in paths {
+                await Self.report(path: path)
             }
         }
+
+        monitor.pathUpdateHandler = { continuation.yield($0) }
+        monitor.start(queue: monitorQueue)
+
+        nwPathMonitor = monitor
+        pathContinuation = continuation
+    }
+
+    func stop() async {
+        nwPathMonitor?.cancel()
+        nwPathMonitor = nil
+        pathContinuation?.finish()
+        pathContinuation = nil
+
+        // invoke() is uncancellable, so a report in flight during stop() would otherwise outlive this
+        // session and race the next session's reports on the concurrent RPC queue, landing a stale path
+        // last. cancel() stops draining buffered paths; awaiting value lets the in-flight report finish
+        // before stop() returns. Detach from the stored property first so a re-entrant start() isn't cleared.
+        let task = reportingTask
+        reportingTask = nil
+        task?.cancel()
+        await task?.value
+    }
+
+    // MARK: - Private
+
+    private static func report(path: NWPath) async {
+        let networkType = path.deviceNetworkType
+        let networkId = path.networkId
+
+        log.debug("Reporting network state", metadata: ["type": "\(networkType)", "networkId": networkId])
+
+        _ = try? await ClientCommands.deviceNetworkStateSet(.with {
+            $0.deviceNetworkType = networkType
+            $0.networkID = networkId
+        }).invoke()
+    }
+}
+
+private extension NWPath {
+
+    var deviceNetworkType: Anytype_Model_DeviceNetworkType {
+        switch status {
+        case .satisfied:
+            // Cellular takes precedence when a path uses both interface types, matching the
+            // integration guide and Android. Everything else satisfied (wi-fi, wired, other) is wifi.
+            return usesInterfaceType(.cellular) ? .cellular : .wifi
+        case .requiresConnection, .unsatisfied:
+            return .notConnected
+        @unknown default:
+            return .notConnected
+        }
+    }
+
+    // Opaque identity of the path. The type enum can't express a same-type switch (Wi-Fi to Wi-Fi),
+    // which middleware needs to see to reset connections and re-sync instead of waiting out transport timeouts.
+    var networkId: String {
+        guard status == .satisfied else { return "" }
+
+        let interfaceNames = availableInterfaces.map(\.name).sorted().joined(separator: ",")
+        let gatewayNames = gateways.map { "\($0)" }.sorted().joined(separator: ",")
+        return interfaceNames + "|" + gatewayNames
     }
 }
 

--- a/Modules/ProtobufMessages/Sources/Protocol/Commands/Anytype_Rpc.Device.NetworkState.swift
+++ b/Modules/ProtobufMessages/Sources/Protocol/Commands/Anytype_Rpc.Device.NetworkState.swift
@@ -33,6 +33,13 @@ extension Anytype_Rpc.Device {
 
           public var deviceNetworkType: Anytype_Model_DeviceNetworkType = .wifi
 
+          /// opaque identity of the current network path as reported by the OS
+          /// (iOS: NWPath interfaces/gateway digest; Android: Network#getNetworkHandle()).
+          /// When it changes while the type stays the same (Wi-Fi to Wi-Fi switch,
+          /// cellular re-attach) the middleware still resets connections and re-syncs.
+          /// Optional: empty means unknown, only type transitions are used then.
+          public var networkID: String = String()
+
           public var unknownFields = SwiftProtobuf.UnknownStorage()
 
           public init() {}
@@ -162,7 +169,7 @@ extension Anytype_Rpc.Device.NetworkState.Set: SwiftProtobuf.Message, SwiftProto
 
 extension Anytype_Rpc.Device.NetworkState.Set.Request: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = Anytype_Rpc.Device.NetworkState.Set.protoMessageName + ".Request"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}deviceNetworkType\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}deviceNetworkType\0\u{1}networkId\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -171,6 +178,7 @@ extension Anytype_Rpc.Device.NetworkState.Set.Request: SwiftProtobuf.Message, Sw
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularEnumField(value: &self.deviceNetworkType) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.networkID) }()
       default: break
       }
     }
@@ -180,11 +188,15 @@ extension Anytype_Rpc.Device.NetworkState.Set.Request: SwiftProtobuf.Message, Sw
     if self.deviceNetworkType != .wifi {
       try visitor.visitSingularEnumField(value: self.deviceNetworkType, fieldNumber: 1)
     }
+    if !self.networkID.isEmpty {
+      try visitor.visitSingularStringField(value: self.networkID, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Anytype_Rpc.Device.NetworkState.Set.Request, rhs: Anytype_Rpc.Device.NetworkState.Set.Request) -> Bool {
     if lhs.deviceNetworkType != rhs.deviceNetworkType {return false}
+    if lhs.networkID != rhs.networkID {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Modules/Services/Sources/Services/SceneLifecycleStateService/SceneLifecycleStateService.swift
+++ b/Modules/Services/Sources/Services/SceneLifecycleStateService/SceneLifecycleStateService.swift
@@ -8,24 +8,46 @@ public protocol SceneLifecycleStateServiceProtocol: Sendable {
 
 /// Middleware should know about current app state in order to correctly handling socket listening
 /// @see https://developer.apple.com/library/archive/technotes/tn2277/_index.html#//apple_ref/doc/uid/DTS40010841-CH1-SUBSECTION2
- final class SceneLifecycleStateService: SceneLifecycleStateServiceProtocol {
-    
+final class SceneLifecycleStateService: SceneLifecycleStateServiceProtocol {
+
+    private let transitionContinuation: AsyncStream<LifecycleStateTransition>.Continuation
+
+    init() {
+        let (transitions, transitionContinuation) = AsyncStream<LifecycleStateTransition>.makeStream(bufferingPolicy: .unbounded)
+        self.transitionContinuation = transitionContinuation
+
+        // Transitions are reported one at a time because invocations run on a concurrent queue:
+        // parallel tasks could deliver a quick background/foreground pair reversed, leaving
+        // middleware treating a foreground app as backgrounded and skipping the resume head-sync.
+        Task {
+            for await transition in transitions {
+                await Self.report(transition: transition)
+            }
+        }
+    }
+
+    deinit {
+        transitionContinuation.finish()
+    }
+
     // MARK: - SceneLifecycleStateServiceProtocol
-    
+
     public func handleStateTransition(_ transition: LifecycleStateTransition) {
+        transitionContinuation.yield(transition)
+    }
+
+    // MARK: - Private
+
+    private static func report(transition: LifecycleStateTransition) async {
         let deviceState: Anytype_Rpc.App.SetDeviceState.Request.DeviceState = {
             switch transition {
             case .willEnterForeground: return .foreground
             case .didEnterBackground: return .background
             }
         }()
-		
-		Task {
-			_ = try? await ClientCommands.appSetDeviceState(.with {
-				$0.deviceState = deviceState
-			}).invoke()
-		}
-    }
-    
-}
 
+        _ = try? await ClientCommands.appSetDeviceState(.with {
+            $0.deviceState = deviceState
+        }).invoke()
+    }
+}


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE until anytype-heart [#3211](https://github.com/anyproto/anytype-heart/pull/3211) (GO-7379) is merged and a middleware bump lands.**
> The `networkId` proto field (field 2) exists only on that PR's branch. The generated Swift is committed here so this branch builds, but `Dependencies/Middleware/` is gitignored — once merged to `develop`, the nightly `update_middleware` job runs `make setup-middle`, which re-downloads the real proto (no field 2), regenerates without `networkID`, and then fails at the build step on the call site — stalling every middleware bump. This PR's own CI stays green because `setup-middle-ci` only downloads (no regen). When #3211 releases, bump `Libraryfile` + run `make setup-middle`; the generated diff here should be a zero-diff (proto copied verbatim from the PR branch).

## Summary
Implements IOS-6589: report the new `networkId` path-identity field on network changes, and fixes two ordering/lifecycle bugs found while auditing the device-state RPC contract from anytype-heart's `docs/mobile-network-integration.md`.

- **`networkId` (new):** `NetworkState.Set` now sends the OS path digest (sorted interface names + gateways, empty when unsatisfied) so a same-type Wi-Fi→Wi-Fi switch is visible to heart's recovery pipeline. Derivation matches the integration guide verbatim.
- **Fix: reports going permanently silent after logout→login.** `NetworkConnectionStatusDaemon` reused one `NWPathMonitor` whose `cancel()` is terminal, so post-logout `start()` fired on a dead monitor. Rebuilt as an `actor` that creates a fresh monitor per `start()`.
- **Fix: out-of-order reports.** Both `NetworkState.Set` and `SetDeviceState(FOREGROUND/BACKGROUND)` funneled each report into a bare `Task {}`, and `Invocation` dispatches to a *concurrent* queue — a fast background→foreground pair could land reversed, leaving heart treating a foreground app as backgrounded. Both now serialize through a single-consumer `AsyncStream`. `stop()` awaits any in-flight (uncancellable) report so it can't race the next session.
- Type mapping switched to cellular-first to match the guide and Android. `NOT_CONNECTED` still derives solely from `NWPath.status` — no reachability probing.

## Notes for reviewers
- `Anytype_Rpc.Device.NetworkState.swift` is generated; the proto text was copied verbatim from heart #3211.
- Reviewed by an adversarial pass; the cross-session ordering race in `stop()` was caught and fixed there.
- Open question raised in review: the guide's `networkId` formula uses all `availableInterfaces`, which can churn on cellular radio flaps while on a stable Wi-Fi (spurious heart resync). Kept the guide's formula as source-of-truth; worth confirming with the heart team rather than forking the derivation client-side.
