### PR TITLE
IOS-6592 Refresh live cell after paste 'Plain text' so it survives the identity fork

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockActionHandler.swift
@@ -49,6 +49,12 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
     // Set only for the trailing "tap to type" placeholder. While unmaterialized, mutating
     // paths must not target `info.id` — the block does not exist in the middleware yet.
     private let virtualBlockSession: (any VirtualTrailingBlockSessionProtocol)?
+    // Refreshes the live on-screen cell for a block id from current model state. After the
+    // empty-block identity fork or the virtual-placeholder materialization, the visible cell is
+    // a freshly built handler; this handler's own `resetSubject` drives the replaced (dead) cell.
+    // A programmatic text write from the paste menu must therefore refresh the live cell
+    // explicitly — this also re-syncs its text view before the next keystroke can read stale text.
+    private let reconfigureLiveBlock: @MainActor (String) -> Void
 
     @Injected(\.linkToSearchHelper)
     private var linkToSearchHelper: any LinkToSearchHelperProtocol
@@ -101,7 +107,8 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
         markupChanger: some BlockMarkupChangerProtocol,
         slashMenuActionHandler: SlashMenuActionHandler,
         openLinkToObject: @MainActor @escaping (LinkToObjectSearchModuleData) -> Void,
-        virtualBlockSession: (any VirtualTrailingBlockSessionProtocol)? = nil
+        virtualBlockSession: (any VirtualTrailingBlockSessionProtocol)? = nil,
+        reconfigureLiveBlock: @MainActor @escaping (String) -> Void = { _ in }
     ) {
         self.document = document
         self.info = info
@@ -129,6 +136,7 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
         self.slashMenuActionHandler = slashMenuActionHandler
         self.openLinkToObject = openLinkToObject
         self.virtualBlockSession = virtualBlockSession
+        self.reconfigureLiveBlock = reconfigureLiveBlock
     }
 
     // MARK: - Virtual trailing block
@@ -499,9 +507,9 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
                             range: range
                         )
                         if let newText {
-                            self?.setNewTextSync(attributedString: newText)
+                            self?.setNewTextRefreshingLiveBlock(attributedString: newText)
                         }
-                        
+
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             SharingTip.didCopyText = true
                         }
@@ -903,5 +911,18 @@ extension TextBlockActionHandler: AccessoryViewOutput {
 
     private func setNewTextSync(attributedString: NSAttributedString) {
         Task { try await setNewText(attributedString: attributedString.sendable()) }
+    }
+
+    /// Like `setNewTextSync`, but after the write refreshes the live cell for the current block id.
+    /// The paste-menu callbacks run on the pre-fork handler: if the empty-block identity fork or the
+    /// virtual-placeholder materialization has swapped this block's identity, `setNewText`'s
+    /// `resetSubject` only reaches this handler's now-replaced cell. Reconfiguring the live cell from
+    /// the freshly written model both shows the new value and re-syncs its text view, so the next
+    /// keystroke cannot read the stale link back and overwrite the plain text.
+    private func setNewTextRefreshingLiveBlock(attributedString: NSAttributedString) {
+        Task { @MainActor in
+            try await setNewText(attributedString: attributedString.sendable())
+            reconfigureLiveBlock(info.id)
+        }
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelBuilder.swift
@@ -220,7 +220,11 @@ final class BlockViewModelBuilder {
             openLinkToObject: { [weak self] data in
                 self?.output?.showLinkToObject(data: data)
             },
-            virtualBlockSession: virtualBlockSession
+            virtualBlockSession: virtualBlockSession,
+            reconfigureLiveBlock: { [weak modelsHolder, weak blockCollectionController] blockId in
+                guard let model = modelsHolder?.blocksMapping[blockId] else { return }
+                blockCollectionController?.reconfigure(items: [.block(model)])
+            }
         )
         let viewModel = TextBlockViewModel(
             document: document,


### PR DESCRIPTION
## Summary
- Port of #5074 to `release`: choosing **Plain text** in the "Paste as" menu on an empty / trailing "tap to type" block did nothing — the eager link preview forks the block identity, and `pasteAsText`'s refresh only reached the dead pre-fork cell. The fix reconfigures the live cell for the current block id after the write, which also re-syncs the text view so the next keystroke can't restore the stale link.
- Middleware v0.50.17 is already on `release` (#5073), so no `Libraryfile` change is needed here.