### PR TITLE
Support owner-held invites (GO-7222)

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
@@ -753,7 +753,8 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
     func updateInviteState() async {
         do {
             let invite = try await workspaceService.getCurrentInvite(spaceId: spaceId)
-            qrCodeInviteUrl = universalLinkParser.createUrl(link: .invite(cid: invite.cid, key: invite.fileKey))
+            // Invite held by the owner resolves with an empty cid on a member's device — never render an empty link
+            qrCodeInviteUrl = invite.hasLink ? universalLinkParser.createUrl(link: .invite(cid: invite.cid, key: invite.fileKey)) : nil
         } catch {
             qrCodeInviteUrl = nil
         }

--- a/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Discussion/DiscussionViewModel.swift
@@ -738,7 +738,8 @@ final class DiscussionViewModel: MessageModuleOutput, ChatActionProviderHandler 
 
     func copyObjectLink() async {
         let invite = try? await workspaceService.getCurrentInvite(spaceId: spaceId)
-        let link = universalLinkParser.createUrl(link: .object(objectId: objectId, spaceId: spaceId, cid: invite?.cid, key: invite?.fileKey))
+        let hasLink = invite?.hasLink ?? false
+        let link = universalLinkParser.createUrl(link: .object(objectId: objectId, spaceId: spaceId, cid: hasLink ? invite?.cid : nil, key: hasLink ? invite?.fileKey : nil))
         UIPasteboard.general.string = link?.absoluteString
         toastBarData = ToastBarData(Loc.copied)
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeWidgets/Container/Submodule/WidgetsHeader/WidgetsHeaderViewModel.swift
@@ -118,7 +118,7 @@ final class WidgetsHeaderViewModel {
 
         do {
             let invite = try await workspaceService.getCurrentInvite(spaceId: accountSpaceId)
-            inviteLink = universalLinkParser.createUrl(link: .invite(cid: invite.cid, key: invite.fileKey))
+            inviteLink = invite.hasLink ? universalLinkParser.createUrl(link: .invite(cid: invite.cid, key: invite.fileKey)) : nil
         } catch {
             inviteLink = nil
         }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Views/InviteSharingAlerts.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Views/InviteSharingAlerts.swift
@@ -13,7 +13,7 @@ struct ShareInviteWithSpaceAlert: View {
             BottomAlertButton(text: Loc.cancel, style: .secondary) {
                 dismiss()
             }
-            BottomAlertButton(text: Loc.confirm, style: .primary) {
+            BottomAlertButton(text: Loc.Space.Invite.Share.confirmButton, style: .primary) {
                 onConfirm()
                 dismiss()
             }
@@ -27,7 +27,7 @@ struct ResetInviteLinkAlert: View {
 
     var body: some View {
         BottomAlertView(
-            title: Loc.Space.Invite.Reset.title,
+            title: Loc.Space.Invite.Reset.confirmTitle,
             message: Loc.Space.Invite.Reset.confirmMessage,
             icon: .Dialog.exclamation
         ) {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Views/InviteSharingAlerts.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Views/InviteSharingAlerts.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct ShareInviteWithSpaceAlert: View {
+    @Environment(\.dismiss) private var dismiss
+    let onConfirm: () -> ()
+
+    var body: some View {
+        BottomAlertView(
+            title: Loc.Space.Invite.Share.confirmTitle,
+            message: Loc.Space.Invite.Share.confirmMessage,
+            icon: .Dialog.exclamation
+        ) {
+            BottomAlertButton(text: Loc.cancel, style: .secondary) {
+                dismiss()
+            }
+            BottomAlertButton(text: Loc.confirm, style: .primary) {
+                onConfirm()
+                dismiss()
+            }
+        }
+    }
+}
+
+struct ResetInviteLinkAlert: View {
+    @Environment(\.dismiss) private var dismiss
+    let onConfirm: () -> ()
+
+    var body: some View {
+        BottomAlertView(
+            title: Loc.Space.Invite.Reset.title,
+            message: Loc.Space.Invite.Reset.confirmMessage,
+            icon: .Dialog.exclamation
+        ) {
+            BottomAlertButton(text: Loc.cancel, style: .secondary) {
+                dismiss()
+            }
+            BottomAlertButton(text: Loc.Space.Invite.Reset.title, style: .warning) {
+                onConfirm()
+                dismiss()
+            }
+        }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Views/InviteTypePicker.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Views/InviteTypePicker.swift
@@ -3,8 +3,9 @@ import SwiftUI
 
 struct InviteTypePicker: View {
     let currentType: SpaceRichIviteType
+    var disabledTypes: [SpaceRichIviteType] = []
     let onSelect: (SpaceRichIviteType) -> Void
-    
+
     var body: some View {
         VStack(spacing: 0) {
             DragIndicator()
@@ -24,6 +25,8 @@ struct InviteTypePicker: View {
                         $0.newDivider()
                     }
                 }
+                .disabled(disabledTypes.contains(type))
+                .opacity(disabledTypes.contains(type) ? 0.3 : 1)
             }
             Spacer.fixedHeight(8)
         }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Views/NewInviteLinkView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Views/NewInviteLinkView.swift
@@ -12,39 +12,54 @@ struct NewInviteLinkView: View {
         self.canChangeInvite = canChangeInvite
         self.hasReachedSharedSpacesLimit = hasReachedSharedSpacesLimit
     }
-    
+
     var body: some View {
-        Group {
-            if model.showInitialLoading {
-                loadingView
-            } else if model.shareLink.isNotNil {
-                linkContent
-            } else {
-                linkStateButton
-                    .opacity(hasReachedSharedSpacesLimit ? 0.5 : 1)
-                    .disabled(model.isLoading || !canChangeInvite || hasReachedSharedSpacesLimit)
+        content
+            .transition(.opacity)
+            .background(Color.Background.primary)
+            .animation(.default, value: model.shareLink)
+            .animation(.default, value: model.inviteType)
+            .task {
+                await model.onAppear()
             }
-        }
-        .transition(.opacity)
-        .background(Color.Background.primary)
-        .animation(.default, value: model.shareLink)
-        .animation(.default, value: model.inviteType)
-        .task {
-            await model.onAppear()
-        }
-        .anytypeSheet(item: $model.invitePickerItem) {
-            InviteTypePicker(currentType: $0) { type in
-                model.onInviteLinkTypeSelected(type)
+            .anytypeSheet(item: $model.invitePickerItem) {
+                InviteTypePicker(currentType: $0, disabledTypes: model.disabledPickerTypes) { type in
+                    model.onInviteLinkTypeSelected(type)
+                }
             }
-        }
-        .anytypeSheet(item: $model.inviteChangeConfirmation) { invite in
-            SpaceInviteChangeAlert {
-                model.onInviteChangeConfirmed(invite)
+            .anytypeSheet(item: $model.inviteChangeConfirmation) { invite in
+                SpaceInviteChangeAlert {
+                    model.onInviteChangeConfirmed(invite)
+                }
             }
-        }
-        .snackbar(toastBarData: $model.toastBarData)
+            .anytypeSheet(isPresented: $model.showShareConfirmation) {
+                ShareInviteWithSpaceAlert {
+                    model.onShareConfirmed()
+                }
+            }
+            .anytypeSheet(isPresented: $model.showResetConfirmation) {
+                ResetInviteLinkAlert {
+                    model.onResetConfirmed()
+                }
+            }
+            .snackbar(toastBarData: $model.toastBarData)
     }
-    
+
+    @ViewBuilder
+    private var content: some View {
+        if model.showInitialLoading {
+            loadingView
+        } else if model.inviteHeldByOwner {
+            heldByOwnerView
+        } else if model.shareLink.isNotNil {
+            linkContent
+        } else {
+            linkStateButton
+                .opacity(hasReachedSharedSpacesLimit ? 0.5 : 1)
+                .disabled(model.isLoading || !canChangeInvite || hasReachedSharedSpacesLimit)
+        }
+    }
+
     private var loadingView: some View {
         VStack {
             CircleLoadingView()
@@ -53,7 +68,14 @@ struct NewInviteLinkView: View {
         .padding(30)
         .frame(maxWidth: .infinity)
     }
-    
+
+    private var heldByOwnerView: some View {
+        AnytypeText(Loc.Space.Invite.HeldByOwner.message, style: .uxCalloutRegular)
+            .foregroundStyle(Color.Text.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 20)
+    }
+
     private var linkContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             linkStateButton
@@ -62,9 +84,71 @@ struct NewInviteLinkView: View {
             StandardButton(Loc.copyLink, style: .primaryMedium) {
                 model.onCopyLink(route: .button)
             }
+            if canChangeInvite && model.inviteType != nil {
+                inviteManagementSection
+            }
         }
     }
-    
+
+    private var inviteManagementSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Spacer.fixedHeight(16)
+            shareToggleRow
+            if let hint = shareToggleHint {
+                Spacer.fixedHeight(4)
+                caption(hint)
+            }
+            warningsView
+            if model.isSharedWithinSpace {
+                Spacer.fixedHeight(16)
+                StandardButton(Loc.Space.Invite.Reset.title, style: .warningMedium) {
+                    model.onResetLinkTap()
+                }
+            }
+        }
+    }
+
+    private var shareToggleRow: some View {
+        Toggle(isOn: Binding(
+            get: { model.shareToggleState == .onLocked },
+            set: { model.onShareToggleChanged($0) }
+        )) {
+            AnytypeText(Loc.Space.Invite.Share.toggle, style: .uxCalloutRegular)
+                .foregroundStyle(Color.Text.primary)
+        }
+        .toggleStyle(SwitchToggleStyle(tint: .Control.accent50))
+        .disabled(model.shareToggleState != .off || model.isLoading)
+    }
+
+    private var shareToggleHint: String? {
+        switch model.shareToggleState {
+        case .off:
+            nil
+        case .onLocked:
+            Loc.Space.Invite.Share.lockedHint
+        case .blocked:
+            Loc.Space.Invite.Share.disabledReason
+        }
+    }
+
+    @ViewBuilder
+    private var warningsView: some View {
+        if model.inviteType == .viewer || model.inviteType == .editor {
+            Spacer.fixedHeight(8)
+            caption(Loc.Space.Invite.Warning.autoApproval)
+        }
+        if model.inviteType == .editor {
+            Spacer.fixedHeight(4)
+            caption(Loc.Space.Invite.Warning.editorUpgrade)
+        }
+    }
+
+    private func caption(_ text: String) -> some View {
+        AnytypeText(text, style: .relation2Regular)
+            .foregroundStyle(Color.Text.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
     private var linkStateButton: some View {
         Button {
             model.onLinkTypeTap()
@@ -81,7 +165,7 @@ struct NewInviteLinkView: View {
             }
         }.disabled(model.isLoading || !canChangeInvite)
     }
-    
+
     private var linkView: some View {
         Button {
             model.onCopyLink(route: .menu)

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Views/NewInviteLinkViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceShare/Views/NewInviteLinkViewModel.swift
@@ -10,6 +10,14 @@ protocol NewInviteLinkModuleOutput: AnyObject {
     func showSpacesManager()
 }
 
+enum InviteShareToggleState {
+    case off
+    // Shared invites cannot be taken back into the owner's account — only reset
+    case onLocked
+    // Anyone-can-join editor invites cannot be shared within the space
+    case blocked
+}
+
 @MainActor
 @Observable
 final class NewInviteLinkViewModel {
@@ -21,6 +29,21 @@ final class NewInviteLinkViewModel {
     var isLoading = false
     var inviteType: SpaceRichIviteType?
     var inviteChangeConfirmation: SpaceRichIviteType?
+    var inviteHeldByOwner = false
+    var isSharedWithinSpace = false
+    var showShareConfirmation = false
+    var showResetConfirmation = false
+
+    var shareToggleState: InviteShareToggleState {
+        if isSharedWithinSpace { return .onLocked }
+        if inviteType == .editor { return .blocked }
+        return .off
+    }
+
+    // Middleware refuses InviteChange above Reader on a shared invite (INVITE_NOT_SHAREABLE)
+    var disabledPickerTypes: [SpaceRichIviteType] {
+        isSharedWithinSpace && inviteType == .viewer ? [.editor] : []
+    }
 
     @ObservationIgnored
     @Injected(\.spaceViewsStorage)
@@ -37,22 +60,24 @@ final class NewInviteLinkViewModel {
     @ObservationIgnored
     private var spaceId: String { data.spaceId }
     @ObservationIgnored
+    private var currentInvite: SpaceInvite?
+    @ObservationIgnored
     private weak var output: (any NewInviteLinkModuleOutput)?
-    
+
     init(data: SpaceShareData, output: (any NewInviteLinkModuleOutput)?) {
         self.data = data
         self.output = output
     }
-    
+
     func onAppear() async {
         await updateView()
         showInitialLoading = false
     }
-    
+
     func updateLink() {
         Task { await updateView() }
     }
-    
+
     func onInviteLinkTypeSelected(_ invite: SpaceRichIviteType) {
         invitePickerItem = nil
         guard inviteType != invite else { return }
@@ -60,17 +85,69 @@ final class NewInviteLinkViewModel {
             inviteChangeConfirmation = invite
             return
         }
-        
+
         updateInviteAndView(invite)
     }
-    
+
     func onInviteChangeConfirmed(_ invite: SpaceRichIviteType) {
         updateInviteAndView(invite)
     }
-    
+
+    func onShareToggleChanged(_ isOn: Bool) {
+        guard isOn, shareToggleState == .off else { return }
+        showShareConfirmation = true
+    }
+
+    func onShareConfirmed() {
+        guard let currentInvite, let inviteType = currentInvite.inviteType else { return }
+        Task {
+            isLoading = true
+            do {
+                defer { isLoading = false }
+                // Publishes the very same invite into the space — same cid, same key, no new link
+                _ = try await workspaceService.generateInvite(
+                    spaceId: spaceId,
+                    inviteType: inviteType,
+                    permissions: currentInvite.permissions,
+                    shareWithinSpace: true
+                )
+                await updateView()
+            } catch {
+                toastBarData = ToastBarData(error.localizedDescription)
+            }
+        }
+    }
+
+    func onResetLinkTap() {
+        showResetConfirmation = true
+    }
+
+    func onResetConfirmed() {
+        guard let currentInvite, let inviteType = currentInvite.inviteType else { return }
+        Task {
+            isLoading = true
+            do {
+                defer { isLoading = false }
+                // Not atomic: if generate fails after revoke, the space is left without an invite.
+                // updateView() in the catch recovers the UI to the disabled state so the owner can regenerate.
+                try await workspaceService.revokeInvite(spaceId: spaceId)
+                _ = try await workspaceService.generateInvite(
+                    spaceId: spaceId,
+                    inviteType: inviteType,
+                    permissions: currentInvite.permissions,
+                    shareWithinSpace: false
+                )
+                await updateView()
+            } catch {
+                toastBarData = ToastBarData(error.localizedDescription)
+                await updateView()
+            }
+        }
+    }
+
     private func inviteUpdateNeedsConfirmation(_ invite: SpaceRichIviteType) -> Bool {
         guard inviteType != .disabled else { return false }
-        
+
         switch invite {
         case .editor:
             return inviteType != .viewer
@@ -82,13 +159,13 @@ final class NewInviteLinkViewModel {
             return true
         }
     }
-    
+
     private func updateInviteAndView(_ invite: SpaceRichIviteType) {
         Task {
             isLoading = true
             do {
                 defer { isLoading = false }
-                
+
                 try await updateInvite(invite)
                 if invite.isShared { AnytypeAnalytics.instance().logShareSpace() }
                 if let analyticsValue = invite.analyticsValue { AnytypeAnalytics.instance().logClickShareSpaceNewLink(type: analyticsValue) }
@@ -98,7 +175,7 @@ final class NewInviteLinkViewModel {
             }
         }
     }
-    
+
     private func updateInvite(_ type: SpaceRichIviteType) async throws {
         switch type {
         case .editor:
@@ -125,48 +202,60 @@ final class NewInviteLinkViewModel {
             try await workspaceService.revokeInvite(spaceId: spaceId)
         }
     }
-    
+
     func onCopyLink(route: ClickShareSpaceCopyLinkRoute) {
         AnytypeAnalytics.instance().logClickShareSpaceCopyLink(route: route)
         UIPasteboard.general.string = shareLink?.absoluteString
         toastBarData = ToastBarData(Loc.copied)
     }
-    
+
     func onShareInvite() {
         AnytypeAnalytics.instance().logClickSettingsSpaceShare(type: .shareLink)
         AnytypeAnalytics.instance().logClickShareSpaceShareLink(route: .membersScreen)
         guard let shareLink else { return }
         output?.shareInvite(url: shareLink)
     }
-    
+
     func onShowQrCode() {
         AnytypeAnalytics.instance().logClickSettingsSpaceShare(type: .qr)
         guard let shareLink else { return }
         output?.showQrCode(url: shareLink)
     }
-    
+
     func onLinkTypeTap() {
         invitePickerItem = inviteType
     }
-    
+
     private func updateView() async {
         AnytypeAnalytics.instance().logScreenSettingsSpaceShare(route: data.route)
-        
+
         do {
             let invite = try await workspaceService.getCurrentInvite(spaceId: spaceId)
-            inviteType = invite.richInviteType
-            shareLink = universalLinkParser.createUrl(link: .invite(cid: invite.cid, key: invite.fileKey))
-        } catch let error as Anytype_Rpc.Space.InviteGetCurrent.Response.Error {
-            if error.code == .noActiveInvite {
-                inviteType = .disabled
-                shareLink = nil
-            } else {
+            currentInvite = invite
+            if invite.heldByOwner && !invite.hasLink {
+                // Member's device — the invite is kept in the owner's account
+                inviteHeldByOwner = true
+                isSharedWithinSpace = false
                 inviteType = nil
                 shareLink = nil
+            } else {
+                inviteHeldByOwner = false
+                isSharedWithinSpace = !invite.heldByOwner
+                inviteType = invite.richInviteType
+                shareLink = invite.hasLink ? universalLinkParser.createUrl(link: .invite(cid: invite.cid, key: invite.fileKey)) : nil
             }
+        } catch let error as Anytype_Rpc.Space.InviteGetCurrent.Response.Error {
+            resetState(inviteType: error.code == .noActiveInvite ? .disabled : nil)
         } catch {
-            inviteType = nil
-            shareLink = nil
+            resetState(inviteType: nil)
         }
+    }
+
+    private func resetState(inviteType: SpaceRichIviteType?) {
+        self.inviteType = inviteType
+        currentInvite = nil
+        shareLink = nil
+        inviteHeldByOwner = false
+        isSharedWithinSpace = false
     }
 }

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceProfile/SpaceProfileViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceProfile/SpaceProfileViewModel.swift
@@ -92,7 +92,7 @@ final class SpaceProfileViewModel {
         guard !linkUpdated else { return }
         defer { linkUpdated = true }
 
-        guard let invite = try? await workspaceService.getCurrentInvite(spaceId: workspaceInfo.accountSpaceId) else { return }
+        guard let invite = try? await workspaceService.getCurrentInvite(spaceId: workspaceInfo.accountSpaceId), invite.hasLink else { return }
         inviteLink = universalLinkParser.createUrl(link: .invite(cid: invite.cid, key: invite.fileKey))
     }
     

--- a/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/SpaceSettings/SpaceSettings/SpaceSettingsViewModel.swift
@@ -406,7 +406,7 @@ final class SpaceSettingsViewModel {
         guard !participantSpaceView.spaceView.isOneToOne else { return }
 
         let invite = try? await workspaceService.getCurrentInvite(spaceId: workspaceInfo.accountSpaceId)
-        if let invite {
+        if let invite, invite.hasLink {
             inviteLink = universalLinkParser.createUrl(link: .invite(cid: invite.cid, key: invite.fileKey))
         } else {
             inviteLink = nil

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Settings/ObjectSettings/ObjectSettingsViewModel.swift
@@ -399,7 +399,8 @@ final class ObjectSettingsViewModel {
         guard let details = document.details else { return }
 
         let invite = try? await workspaceService.getCurrentInvite(spaceId: details.spaceId)
-        let link = universalLinkParser.createUrl(link: .object(objectId: details.id, spaceId: details.spaceId, cid: invite?.cid, key: invite?.fileKey))
+        let hasLink = invite?.hasLink ?? false
+        let link = universalLinkParser.createUrl(link: .object(objectId: details.id, spaceId: details.spaceId, cid: hasLink ? invite?.cid : nil, key: hasLink ? invite?.fileKey : nil))
 
         UIPasteboard.general.string = link?.absoluteString
         toastData = ToastBarData(Loc.copied)

--- a/Anytype/Sources/ServiceLayer/PendingShare/PendingShareRetryService.swift
+++ b/Anytype/Sources/ServiceLayer/PendingShare/PendingShareRetryService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Factory
 import Services
+import ProtobufMessages
 
 protocol PendingShareServiceProtocol: AnyObject, Sendable {
     func savePendingAndRunChain(spaceId: String, identities: [PendingIdentity]) async
@@ -54,13 +55,22 @@ actor PendingShareService: PendingShareServiceProtocol {
         }
 
         if state.needsGenerateInvite {
+            // Members are added to the ACL directly; the invite only has to exist. Keep the owner's
+            // invite untouched and default new ones to request-to-join, held by the owner.
             do {
-                _ = try await workspaceService.generateInvite(spaceId: spaceId, inviteType: .withoutApprove, permissions: .writer)
-                state.needsGenerateInvite = false
-                storage.savePendingState(state)
+                _ = try await workspaceService.getCurrentInvite(spaceId: spaceId)
+            } catch let error as Anytype_Rpc.Space.InviteGetCurrent.Response.Error where error.code == .noActiveInvite {
+                do {
+                    _ = try await workspaceService.generateInvite(spaceId: spaceId, inviteType: .member, permissions: nil)
+                } catch {
+                    return
+                }
             } catch {
+                // Transient failure — retry the whole step later instead of risking a duplicate invite
                 return
             }
+            state.needsGenerateInvite = false
+            storage.savePendingState(state)
         }
 
         // Middleware participantsAddList is idempotent — re-sending already-added participants is a no-op.

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -2279,6 +2279,9 @@ public enum Loc {
         public static let subtitle = Loc.tr("Workspace", "Space.Invite.EditorAccess.Subtitle", fallback: "People with link can edit and write in chat")
         public static let title = Loc.tr("Workspace", "Space.Invite.EditorAccess.Title", fallback: "Editor access")
       }
+      public enum HeldByOwner {
+        public static let message = Loc.tr("Workspace", "Space.Invite.HeldByOwner.Message", fallback: "The invite link is held by the space owner. Ask them to share it.")
+      }
       public enum LinkDisabled {
         public static let subtitle = Loc.tr("Workspace", "Space.Invite.LinkDisabled.Subtitle", fallback: "Only already invited members have access")
         public static let title = Loc.tr("Workspace", "Space.Invite.LinkDisabled.Title", fallback: "Link disabled")
@@ -2287,9 +2290,24 @@ public enum Loc {
         public static let subtitle = Loc.tr("Workspace", "Space.Invite.RequestAccess.Subtitle", fallback: "Owner must approve each join request")
         public static let title = Loc.tr("Workspace", "Space.Invite.RequestAccess.Title", fallback: "Request access")
       }
+      public enum Reset {
+        public static let confirmMessage = Loc.tr("Workspace", "Space.Invite.Reset.ConfirmMessage", fallback: "The current link stops working for everyone who has it, including the people you meant to invite. A new link is created in its place.")
+        public static let title = Loc.tr("Workspace", "Space.Invite.Reset.Title", fallback: "Reset link")
+      }
+      public enum Share {
+        public static let confirmMessage = Loc.tr("Workspace", "Space.Invite.Share.ConfirmMessage", fallback: "All space members will be able to see this invite link and share it with anyone. To make it private again, you'll need to reset the link.")
+        public static let confirmTitle = Loc.tr("Workspace", "Space.Invite.Share.ConfirmTitle", fallback: "Share invite link")
+        public static let disabledReason = Loc.tr("Workspace", "Space.Invite.Share.DisabledReason", fallback: "Anyone with this link joins as an editor, without approval. Only you can share it.")
+        public static let lockedHint = Loc.tr("Workspace", "Space.Invite.Share.LockedHint", fallback: "To make it private again, you'll need to reset the link.")
+        public static let toggle = Loc.tr("Workspace", "Space.Invite.Share.Toggle", fallback: "Everyone in the space can share this invite")
+      }
       public enum ViewerAccess {
         public static let subtitle = Loc.tr("Workspace", "Space.Invite.ViewerAccess.Subtitle", fallback: "People with link can view and read chat")
         public static let title = Loc.tr("Workspace", "Space.Invite.ViewerAccess.Title", fallback: "Viewer access")
+      }
+      public enum Warning {
+        public static let autoApproval = Loc.tr("Workspace", "Space.Invite.Warning.AutoApproval", fallback: "Anyone who gains access to this invitation link will be able to join this space at any time, until you reset the link.")
+        public static let editorUpgrade = Loc.tr("Workspace", "Space.Invite.Warning.EditorUpgrade", fallback: "Any existing Viewer who gains access to this invitation link can use it to upgrade themselves to Editor.")
       }
     }
     public enum Notifications {

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -2280,7 +2280,7 @@ public enum Loc {
         public static let title = Loc.tr("Workspace", "Space.Invite.EditorAccess.Title", fallback: "Editor access")
       }
       public enum HeldByOwner {
-        public static let message = Loc.tr("Workspace", "Space.Invite.HeldByOwner.Message", fallback: "The invite link is held by the space owner. Ask them to share it.")
+        public static let message = Loc.tr("Workspace", "Space.Invite.HeldByOwner.Message", fallback: "The invite link is held by the channel owner. Ask them to share it.")
       }
       public enum LinkDisabled {
         public static let subtitle = Loc.tr("Workspace", "Space.Invite.LinkDisabled.Subtitle", fallback: "Only already invited members have access")
@@ -2292,21 +2292,23 @@ public enum Loc {
       }
       public enum Reset {
         public static let confirmMessage = Loc.tr("Workspace", "Space.Invite.Reset.ConfirmMessage", fallback: "The current link stops working for everyone who has it, including the people you meant to invite. A new link is created in its place.")
+        public static let confirmTitle = Loc.tr("Workspace", "Space.Invite.Reset.ConfirmTitle", fallback: "Reset invite link")
         public static let title = Loc.tr("Workspace", "Space.Invite.Reset.Title", fallback: "Reset link")
       }
       public enum Share {
-        public static let confirmMessage = Loc.tr("Workspace", "Space.Invite.Share.ConfirmMessage", fallback: "All space members will be able to see this invite link and share it with anyone. To make it private again, you'll need to reset the link.")
-        public static let confirmTitle = Loc.tr("Workspace", "Space.Invite.Share.ConfirmTitle", fallback: "Share invite link")
+        public static let confirmButton = Loc.tr("Workspace", "Space.Invite.Share.ConfirmButton", fallback: "Share invite")
+        public static let confirmMessage = Loc.tr("Workspace", "Space.Invite.Share.ConfirmMessage", fallback: "All channel members will be able to see this invite link and share it with anyone. To make it private again, you'll need to reset the link.")
+        public static let confirmTitle = Loc.tr("Workspace", "Space.Invite.Share.ConfirmTitle", fallback: "Share this invite with the channel?")
         public static let disabledReason = Loc.tr("Workspace", "Space.Invite.Share.DisabledReason", fallback: "Anyone with this link joins as an editor, without approval. Only you can share it.")
-        public static let lockedHint = Loc.tr("Workspace", "Space.Invite.Share.LockedHint", fallback: "To make it private again, you'll need to reset the link.")
-        public static let toggle = Loc.tr("Workspace", "Space.Invite.Share.Toggle", fallback: "Everyone in the space can share this invite")
+        public static let lockedHint = Loc.tr("Workspace", "Space.Invite.Share.LockedHint", fallback: "This invite is already shared. To take it back, reset the link.")
+        public static let toggle = Loc.tr("Workspace", "Space.Invite.Share.Toggle", fallback: "Everyone in the channel can share this invite")
       }
       public enum ViewerAccess {
         public static let subtitle = Loc.tr("Workspace", "Space.Invite.ViewerAccess.Subtitle", fallback: "People with link can view and read chat")
         public static let title = Loc.tr("Workspace", "Space.Invite.ViewerAccess.Title", fallback: "Viewer access")
       }
       public enum Warning {
-        public static let autoApproval = Loc.tr("Workspace", "Space.Invite.Warning.AutoApproval", fallback: "Anyone who gains access to this invitation link will be able to join this space at any time, until you reset the link.")
+        public static let autoApproval = Loc.tr("Workspace", "Space.Invite.Warning.AutoApproval", fallback: "Anyone who gains access to this invitation link will be able to join this channel at any time, until you reset the link.")
         public static let editorUpgrade = Loc.tr("Workspace", "Space.Invite.Warning.EditorUpgrade", fallback: "Any existing Viewer who gains access to this invitation link can use it to upgrade themselves to Editor.")
       }
     }

--- a/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
@@ -59741,7 +59741,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The invite link is held by the space owner. Ask them to share it."
+            "value" : "The invite link is held by the channel owner. Ask them to share it."
           }
         }
       }
@@ -60377,6 +60377,17 @@
         }
       }
     },
+    "Space.Invite.Reset.ConfirmTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset invite link"
+          }
+        }
+      }
+    },
     "Space.Invite.Reset.Title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -60388,13 +60399,24 @@
         }
       }
     },
+    "Space.Invite.Share.ConfirmButton" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share invite"
+          }
+        }
+      }
+    },
     "Space.Invite.Share.ConfirmMessage" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "All space members will be able to see this invite link and share it with anyone. To make it private again, you'll need to reset the link."
+            "value" : "All channel members will be able to see this invite link and share it with anyone. To make it private again, you'll need to reset the link."
           }
         }
       }
@@ -60405,7 +60427,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Share invite link"
+            "value" : "Share this invite with the channel?"
           }
         }
       }
@@ -60427,7 +60449,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "To make it private again, you'll need to reset the link."
+            "value" : "This invite is already shared. To take it back, reset the link."
           }
         }
       }
@@ -60438,7 +60460,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Everyone in the space can share this invite"
+            "value" : "Everyone in the channel can share this invite"
           }
         }
       }
@@ -60759,7 +60781,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Anyone who gains access to this invitation link will be able to join this space at any time, until you reset the link."
+            "value" : "Anyone who gains access to this invitation link will be able to join this channel at any time, until you reset the link."
           }
         }
       }

--- a/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/Workspace.xcstrings
@@ -59735,6 +59735,17 @@
         }
       }
     },
+    "Space.Invite.HeldByOwner.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The invite link is held by the space owner. Ask them to share it."
+          }
+        }
+      }
+    },
     "Space.Invite.LinkDisabled.Subtitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -60355,6 +60366,83 @@
         }
       }
     },
+    "Space.Invite.Reset.ConfirmMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The current link stops working for everyone who has it, including the people you meant to invite. A new link is created in its place."
+          }
+        }
+      }
+    },
+    "Space.Invite.Reset.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset link"
+          }
+        }
+      }
+    },
+    "Space.Invite.Share.ConfirmMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All space members will be able to see this invite link and share it with anyone. To make it private again, you'll need to reset the link."
+          }
+        }
+      }
+    },
+    "Space.Invite.Share.ConfirmTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share invite link"
+          }
+        }
+      }
+    },
+    "Space.Invite.Share.DisabledReason" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anyone with this link joins as an editor, without approval. Only you can share it."
+          }
+        }
+      }
+    },
+    "Space.Invite.Share.LockedHint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To make it private again, you'll need to reset the link."
+          }
+        }
+      }
+    },
+    "Space.Invite.Share.Toggle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Everyone in the space can share this invite"
+          }
+        }
+      }
+    },
     "Space.Invite.ViewerAccess.Subtitle" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -60661,6 +60749,28 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Viewer access"
+          }
+        }
+      }
+    },
+    "Space.Invite.Warning.AutoApproval" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anyone who gains access to this invitation link will be able to join this space at any time, until you reset the link."
+          }
+        }
+      }
+    },
+    "Space.Invite.Warning.EditorUpgrade" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Any existing Viewer who gains access to this invitation link can use it to upgrade themselves to Editor."
           }
         }
       }

--- a/Modules/Services/Sources/Models/Space/SpaceInvite.swift
+++ b/Modules/Services/Sources/Models/Space/SpaceInvite.swift
@@ -1,27 +1,32 @@
 import Foundation
 import ProtobufMessages
+import AnytypeCore
 
 public struct SpaceInvite: Sendable {
     public let cid: String
     public let fileKey: String
     public let inviteType: InviteType?
     public let permissions: InvitePermissions?
+    public let heldByOwner: Bool
+
+    // A member's InviteGetCurrent succeeds with an empty cid when the invite is held by the owner
+    public var hasLink: Bool { cid.isNotEmpty }
 }
 
 extension Anytype_Rpc.Space.InviteGenerate.Response {
-    func asModel() -> SpaceInvite {
-        return SpaceInvite(cid: inviteCid, fileKey: inviteFileKey, inviteType: inviteType, permissions: permissions)
+    func asModel(shareWithinSpace: Bool) -> SpaceInvite {
+        return SpaceInvite(cid: inviteCid, fileKey: inviteFileKey, inviteType: inviteType, permissions: permissions, heldByOwner: !shareWithinSpace)
     }
 }
 
 extension Anytype_Rpc.Space.InviteGetCurrent.Response {
     func asModel() -> SpaceInvite {
-        return SpaceInvite(cid: inviteCid, fileKey: inviteFileKey, inviteType: inviteType, permissions: permissions)
+        return SpaceInvite(cid: inviteCid, fileKey: inviteFileKey, inviteType: inviteType, permissions: permissions, heldByOwner: heldByOwner)
     }
 }
 
 extension Anytype_Rpc.Space.InviteGetGuest.Response {
     func asModel() -> SpaceInvite {
-        return SpaceInvite(cid: inviteCid, fileKey: inviteFileKey, inviteType: nil, permissions: nil)
+        return SpaceInvite(cid: inviteCid, fileKey: inviteFileKey, inviteType: nil, permissions: nil, heldByOwner: false)
     }
 }

--- a/Modules/Services/Sources/Services/Workspace/WorkspaceService.swift
+++ b/Modules/Services/Sources/Services/Workspace/WorkspaceService.swift
@@ -15,7 +15,7 @@ public protocol WorkspaceServiceProtocol: Sendable {
     func inviteView(cid: String, key: String) async throws -> SpaceInviteView
     func join(spaceId: String, cid: String, key: String, networkId: String) async throws
     func joinCancel(spaceId: String) async throws
-    func generateInvite(spaceId: String, inviteType: InviteType?, permissions: InvitePermissions?) async throws -> SpaceInvite
+    func generateInvite(spaceId: String, inviteType: InviteType?, permissions: InvitePermissions?, shareWithinSpace: Bool) async throws -> SpaceInvite
     func changeInvite(spaceId: String, permissions: InvitePermissions) async throws
     func revokeInvite(spaceId: String) async throws
     func stopSharing(spaceId: String) async throws
@@ -34,8 +34,8 @@ public protocol WorkspaceServiceProtocol: Sendable {
 }
 
 public extension WorkspaceServiceProtocol {
-    func generateInvite(spaceId: String) async throws -> SpaceInvite {
-        try await generateInvite(spaceId: spaceId, inviteType: nil, permissions: nil)
+    func generateInvite(spaceId: String, inviteType: InviteType?, permissions: InvitePermissions?) async throws -> SpaceInvite {
+        try await generateInvite(spaceId: spaceId, inviteType: inviteType, permissions: permissions, shareWithinSpace: false)
     }
 }
 
@@ -145,13 +145,14 @@ final class WorkspaceService: WorkspaceServiceProtocol {
         }).invoke()
     }
     
-    func generateInvite(spaceId: String, inviteType: InviteType?, permissions: InvitePermissions?) async throws -> SpaceInvite {
+    func generateInvite(spaceId: String, inviteType: InviteType?, permissions: InvitePermissions?, shareWithinSpace: Bool) async throws -> SpaceInvite {
         let result = try await ClientCommands.spaceInviteGenerate(.with {
             $0.spaceID = spaceId
             if let inviteType { $0.inviteType = inviteType }
             if let permissions { $0.permissions = permissions }
+            $0.shareWithinSpace = shareWithinSpace
         }).invoke()
-        return result.asModel()
+        return result.asModel(shareWithinSpace: shareWithinSpace)
     }
     
     func changeInvite(spaceId: String, permissions: InvitePermissions) async throws {


### PR DESCRIPTION
## Summary
- Integrate the new invite-sharing model (GO-7222, IOS-6269): invites are held by the owner by default; new share toggle publishes the invite to the space (one-way, confirmed, blocked for anyone-can-join Editor links), with Reset link as the only way back and auto-approval/editor-upgrade warnings per spec copy.
- Member devices with an owner-held invite see "link held by the space owner" instead of a link; all six secondary surfaces (chat QR, widgets header, space settings/profile, object/discussion copy-link) never render an empty-cid link.
- Add-contacts retry flow now generates a request-to-join invite only when none exists (was anyone-can-join + Writer), avoiding invite clobber and INVITE_ALREADY_SHARED aborts.