### PR TITLE
IOS-6579 Restore collapsing object header on Kanban board

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/ScrollAxisLock.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/ScrollAxisLock.swift
@@ -66,6 +66,7 @@ private final class ScrollAxisLockUIView: UIView {
 private final class CrossAxisDragGate: UIGestureRecognizer {
     private let scrollAxis: Axis
     private var startLocation = CGPoint.zero
+    private var stationaryHoldTimeout: DispatchWorkItem?
 
     init(scrollAxis: Axis) {
         self.scrollAxis = scrollAxis
@@ -83,6 +84,18 @@ private final class CrossAxisDragGate: UIGestureRecognizer {
             return
         }
         startLocation = touch.location(in: view)
+
+        // A press that hasn't moved is not a scroll - fail before the system's ~0.5s
+        // drag-lift/context-menu timers, or anything made to wait for this gate's resolution
+        // (it otherwise resolves only on movement or touch end) never fires on a long press.
+        let timeout = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, self.state == .possible else { return }
+                self.state = .failed
+            }
+        }
+        stationaryHoldTimeout = timeout
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.stationaryHoldTimeout, execute: timeout)
     }
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
@@ -112,6 +125,12 @@ private final class CrossAxisDragGate: UIGestureRecognizer {
         state = state == .began ? .cancelled : .failed
     }
 
+    override func reset() {
+        super.reset()
+        stationaryHoldTimeout?.cancel()
+        stationaryHoldTimeout = nil
+    }
+
     // A gate that can't be the wrong gate: a scroll view with nothing to scroll along its axis
     // needs no arbitration, and neither does one we attached to by mistake.
     private var canScrollAlongAxis: Bool {
@@ -132,5 +151,8 @@ private final class CrossAxisDragGate: UIGestureRecognizer {
 private extension CrossAxisDragGate {
     enum Constants {
         static let directionThreshold: CGFloat = 6
+        // Below the ~0.5s system long-press timers, above any hesitation between touch-down
+        // and the start of a deliberate swipe.
+        static let stationaryHoldTimeout: TimeInterval = 0.3
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetView.swift
@@ -114,7 +114,8 @@ struct EditorSetView: View {
                 model: model,
                 tableHeaderSize: $tableHeaderSize,
                 offset: $offset,
-                headerMinimizedSize: headerMinimizedSize
+                headerMinimizedSize: headerMinimizedSize,
+                fullHeaderHeight: tableHeaderFullSize.height
             )
         }
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel+DragAndDropDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel+DragAndDropDelegate.swift
@@ -35,6 +35,17 @@ extension EditorSetViewModel: SetDragAndDropDelegate {
         revertOptimisticCardMoves()
     }
 
+    // Menu-driven variant of a drag to another column: same optimistic move to the target's
+    // end, same persistence and revert-on-failure path.
+    func moveCard(_ configurationId: String, fromGroupId: String, toGroupId: String) {
+        guard canDragCards, fromGroupId != toGroupId else { return }
+        onDrag(
+            from: SetDragAndDropConfiguration(groupId: fromGroupId, configurationId: configurationId),
+            to: SetDragAndDropConfiguration(groupId: toGroupId, configurationId: nil)
+        )
+        _ = onDrop(configurationId: configurationId, fromGroupId: fromGroupId, toGroupId: toGroupId)
+    }
+
     func onDrop(configurationId: String, fromGroupId: String, toGroupId: String) -> Bool {
         guard canDragCards else {
             revertOptimisticCardMoves()

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
@@ -5,12 +5,15 @@ import UIKit
 ///
 /// The board has no whole-page vertical scroll. Every column reserves the collapse distance with
 /// a transparent top spacer in its scroll content, and the column the user is scrolling becomes
-/// the driver: its offset is mirrored 1:1 into `headerTravel`, which positions the shared object
-/// header — including past the collapse point, so continued card scrolling slides the header
-/// fully off-screen the way the other view types do (stopping at the collapse point would leave
-/// the header's bottom parked behind the translucent nav bar). All other columns are kept
-/// scrolled at least to the collapse point, so switching to them never reveals the reserved
-/// spacer as a hole; columns scrolled deeper keep their position.
+/// the driver: its scroll *deltas* move `headerTravel`, which positions the shared object
+/// header. Deltas, not absolute offsets - a column scrolled deeper than the page must not make
+/// the header jump to its depth the moment it starts driving, and dragging any column down with
+/// the header already expanded must scroll only that column's cards.
+///
+/// Columns sitting exactly on the page line follow it in both directions - that is the
+/// whole-page scroll illusion, and it is what brings every synced column back to its own top
+/// when the page re-expands. Columns scrolled deeper keep their position until the page line
+/// catches them.
 ///
 /// TODO: IOS-6595 - the introspection + KVO + setContentOffset plumbing exists only because
 /// SwiftUI on iOS 17 exposes neither scroll offsets nor pixel-level scroll control. Once the
@@ -28,31 +31,28 @@ final class KanbanCollapseCoordinator {
     }
 
     private var entries = [ObjectIdentifier: Entry]()
-    // The settle point: settings row rests at the top, followers are synced to at least this.
+    // The settle point: the settings row rests at the top once the page has collapsed this far.
     private var collapseDistance: CGFloat = 0
     // The travel at which the object header is fully off-screen; tracking stops there so deep
     // card scrolling doesn't publish useless updates.
     private var headerTravelDistance: CGFloat = 0
-    private var collapse: CGFloat = 0
     private weak var driver: UIScrollView?
     private var isSyncing = false
+
+    // The page line: how far the settings row and page-locked columns have collapsed. Header
+    // travel beyond it only slides the header's remainder out from behind the nav bar.
+    private var pageCollapse: CGFloat {
+        min(max(headerTravel, 0), collapseDistance)
+    }
 
     func setDistances(collapse collapseDistance: CGFloat, headerTravel headerTravelDistance: CGFloat) {
         self.collapseDistance = max(collapseDistance, 0)
         self.headerTravelDistance = max(headerTravelDistance, self.collapseDistance)
-
-        let clampedTravel = min(headerTravel, self.headerTravelDistance)
-        let clampedCollapse = min(max(clampedTravel, 0), self.collapseDistance)
-        guard clampedTravel != headerTravel || clampedCollapse != collapse else { return }
-        headerTravel = clampedTravel
-        collapse = clampedCollapse
-        syncFollowers(except: nil)
-        onHeaderTravelChange?(headerTravel)
+        applyTravel(min(headerTravel, self.headerTravelDistance), driver: nil)
     }
 
     func reset() {
         headerTravel = 0
-        collapse = 0
         driver = nil
     }
 
@@ -62,74 +62,125 @@ final class KanbanCollapseCoordinator {
         let id = ObjectIdentifier(scrollView)
         guard entries[id] == nil else { return }
 
-        let observation = scrollView.observe(\.contentOffset) { [weak self] scrollView, _ in
-            guard let self else { return }
+        let observation = scrollView.observe(\.contentOffset, options: [.old, .new]) { [weak self] scrollView, change in
+            guard let self, let old = change.oldValue, let new = change.newValue else { return }
             // UIScrollView reports contentOffset changes on the main thread.
             MainActor.assumeIsolated {
-                self.offsetChanged(scrollView)
+                self.offsetChanged(scrollView, delta: new.y - old.y)
             }
         }
         entries[id] = Entry(scrollView: scrollView, observation: observation)
 
         // A column materialized mid-collapse starts at zero offset; consume its spacer right
         // away so it doesn't show a hole where the header used to be.
-        followIfBehind(scrollView)
+        catchUp(scrollView)
     }
 
-    private func offsetChanged(_ scrollView: UIScrollView) {
+    private func offsetChanged(_ scrollView: UIScrollView, delta: CGFloat) {
         guard !isSyncing else { return }
 
         let fingerDriven = scrollView.isTracking || scrollView.isDragging
         let isActive = fingerDriven || scrollView.isDecelerating
 
-        if isActive {
-            let driverFingerDriven = driver.map { $0.isTracking || $0.isDragging } ?? false
-            // A merely decelerating column can't steal the header from a finger-driven one.
-            if fingerDriven || driver == nil || driver === scrollView || !driverFingerDriven {
-                driver = scrollView
-            }
+        if fingerDriven {
+            claimDriver(scrollView)
+        } else if isActive, driver == nil {
+            // Deceleration without a driver only happens if the driving column was deallocated.
+            driver = scrollView
         }
 
-        if driver === scrollView, isActive {
-            // Raw below zero so the header follows the driver's rubber band 1:1, capped once
-            // the header is fully off-screen.
-            let travel = min(relativeOffset(scrollView), headerTravelDistance)
-            guard travel != headerTravel else { return }
-            headerTravel = travel
-
-            let newCollapse = min(max(travel, 0), collapseDistance)
-            if newCollapse != collapse {
-                collapse = newCollapse
-                syncFollowers(except: scrollView)
+        guard driver === scrollView, isActive else {
+            if !fingerDriven {
+                catchUp(scrollView)
             }
-            onHeaderTravelChange?(travel)
-        } else if !fingerDriven {
-            // Programmatic or layout-induced movement (lazy content sizing, drag auto-scroll):
-            // the no-hole invariant still applies.
-            followIfBehind(scrollView)
+            return
         }
+
+        let rel = relativeOffset(scrollView)
+        var newTravel = headerTravel
+        // Upward deltas coming out of the top rubber band are dropped: the snap-back must not
+        // re-collapse what the stretch just expanded, or a column with no scroll range left
+        // could never finish expanding the header.
+        if delta < 0 || rel - delta >= 0 {
+            newTravel += delta
+        }
+        newTravel = min(newTravel, headerTravelDistance)
+        // Floor at zero - except a column rubber-banding at its own top drags the header down
+        // with it 1:1 (and back), like the other view types' bounce.
+        newTravel = max(newTravel, min(rel, 0))
+        applyTravel(newTravel, driver: scrollView)
     }
 
-    private func syncFollowers(except driver: UIScrollView?) {
+    private func applyTravel(_ newTravel: CGFloat, driver: UIScrollView?) {
+        guard newTravel != headerTravel else { return }
+        let oldPage = pageCollapse
+        headerTravel = newTravel
+        let newPage = pageCollapse
+        if newPage != oldPage {
+            syncColumns(oldPage: oldPage, newPage: newPage, except: driver)
+        }
+        onHeaderTravelChange?(newTravel)
+    }
+
+    private func syncColumns(oldPage: CGFloat, newPage: CGFloat, except driver: UIScrollView?) {
         for entry in entries.values {
             guard
                 let scrollView = entry.scrollView,
                 scrollView !== driver,
                 !scrollView.isTracking, !scrollView.isDragging
             else { continue }
-            followIfBehind(scrollView)
+            let rel = relativeOffset(scrollView)
+            // Columns on the page line move with it in both directions; columns behind the new
+            // line are caught up so their spacer never shows as a hole; deeper columns keep
+            // their position until the line reaches them (Trello-style persistence).
+            if abs(rel - oldPage) <= Constants.lockTolerance || rel < newPage {
+                scroll(scrollView, to: max(newPage, 0))
+            }
         }
     }
 
-    private func followIfBehind(_ scrollView: UIScrollView) {
-        guard relativeOffset(scrollView) < collapse else { return }
+    private func catchUp(_ scrollView: UIScrollView) {
+        let page = pageCollapse
+        guard relativeOffset(scrollView) < page - Constants.lockTolerance else { return }
+        scroll(scrollView, to: page)
+    }
+
+    private func scroll(_ scrollView: UIScrollView, to rel: CGFloat) {
         isSyncing = true
-        scrollView.contentOffset.y = collapse - scrollView.adjustedContentInset.top
+        // setContentOffset (not a plain assignment) also kills any in-flight deceleration, so a
+        // synced column doesn't keep drifting and fight the correction.
+        let target = CGPoint(
+            x: scrollView.contentOffset.x,
+            y: rel - scrollView.adjustedContentInset.top
+        )
+        scrollView.setContentOffset(target, animated: false)
         isSyncing = false
+    }
+
+    // Only finger contact claims the header - a decelerating column never takes it back. The
+    // previous driver's fling is stopped dead (the same way a scroll view's own deceleration
+    // ends the moment you touch it): without this, two decelerating columns both feed deltas
+    // into the header and it flickers.
+    private func claimDriver(_ scrollView: UIScrollView) {
+        guard driver !== scrollView else { return }
+        if let previous = driver, previous.isDecelerating {
+            isSyncing = true
+            previous.setContentOffset(previous.contentOffset, animated: false)
+            isSyncing = false
+        }
+        driver = scrollView
     }
 
     private func relativeOffset(_ scrollView: UIScrollView) -> CGFloat {
         scrollView.contentOffset.y + scrollView.adjustedContentInset.top
+    }
+}
+
+private extension KanbanCollapseCoordinator {
+    enum Constants {
+        // Columns are placed on the page line by our own setContentOffset, so matches are
+        // near-exact; the tolerance only absorbs float noise.
+        static let lockTolerance: CGFloat = 1
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+import UIKit
+
+/// Drives the shared collapsing object header from the kanban columns' own scroll views.
+///
+/// The board has no whole-page vertical scroll. Every column reserves the collapse distance with
+/// a transparent top spacer in its scroll content, and the column the user is scrolling becomes
+/// the driver: its offset is mirrored 1:1 into `headerTravel`, which positions the shared object
+/// header — including past the collapse point, so continued card scrolling slides the header
+/// fully off-screen the way the other view types do (stopping at the collapse point would leave
+/// the header's bottom parked behind the translucent nav bar). All other columns are kept
+/// scrolled at least to the collapse point, so switching to them never reveals the reserved
+/// spacer as a hole; columns scrolled deeper keep their position.
+///
+/// TODO: IOS-6595 - the introspection + KVO + setContentOffset plumbing exists only because
+/// SwiftUI on iOS 17 exposes neither scroll offsets nor pixel-level scroll control. Once the
+/// deployment target reaches iOS 18, replace it with `onScrollGeometryChange` (observation),
+/// `onScrollPhaseChange` (driver detection) and `ScrollPosition` (follower sync), and delete
+/// `kanbanCollapseSync`. The driver/follower rules stay as they are.
+@MainActor
+final class KanbanCollapseCoordinator {
+    var onHeaderTravelChange: ((CGFloat) -> Void)?
+    private(set) var headerTravel: CGFloat = 0
+
+    private struct Entry {
+        weak var scrollView: UIScrollView?
+        let observation: NSKeyValueObservation
+    }
+
+    private var entries = [ObjectIdentifier: Entry]()
+    // The settle point: settings row rests at the top, followers are synced to at least this.
+    private var collapseDistance: CGFloat = 0
+    // The travel at which the object header is fully off-screen; tracking stops there so deep
+    // card scrolling doesn't publish useless updates.
+    private var headerTravelDistance: CGFloat = 0
+    private var collapse: CGFloat = 0
+    private weak var driver: UIScrollView?
+    private var isSyncing = false
+
+    func setDistances(collapse collapseDistance: CGFloat, headerTravel headerTravelDistance: CGFloat) {
+        self.collapseDistance = max(collapseDistance, 0)
+        self.headerTravelDistance = max(headerTravelDistance, self.collapseDistance)
+
+        let clampedTravel = min(headerTravel, self.headerTravelDistance)
+        let clampedCollapse = min(max(clampedTravel, 0), self.collapseDistance)
+        guard clampedTravel != headerTravel || clampedCollapse != collapse else { return }
+        headerTravel = clampedTravel
+        collapse = clampedCollapse
+        syncFollowers(except: nil)
+        onHeaderTravelChange?(headerTravel)
+    }
+
+    func reset() {
+        headerTravel = 0
+        collapse = 0
+        driver = nil
+    }
+
+    func register(_ scrollView: UIScrollView) {
+        entries = entries.filter { $0.value.scrollView != nil }
+
+        let id = ObjectIdentifier(scrollView)
+        guard entries[id] == nil else { return }
+
+        let observation = scrollView.observe(\.contentOffset) { [weak self] scrollView, _ in
+            guard let self else { return }
+            // UIScrollView reports contentOffset changes on the main thread.
+            MainActor.assumeIsolated {
+                self.offsetChanged(scrollView)
+            }
+        }
+        entries[id] = Entry(scrollView: scrollView, observation: observation)
+
+        // A column materialized mid-collapse starts at zero offset; consume its spacer right
+        // away so it doesn't show a hole where the header used to be.
+        followIfBehind(scrollView)
+    }
+
+    private func offsetChanged(_ scrollView: UIScrollView) {
+        guard !isSyncing else { return }
+
+        let fingerDriven = scrollView.isTracking || scrollView.isDragging
+        let isActive = fingerDriven || scrollView.isDecelerating
+
+        if isActive {
+            let driverFingerDriven = driver.map { $0.isTracking || $0.isDragging } ?? false
+            // A merely decelerating column can't steal the header from a finger-driven one.
+            if fingerDriven || driver == nil || driver === scrollView || !driverFingerDriven {
+                driver = scrollView
+            }
+        }
+
+        if driver === scrollView, isActive {
+            // Raw below zero so the header follows the driver's rubber band 1:1, capped once
+            // the header is fully off-screen.
+            let travel = min(relativeOffset(scrollView), headerTravelDistance)
+            guard travel != headerTravel else { return }
+            headerTravel = travel
+
+            let newCollapse = min(max(travel, 0), collapseDistance)
+            if newCollapse != collapse {
+                collapse = newCollapse
+                syncFollowers(except: scrollView)
+            }
+            onHeaderTravelChange?(travel)
+        } else if !fingerDriven {
+            // Programmatic or layout-induced movement (lazy content sizing, drag auto-scroll):
+            // the no-hole invariant still applies.
+            followIfBehind(scrollView)
+        }
+    }
+
+    private func syncFollowers(except driver: UIScrollView?) {
+        for entry in entries.values {
+            guard
+                let scrollView = entry.scrollView,
+                scrollView !== driver,
+                !scrollView.isTracking, !scrollView.isDragging
+            else { continue }
+            followIfBehind(scrollView)
+        }
+    }
+
+    private func followIfBehind(_ scrollView: UIScrollView) {
+        guard relativeOffset(scrollView) < collapse else { return }
+        isSyncing = true
+        scrollView.contentOffset.y = collapse - scrollView.adjustedContentInset.top
+        isSyncing = false
+    }
+
+    private func relativeOffset(_ scrollView: UIScrollView) -> CGFloat {
+        scrollView.contentOffset.y + scrollView.adjustedContentInset.top
+    }
+}
+
+extension View {
+    /// Registers the enclosing scroll view as one of the kanban columns driving the header
+    /// collapse. Apply to the column scroll view's *content*, like `scrollAxisLock`.
+    func kanbanCollapseSync(_ coordinator: KanbanCollapseCoordinator) -> some View {
+        background(KanbanCollapseSyncView(coordinator: coordinator))
+    }
+}
+
+private struct KanbanCollapseSyncView: UIViewRepresentable {
+    let coordinator: KanbanCollapseCoordinator
+
+    func makeUIView(context: Context) -> UIView {
+        KanbanCollapseSyncUIView(coordinator: coordinator)
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}
+
+private final class KanbanCollapseSyncUIView: UIView {
+    private let coordinator: KanbanCollapseCoordinator
+
+    init(coordinator: KanbanCollapseCoordinator) {
+        self.coordinator = coordinator
+        super.init(frame: .zero)
+        isUserInteractionEnabled = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard window != nil, let scrollView = enclosingScrollView else { return }
+        coordinator.register(scrollView)
+    }
+
+    private var enclosingScrollView: UIScrollView? {
+        var ancestor: UIView? = superview
+        while let current = ancestor {
+            if let scrollView = current as? UIScrollView { return scrollView }
+            ancestor = current.superview
+        }
+        return nil
+    }
+}

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
@@ -13,7 +13,8 @@ import UIKit
 /// Columns sitting exactly on the page line follow it in both directions - that is the
 /// whole-page scroll illusion, and it is what brings every synced column back to its own top
 /// when the page re-expands. Columns scrolled deeper keep their position until the page line
-/// catches them.
+/// catches them. Over-dragging past fully expanded stretches the whole board down as one sheet,
+/// like the other view types' rubber band.
 ///
 /// TODO: IOS-6595 - the introspection + KVO + setContentOffset plumbing exists only because
 /// SwiftUI on iOS 17 exposes neither scroll offsets nor pixel-level scroll control. Once the
@@ -40,9 +41,10 @@ final class KanbanCollapseCoordinator {
     private var isSyncing = false
 
     // The page line: how far the settings row and page-locked columns have collapsed. Header
-    // travel beyond it only slides the header's remainder out from behind the nav bar.
+    // travel beyond it only slides the header's remainder out from behind the nav bar. Negative
+    // is the over-drag stretch: the whole board follows the rubber band down as one sheet.
     private var pageCollapse: CGFloat {
-        min(max(headerTravel, 0), collapseDistance)
+        min(headerTravel, collapseDistance)
     }
 
     func setDistances(collapse collapseDistance: CGFloat, headerTravel headerTravelDistance: CGFloat) {
@@ -130,11 +132,19 @@ final class KanbanCollapseCoordinator {
                 !scrollView.isTracking, !scrollView.isDragging
             else { continue }
             let rel = relativeOffset(scrollView)
-            // Columns on the page line move with it in both directions; columns behind the new
-            // line are caught up so their spacer never shows as a hole; deeper columns keep
-            // their position until the line reaches them (Trello-style persistence).
+            // Columns on the page line move with it in both directions (into the over-drag
+            // stretch too); columns behind the new line are caught up so their spacer never
+            // shows as a hole; deeper columns keep their position until the line reaches them
+            // (Trello-style persistence)...
             if abs(rel - oldPage) <= Constants.lockTolerance || rel < newPage {
-                scroll(scrollView, to: max(newPage, 0))
+                scroll(scrollView, to: newPage)
+            } else {
+                // ...except during the stretch, where they too move with the sheet. The shift
+                // telescopes back to zero as the bounce settles, so their position is kept.
+                let stretchShift = min(newPage, 0) - min(oldPage, 0)
+                if stretchShift != 0 {
+                    scroll(scrollView, to: rel + stretchShift)
+                }
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
@@ -13,8 +13,10 @@ import UIKit
 /// Columns sitting exactly on the page line follow it in both directions - that is the
 /// whole-page scroll illusion, and it is what brings every synced column back to its own top
 /// when the page re-expands. Columns scrolled deeper keep their position until the page line
-/// catches them. Over-dragging past fully expanded stretches the whole board down as one sheet,
-/// like the other view types' rubber band.
+/// catches them. Over-dragging past fully expanded bounces only the dragged column under a
+/// static header: followers cannot mirror a rubber band (UIKit re-clamps a non-interacting
+/// scroll view's out-of-range offset on every layout pass, which reads as flicker), so the
+/// header does not follow it either.
 ///
 /// TODO: IOS-6595 - the introspection + KVO + setContentOffset plumbing exists only because
 /// SwiftUI on iOS 17 exposes neither scroll offsets nor pixel-level scroll control. Once the
@@ -41,10 +43,9 @@ final class KanbanCollapseCoordinator {
     private var isSyncing = false
 
     // The page line: how far the settings row and page-locked columns have collapsed. Header
-    // travel beyond it only slides the header's remainder out from behind the nav bar. Negative
-    // is the over-drag stretch: the whole board follows the rubber band down as one sheet.
+    // travel beyond it only slides the header's remainder out from behind the nav bar.
     private var pageCollapse: CGFloat {
-        min(headerTravel, collapseDistance)
+        min(max(headerTravel, 0), collapseDistance)
     }
 
     func setDistances(collapse collapseDistance: CGFloat, headerTravel headerTravelDistance: CGFloat) {
@@ -106,11 +107,7 @@ final class KanbanCollapseCoordinator {
         if delta < 0 || rel - delta >= 0 {
             newTravel += delta
         }
-        newTravel = min(newTravel, headerTravelDistance)
-        // Floor at zero - except a column rubber-banding at its own top drags the header down
-        // with it 1:1 (and back), like the other view types' bounce.
-        newTravel = max(newTravel, min(rel, 0))
-        applyTravel(newTravel, driver: scrollView)
+        applyTravel(min(max(newTravel, 0), headerTravelDistance), driver: scrollView)
     }
 
     private func applyTravel(_ newTravel: CGFloat, driver: UIScrollView?) {
@@ -132,19 +129,11 @@ final class KanbanCollapseCoordinator {
                 !scrollView.isTracking, !scrollView.isDragging
             else { continue }
             let rel = relativeOffset(scrollView)
-            // Columns on the page line move with it in both directions (into the over-drag
-            // stretch too); columns behind the new line are caught up so their spacer never
-            // shows as a hole; deeper columns keep their position until the line reaches them
-            // (Trello-style persistence)...
+            // Columns on the page line move with it in both directions; columns behind the new
+            // line are caught up so their spacer never shows as a hole; deeper columns keep
+            // their position until the line reaches them (Trello-style persistence).
             if abs(rel - oldPage) <= Constants.lockTolerance || rel < newPage {
                 scroll(scrollView, to: newPage)
-            } else {
-                // ...except during the stretch, where they too move with the sheet. The shift
-                // telescopes back to zero as the bounce settles, so their position is kept.
-                let stretchShift = min(newPage, 0) - min(oldPage, 0)
-                if stretchShift != 0 {
-                    scroll(scrollView, to: rel + stretchShift)
-                }
             }
         }
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
@@ -60,6 +60,8 @@ final class KanbanCollapseCoordinator {
     }
 
     func register(_ scrollView: UIScrollView) {
+        // Backstop for teardown paths that skip `unregister` - the observation token holds the
+        // scroll view weakly, so entries of deallocated columns prune here.
         entries = entries.filter { $0.value.scrollView != nil }
 
         let id = ObjectIdentifier(scrollView)
@@ -77,6 +79,13 @@ final class KanbanCollapseCoordinator {
         // A column materialized mid-collapse starts at zero offset; consume its spacer right
         // away so it doesn't show a hole where the header used to be.
         catchUp(scrollView)
+    }
+
+    func unregister(_ scrollView: UIScrollView) {
+        entries.removeValue(forKey: ObjectIdentifier(scrollView))?.observation.invalidate()
+        if driver === scrollView {
+            driver = nil
+        }
     }
 
     private func offsetChanged(_ scrollView: UIScrollView, delta: CGFloat) {
@@ -203,6 +212,7 @@ private struct KanbanCollapseSyncView: UIViewRepresentable {
 
 private final class KanbanCollapseSyncUIView: UIView {
     private let coordinator: KanbanCollapseCoordinator
+    private weak var registeredScrollView: UIScrollView?
 
     init(coordinator: KanbanCollapseCoordinator) {
         self.coordinator = coordinator
@@ -216,8 +226,16 @@ private final class KanbanCollapseSyncUIView: UIView {
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
-        guard window != nil, let scrollView = enclosingScrollView else { return }
-        coordinator.register(scrollView)
+        if window != nil {
+            guard let scrollView = enclosingScrollView else { return }
+            registeredScrollView = scrollView
+            coordinator.register(scrollView)
+        } else if let scrollView = registeredScrollView {
+            // Deterministic cleanup on teardown and on the whole board leaving the window
+            // (navigation push); reattachment re-registers and catches the column up.
+            registeredScrollView = nil
+            coordinator.unregister(scrollView)
+        }
     }
 
     private var enclosingScrollView: UIScrollView? {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
@@ -9,34 +9,104 @@ struct SetKanbanView: View {
     @Binding var offset: CGPoint
 
     @State private var dropData = SetCardDropData()
+    @State private var headerTravel: CGFloat = 0
+    @State private var settingsHeaderSize = CGSize.zero
+    @State private var collapseCoordinator = KanbanCollapseCoordinator()
 
     var headerMinimizedSize: CGSize
+    // Full object header height including the top safe area - the travel at which the header
+    // has slid completely off-screen.
+    var fullHeaderHeight: CGFloat
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer.fixedHeight(max(tableHeaderSize.height - headerMinimizedSize.height, 0))
-            if !model.isEmptyViews {
-                compoundHeader
-                boardView
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .onAppear {
+                collapseCoordinator.onHeaderTravelChange = { travel in
+                    headerTravel = travel
+                    offset = CGPoint(x: 0, y: -travel)
+                }
             }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .onAppear {
-            // The board doesn't scroll vertically as a whole, so the shared
-            // offset must be reset after switching from a scrolled view type.
-            offset = .zero
-        }
+            .onDisappear {
+                // The closure captures the view, whose @State storage owns the coordinator -
+                // break the cycle or the coordinator outlives the board.
+                collapseCoordinator.onHeaderTravelChange = nil
+            }
+            .onChange(of: collapseDistance, initial: true) { _, _ in
+                updateCoordinatorDistances()
+            }
+            .onChange(of: fullHeaderHeight) { _, _ in
+                updateCoordinatorDistances()
+            }
+            .onChange(of: showsBoard, initial: true) { _, showsBoard in
+                if showsBoard {
+                    offset = CGPoint(x: 0, y: -headerTravel)
+                } else {
+                    collapseCoordinator.reset()
+                    headerTravel = 0
+                    offset = .zero
+                }
+            }
+    }
+
+    // The distance the page must scroll before the settings row rests at the top. The object
+    // header keeps sliding past this point (up to fullHeaderHeight) as cards scroll on.
+    private var collapseDistance: CGFloat {
+        max(tableHeaderSize.height - headerMinimizedSize.height, 0)
+    }
+
+    private func updateCoordinatorDistances() {
+        collapseCoordinator.setDistances(collapse: collapseDistance, headerTravel: fullHeaderHeight)
+    }
+
+    private var showsBoard: Bool {
+        !model.isEmptyViews && model.boardState == .ready
     }
 
     @ViewBuilder
-    private var boardView: some View {
-        switch model.boardState {
-        case .loading:
-            loadingView
-        case .error:
-            errorView
-        case .ready:
-            boardContent
+    private var content: some View {
+        if showsBoard {
+            board
+        } else {
+            staticHeader
+        }
+    }
+
+    // Loading/error/empty states have no columns to drive the collapse, so the header stays
+    // expanded and the settings row keeps its resting position below it.
+    private var staticHeader: some View {
+        VStack(spacing: 0) {
+            Spacer.fixedHeight(collapseDistance)
+            if !model.isEmptyViews {
+                compoundHeader
+                switch model.boardState {
+                case .loading:
+                    loadingView
+                case .error:
+                    errorView
+                case .ready:
+                    EmptyView()
+                }
+            }
+        }
+    }
+
+    // The board never scrolls vertically as a page. Each column reserves `collapseDistance`
+    // points with a top spacer inside its own scroll content, the actively scrolled column
+    // publishes the shared `headerTravel`, and the settings row + object header are overlays
+    // slaved to it - so the whole page visually scrolls as one, like the other view types.
+    private var board: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .top) {
+                boardContent(viewportHeight: geometry.size.height)
+                    .padding(.top, settingsHeaderSize.height)
+
+                compoundHeader
+                    .readSize { settingsHeaderSize = $0 }
+                    // Stops at the top once the collapse is consumed; follows the driver's
+                    // rubber band below zero so the whole page bounces as one, like Grid.
+                    .offset(y: collapseDistance - min(headerTravel, collapseDistance))
+            }
         }
     }
 
@@ -59,7 +129,7 @@ struct SetKanbanView: View {
         .padding(.top, 60)
     }
 
-    private var boardContent: some View {
+    private func boardContent(viewportHeight: CGFloat) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(alignment: .top, spacing: 8) {
                 ForEach(model.configurationsDict.keys, id: \.self) { groupId in
@@ -72,6 +142,9 @@ struct SetKanbanView: View {
                             isGroupBackgroundColors: model.isGroupBackgroundColors,
                             backgroundColor: model.groupBackgroundColor(for: groupId),
                             showPagingView: model.pagitationData(by: groupId).pageCount > 1,
+                            collapseDistance: collapseDistance,
+                            minContentHeight: viewportHeight - settingsHeaderSize.height + collapseDistance,
+                            collapseCoordinator: collapseCoordinator,
                             dragAndDropDelegate: model,
                             dropData: $dropData,
                             onShowMoreTap: {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
@@ -103,8 +103,7 @@ struct SetKanbanView: View {
 
                 compoundHeader
                     .readSize { settingsHeaderSize = $0 }
-                    // Stops at the top once the collapse is consumed; follows the driver's
-                    // rubber band below zero so the whole page bounces as one, like Grid.
+                    // Stops at the top once the collapse is consumed.
                     .offset(y: collapseDistance - min(headerTravel, collapseDistance))
             }
         }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
@@ -129,7 +129,10 @@ struct SetKanbanView: View {
     }
 
     private func boardContent(viewportHeight: CGFloat) -> some View {
-        ScrollView(.horizontal, showsIndicators: false) {
+        let moveTargets = model.configurationsDict.keys.map { groupId in
+            SetKanbanMoveTarget(id: groupId, title: model.headerType(for: groupId).title)
+        }
+        return ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(alignment: .top, spacing: 8) {
                 ForEach(model.configurationsDict.keys, id: \.self) { groupId in
                     if let configurations = model.configurationsDict[groupId] {
@@ -144,6 +147,7 @@ struct SetKanbanView: View {
                             collapseDistance: collapseDistance,
                             minContentHeight: viewportHeight - settingsHeaderSize.height + collapseDistance,
                             collapseCoordinator: collapseCoordinator,
+                            moveTargets: moveTargets,
                             dragAndDropDelegate: model,
                             dropData: $dropData,
                             onShowMoreTap: {
@@ -154,6 +158,9 @@ struct SetKanbanView: View {
                             },
                             onCreateTap: model.canCreateCardInColumn ? {
                                 model.onCreateObjectInColumnTap(groupId)
+                            } : nil,
+                            onMoveTap: model.canDragCards ? { configurationId, toGroupId in
+                                model.moveCard(configurationId, fromGroupId: groupId, toGroupId: toGroupId)
                             } : nil
                         )
                     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
@@ -31,23 +31,31 @@ struct SetKanbanColumn: View {
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
-            VStack(spacing: 0) {
-                Spacer.fixedHeight(collapseDistance)
-                LazyVStack(spacing: 8, pinnedViews: [.sectionHeaders]) {
-                    Section(header: pinnedHeader) {
-                        cards
+            // The whole column is a drop target: without it, a release over the top spacer,
+            // the pinned header, the gaps between cards or the empty bottom area performs no
+            // drop - the card stays dimmed and the move never persists.
+            SetDragAndDropView(
+                dropData: $dropData,
+                configuration: nil,
+                groupId: groupId,
+                dragAndDropDelegate: dragAndDropDelegate,
+                content: {
+                    VStack(spacing: 0) {
+                        Spacer.fixedHeight(collapseDistance)
+                        LazyVStack(spacing: 8, pinnedViews: [.sectionHeaders]) {
+                            Section(header: pinnedHeader) {
+                                cards
+                            }
+                        }
+                        .padding(.bottom, configurations.isEmpty ? 0 : Constants.contentInset)
+                        .background(columnBackgroundColor, in: .rect(cornerRadius: 4))
+                        // Room to scroll the last card and the create button clear of the
+                        // floating home panel, whose blur intercepts touches full-width.
+                        AnytypeNavigationSpacer()
                     }
+                    .frame(minHeight: minContentHeight, alignment: .top)
                 }
-                .padding(.bottom, configurations.isEmpty ? 0 : Constants.contentInset)
-                .background(columnBackgroundColor, in: .rect(cornerRadius: 4))
-                if configurations.isEmpty {
-                    emptyDroppableArea
-                }
-                // Room to scroll the last card and the create button clear of the floating
-                // home panel, whose blur intercepts touches across the full width.
-                AnytypeNavigationSpacer()
-            }
-            .frame(minHeight: minContentHeight, alignment: .top)
+            )
             .scrollAxisLock(.vertical)
             .kanbanCollapseSync(collapseCoordinator)
         }
@@ -251,19 +259,6 @@ struct SetKanbanColumn: View {
         }
     }
 
-    private var emptyDroppableArea: some View {
-        SetDragAndDropView(
-            dropData: $dropData,
-            configuration: nil,
-            groupId: groupId,
-            dragAndDropDelegate: dragAndDropDelegate,
-            content: {
-                Rectangle()
-                    .fill(Color.Background.primary)
-                    .frame(height: 44)
-            }
-        )
-    }
 }
 
 extension SetKanbanColumn {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
@@ -18,12 +18,16 @@ struct SetKanbanColumn: View {
     let minContentHeight: CGFloat
     let collapseCoordinator: KanbanCollapseCoordinator
 
+    // Every column of the board, for the card's "Move to" menu; this column filters itself out.
+    let moveTargets: [SetKanbanMoveTarget]
+
     let dragAndDropDelegate: any SetDragAndDropDelegate
     @Binding var dropData: SetCardDropData
 
     let onShowMoreTap: () -> Void
     let onSettingsTap: () -> Void
     let onCreateTap: (() -> Void)?
+    let onMoveTap: ((_ configurationId: String, _ toGroupId: String) -> Void)?
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
@@ -107,6 +111,13 @@ struct SetKanbanColumn: View {
                     SetGalleryViewCell(configuration: configuration)
                 }
             )
+            // A stationary long press opens the menu; moving during the press still starts
+            // the drag - the underlying UIKit interactions arbitrate between the two.
+            .ifLet(onMoveTap) { view, onMoveTap in
+                view.contextMenu {
+                    moveMenu(for: configuration, onMoveTap: onMoveTap)
+                }
+            }
             .padding(.horizontal, 8)
         }
         if showPagingView {
@@ -116,6 +127,23 @@ struct SetKanbanColumn: View {
         if let onCreateTap {
             createView(onCreateTap)
                 .padding(.horizontal, 8)
+        }
+    }
+
+    @ViewBuilder
+    private func moveMenu(
+        for configuration: SetContentViewItemConfiguration,
+        onMoveTap: @escaping (_ configurationId: String, _ toGroupId: String) -> Void
+    ) -> some View {
+        let targets = moveTargets.filter { $0.id != groupId }
+        if !targets.isEmpty {
+            Menu(Loc.moveTo) {
+                ForEach(targets) { target in
+                    Button(target.title) {
+                        onMoveTap(configuration.id, target.id)
+                    }
+                }
+            }
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
@@ -9,44 +9,68 @@ struct SetKanbanColumn: View {
     let isGroupBackgroundColors: Bool
     let backgroundColor: BlockBackgroundColor
     let showPagingView: Bool
-    
+    // The first `collapseDistance` points of this column's scroll collapse the shared object
+    // header instead of moving cards: a same-height top spacer reserves that travel, and the
+    // coordinator mirrors the offset into the header overlays.
+    let collapseDistance: CGFloat
+    // Viewport height + collapseDistance, so even a short column can always scroll far enough
+    // to fully collapse the header.
+    let minContentHeight: CGFloat
+    let collapseCoordinator: KanbanCollapseCoordinator
+
     let dragAndDropDelegate: any SetDragAndDropDelegate
     @Binding var dropData: SetCardDropData
-    
+
     let onShowMoreTap: () -> Void
     let onSettingsTap: () -> Void
     let onCreateTap: (() -> Void)?
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-                .padding(.horizontal, 8)
-                .background(
-                    columnBackgroundColor,
-                    in: .rect(topLeadingRadius: 4, topTrailingRadius: 4)
-                )
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 0) {
-                    column
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, configurations.isEmpty ? 0 : Constants.contentInset)
-                        .background(
-                            columnBackgroundColor,
-                            in: .rect(bottomLeadingRadius: 4, bottomTrailingRadius: 4)
-                        )
-                    if configurations.isEmpty {
-                        emptyDroppableArea
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(spacing: 0) {
+                Spacer.fixedHeight(collapseDistance)
+                LazyVStack(spacing: 8, pinnedViews: [.sectionHeaders]) {
+                    Section(header: pinnedHeader) {
+                        cards
                     }
-                    // Room to scroll the last card and the create button clear of the floating
-                    // home panel, whose blur intercepts touches across the full width.
-                    AnytypeNavigationSpacer()
                 }
-                .scrollAxisLock(.vertical)
+                .padding(.bottom, configurations.isEmpty ? 0 : Constants.contentInset)
+                .background(columnBackgroundColor, in: .rect(cornerRadius: 4))
+                if configurations.isEmpty {
+                    emptyDroppableArea
+                }
+                // Room to scroll the last card and the create button clear of the floating
+                // home panel, whose blur intercepts touches across the full width.
+                AnytypeNavigationSpacer()
             }
-            .scrollBounceBehavior(.basedOnSize)
-            .overlay(alignment: .top) { topFade }
+            .frame(minHeight: minContentHeight, alignment: .top)
+            .scrollAxisLock(.vertical)
+            .kanbanCollapseSync(collapseCoordinator)
         }
+        .scrollBounceBehavior(.basedOnSize)
         .frame(width: 270)
+    }
+
+    // Stays inside the scroll view so drags starting on it still drive the collapse, and pins to
+    // the column viewport top once the header travel is consumed.
+    private var pinnedHeader: some View {
+        header
+            .padding(.horizontal, 8)
+            .background {
+                // Opaque even when the group tint is translucent - cards scroll under the
+                // pinned header.
+                ZStack {
+                    headerBackgroundShape.fill(Color.Background.primary)
+                    headerBackgroundShape.fill(columnBackgroundColor)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                topFade.offset(y: Constants.contentInset)
+            }
+    }
+
+    private var headerBackgroundShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(topLeadingRadius: 4, topTrailingRadius: 4)
     }
 
     private var columnBackgroundColor: Color {
@@ -55,9 +79,10 @@ struct SetKanbanColumn: View {
         Color.Background.primary
     }
 
-    // Softens the hard clip under the header: cards dissolve into the column's own color instead
-    // of being cut off. The group tint is translucent, so the fade has to be its composite over
-    // the board background - fading to the tint alone would leave cards showing through it.
+    // Softens the hard clip under the pinned header: cards dissolve into the column's own color
+    // instead of being cut off. The group tint is translucent, so the fade has to be its
+    // composite over the board background - fading to the tint alone would leave cards showing
+    // through it.
     private var topFade: some View {
         ZStack {
             Color.Background.primary
@@ -70,27 +95,28 @@ struct SetKanbanColumn: View {
         .allowsHitTesting(false)
     }
 
-    private var column: some View {
-        LazyVStack(spacing: 8) {
-            ForEach(configurations) { configuration in
-                SetDragAndDropView(
-                    dropData: $dropData,
-                    configuration: configuration,
-                    groupId: groupId,
-                    dragAndDropDelegate: dragAndDropDelegate,
-                    content: {
-                        SetGalleryViewCell(configuration: configuration)
-                    }
-                )
-            }
-            if showPagingView {
-                pagingView
-            }
-            if let onCreateTap {
-                createView(onCreateTap)
-            }
+    @ViewBuilder
+    private var cards: some View {
+        ForEach(configurations) { configuration in
+            SetDragAndDropView(
+                dropData: $dropData,
+                configuration: configuration,
+                groupId: groupId,
+                dragAndDropDelegate: dragAndDropDelegate,
+                content: {
+                    SetGalleryViewCell(configuration: configuration)
+                }
+            )
+            .padding(.horizontal, 8)
         }
-        .frame(width: 254)
+        if showPagingView {
+            pagingView
+                .padding(.horizontal, 8)
+        }
+        if let onCreateTap {
+            createView(onCreateTap)
+                .padding(.horizontal, 8)
+        }
     }
 
     private func createView(_ onTap: @escaping () -> Void) -> some View {
@@ -118,7 +144,7 @@ struct SetKanbanColumn: View {
             }
         )
     }
-    
+
     private var header: some View {
         Button {
             onSettingsTap()
@@ -129,7 +155,7 @@ struct SetKanbanColumn: View {
         .frame(height: 44)
         .buttonStyle(LightDimmingButtonStyle())
     }
-    
+
     private var headerContent: some View {
         HStack(spacing: 0) {
             switch headerType {
@@ -172,7 +198,7 @@ struct SetKanbanColumn: View {
         }
         .padding(.horizontal, 10)
     }
-    
+
     private var pagingView: some View {
         Button {
             onShowMoreTap()
@@ -196,7 +222,7 @@ struct SetKanbanColumn: View {
             }
         }
     }
-    
+
     private var emptyDroppableArea: some View {
         SetDragAndDropView(
             dropData: $dropData,

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumnHeaderType.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumnHeaderType.swift
@@ -3,4 +3,28 @@ enum SetKanbanColumnHeaderType {
     case status([Property.Status.Option])
     case tag([Property.Tag.Option])
     case checkbox(title: String, isChecked: Bool)
+
+    // Plain-text column name for places that can't render the styled header, like the card's
+    // "Move to" menu.
+    var title: String {
+        switch self {
+        case .uncategorized:
+            return Loc.Set.View.Kanban.Column.Title.uncategorized
+        case let .status(options):
+            let title = options.map(\.text).joined(separator: ", ")
+            return title.isEmpty ? Loc.Set.View.Kanban.Column.Title.uncategorized : title
+        case let .tag(options):
+            let title = options.map(\.text).joined(separator: ", ")
+            return title.isEmpty ? Loc.Set.View.Kanban.Column.Title.uncategorized : title
+        case let .checkbox(title, isChecked):
+            return isChecked ?
+            Loc.Set.View.Kanban.Column.Title.checked(title) :
+            Loc.Set.View.Kanban.Column.Title.unchecked(title)
+        }
+    }
+}
+
+struct SetKanbanMoveTarget: Identifiable {
+    let id: String
+    let title: String
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetCardDropInsideDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetCardDropInsideDelegate.swift
@@ -23,22 +23,28 @@ final class SetCardDropInsideDelegate: DropDelegate {
             return
         }
 
-        dragAndDropDelegate.onDrag(
-            from: SetDragAndDropConfiguration(
-                groupId: fromGroupId,
-                configurationId: draggingCard.id
-            ),
-            to: SetDragAndDropConfiguration(
-                groupId: toGroupId,
-                configurationId: droppingCard?.id
+        // A background target (no specific card under the drag) appends only when coming from
+        // another column; inside the card's own column it must not teleport the card to the
+        // end - it just arms performDrop for a release over the column's empty areas.
+        let movesCard = droppingCard != nil || fromGroupId != toGroupId
+        if movesCard {
+            dragAndDropDelegate.onDrag(
+                from: SetDragAndDropConfiguration(
+                    groupId: fromGroupId,
+                    configurationId: draggingCard.id
+                ),
+                to: SetDragAndDropConfiguration(
+                    groupId: toGroupId,
+                    configurationId: droppingCard?.id
+                )
             )
-        )
 
-        if fromGroupId != toGroupId {
-            data.fromGroupId = toGroupId
+            if fromGroupId != toGroupId {
+                data.fromGroupId = toGroupId
+            }
+
+            UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
         }
-
-        UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
 
         data.droppingCard = droppingCard
         data.toGroupId = toGroupId

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/SetDragAndDropView/SetDragAndDropView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/SetDragAndDropView/SetDragAndDropView.swift
@@ -47,7 +47,11 @@ struct SetDragAndDropView<Content>: View where Content: View {
                             }
                             return provider
                         }
-                        .opacity(dropData.draggingCard?.id == configuration.id ? 0.4 : 1)
+                        // Dim only once a drop target has been entered, not on payload
+                        // creation alone: SwiftUI may invoke the onDrag closure without a real
+                        // drag (e.g. the armed context-menu interaction re-requesting the
+                        // payload after a drop), and that must not re-dim the card.
+                        .opacity(dropData.draggingCard?.id == configuration.id && dropData.toGroupId != nil ? 0.4 : 1)
                 }
                 .onDrop(
                     of: SetItemProviderObject.writableTypeIdentifiersForItemProvider,

--- a/docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md
+++ b/docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md
@@ -283,6 +283,10 @@ Two more field bugs, both rooted in this doc's original cross-column rules:
      them.
    - Net effect: dragging any column down with the header expanded scrolls only that column's
      cards (header pinned at 0), and the "all group headers visible" state is always reachable.
+   - The over-drag stretch (`pageCollapse < 0`) moves ALL columns with the sheet: locked ones
+     follow the line, deeper ones are shifted by the stretch deltas (telescopes back to zero on
+     settle, so their position is preserved). Without this the opaque header slid down over
+     static neighbor columns during the bounce.
 
 ## Key files
 

--- a/docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md
+++ b/docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md
@@ -272,10 +272,9 @@ Two more field bugs, both rooted in this doc's original cross-column rules:
    could never be walked back. Fix, the current model in `KanbanCollapseCoordinator`:
    - `headerTravel` moves by the driver's scroll **deltas** (KVO old/new), clamped to
      `[0, fullHeaderHeight]`; it is continuous across driver changes — no jumps by construction.
-     A floor of `min(rel, 0)` lets a top-bouncing column drag the header down 1:1 and back;
-     upward deltas coming out of the rubber band are dropped so the snap-back can't re-collapse
-     what the stretch expanded (this also lets a range-exhausted column finish expanding the
-     header with repeated pulls).
+     Upward deltas coming out of the top rubber band are dropped so the snap-back can't
+     re-collapse what the stretch expanded (this also lets a range-exhausted column finish
+     expanding the header with repeated pulls).
    - `pageCollapse = clamp(headerTravel, 0, H)` is the page line. Columns sitting **on** the
      line follow it in *both* directions — that's the page illusion, and it's what returns
      every synced column to its own top when the page expands. Columns behind the new line are
@@ -283,10 +282,13 @@ Two more field bugs, both rooted in this doc's original cross-column rules:
      them.
    - Net effect: dragging any column down with the header expanded scrolls only that column's
      cards (header pinned at 0), and the "all group headers visible" state is always reachable.
-   - The over-drag stretch (`pageCollapse < 0`) moves ALL columns with the sheet: locked ones
-     follow the line, deeper ones are shifted by the stretch deltas (telescopes back to zero on
-     settle, so their position is preserved). Without this the opaque header slid down over
-     static neighbor columns during the bounce.
+   - Over-drag past fully expanded bounces ONLY the dragged column under a static header.
+     Whole-sheet stretch was tried and reverted: a non-interacting `UIScrollView` won't hold an
+     out-of-range (negative) contentOffset — UIKit re-clamps it to 0 on every layout pass, so
+     mirrored followers flickered between the pushed position and the clamp ("columns jump
+     up"). Only the actively-panned scroll view can sit in the rubber-band zone. If the
+     whole-sheet look is ever wanted, it must be done with SwiftUI `.offset` on non-driver
+     columns (needs driver identity plumbed up), not with contentOffset.
 
 ## Key files
 

--- a/docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md
+++ b/docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md
@@ -1,0 +1,268 @@
+# Handoff — Kanban collapsing object header (IOS-6579, follow-up)
+
+## Context
+
+Branch: `ios-6579-kanban-view-audit-and-fix-dormant-implementation-enable-by`
+Last commit: `a38b3bb66f` "IOS-6579 Virtualize Kanban board scrolling to fix scroll jank"
+
+The prior work (see `20260714-ios-6579-kanban-scroll-fps-handoff.md`, read it first) fixed scroll
+jank by restructuring the board into `ScrollView(.horizontal) { LazyHStack { columns } }` where
+each column is its own `ScrollView(.vertical) { LazyVStack { cards } }`. That fixed FPS but
+**removed the whole-page vertical scroll**, and with it the collapsing object header.
+
+**The bug**: on Board layout the object header (cover/icon, title, Layout/Properties/Templates
+chips) is permanently pinned in place and eats ~40% of the screen. Every other Set view type
+(Grid/List/Gallery) scrolls that header away and leaves the view-settings row (`Board ⌄ … New`)
+stuck to the top under the nav bar. Kanban must behave the same.
+
+**Required behavior**: dragging vertically anywhere on the board first scrolls the *page* — the
+object header slides up under the nav bar and the settings row + column headers come to rest at the
+top — and only after that does continued dragging scroll *inside the column*. Dragging back down
+reverses it.
+
+## How the other views do it (this is the contract to match)
+
+Nothing in kanban gets to invent its own header behavior — `EditorSetView` owns the header and the
+shared `offset` binding, and each content view drives it. Mechanism, using Grid as the reference:
+
+`EditorSetView.swift:53-79` builds a `ZStack(alignment: .top)`:
+- `contentView` — a `VStack` whose first child is `Spacer.fixedHeight(headerMinimizedSize.height)`,
+  so the content area starts below the nav bar (`EditorSetView.swift:86-91`).
+- `SetFullHeader` — the big object header, drawn *over* the content, positioned by
+  `.offset(x: 0, y: offset.y)` and `.ignoresSafeArea(edges: .top)` (`EditorSetView.swift:58-64`).
+  It is opaque (`SetFullHeader.swift:17` — `.background(Color.Background.primary)`).
+- `SetMinimizedHeader` — the always-visible nav bar; reports its height into
+  `headerMinimizedSize` (`SetMinimizedHeader.swift:31`).
+
+`SetTableView.swift:18-43` then does the actual trick inside its vertical `OffsetAwareScrollView`:
+```swift
+Spacer.fixedHeight(tableHeaderSize.height)          // reserves room for SetFullHeader
+LazyVStack(pinnedViews: [.sectionHeaders]) {
+    content                                         // Section(header: compoundHeader) { rows }
+    pagination
+}
+.padding(.top, -headerMinimizedSize.height)         // pulls the list up under the nav bar
+```
+and publishes `offsetChanged: { offset.y = $0.y }`.
+
+So the header is *not* scrolled by being inside the scroll view — it is an overlay slaved to the
+scroll offset, and a spacer inside the scroll content reserves its space. `tableHeaderSize` is the
+full header height minus the top safe area (`EditorSetView.swift:143-145`).
+
+**The single most important derived quantity** — the total collapse distance:
+
+```
+H = tableHeaderSize.height - headerMinimizedSize.height
+```
+
+At `offset.y == -H` the full header's bottom edge is exactly flush with the nav bar's bottom, and
+the pinned section header (settings row) has reached the top of the scroll viewport. That is the
+resting collapsed state in screenshot 2. Verify this equation before building on it.
+
+## Why kanban lost it, and why the obvious fix does not work
+
+`SetKanbanView.swift:15-29` currently has no scroll view at all — a plain `VStack` with a fixed
+`Spacer.fixedHeight(max(tableHeaderSize.height - headerMinimizedSize.height, 0))` (i.e. a
+permanently-expanded `H`), plus an `onAppear { offset = .zero }` hack to stop the shared header
+from being left mispositioned by a previously-scrolled view type. **Both must go.**
+
+**Do not "just wrap the board in an outer vertical ScrollView".** It compiles, it looks right, and
+it does not work: iOS has no nested-scroll chaining (no equivalent of Android's
+`NestedScrollingParent`). With a vertical `ScrollView` containing a column that is itself a
+vertical `ScrollView`, the innermost scroll view wins the pan for any touch that starts on it, and
+when it hits its top edge it bounces rather than handing the drag to the parent. Result: dragging
+on cards would scroll only the column and never collapse the header — which is the bug we are
+trying to fix. The page would collapse only when dragging the few dead pixels between columns.
+
+The standard UIKit remedy (both scroll views recognize simultaneously, then redistribute
+`contentOffset` in the scroll callbacks) requires owning the scroll views' pan delegates.
+SwiftUI owns them, and `UIScrollView` requires its `panGestureRecognizer.delegate` to be the scroll
+view itself, so that route is closed without replacing the ScrollViews with UIKit.
+
+## Recommended design: let the column's own scroll be the page scroll
+
+The insight that makes this simple: **put a `H`-tall transparent spacer at the top of every
+column's scroll content.** The first `H` points of any column's scroll then move nothing that the
+user can see inside the column, and we slave the header overlays to that same offset. Visually the
+whole page moves as one — identical to Grid — and after `H` the column just keeps scrolling its
+cards. No nested same-axis scroll views, no gesture arbitration, no delegate ownership.
+
+### Geometry
+
+Symbols (all in the coordinate space of `contentTypeView`, i.e. y=0 is just under the nav bar):
+
+- `H` = `tableHeaderSize.height - headerMinimizedSize.height` — total collapse distance.
+- `S` = measured height of `compoundHeader` (settings row + its 16pt spacer).
+- `V` = height of the content area (take it from a `GeometryReader` in `SetKanbanView`).
+- `collapse` = `clamp(driving column's contentOffset.y, 0, H)` — shared state, 0 = expanded.
+
+Layout:
+
+```
+board container:  fixed at y = S, height = V - S          (never moves)
+settings row:     overlay at y = H - collapse, height S    (opaque, slides up, stops at 0)
+SetFullHeader:    driven by publishing offset.y = -collapse to the shared binding
+column content:   Spacer(H) + Section(header: columnHeader) { cards … }  in a pinned LazyVStack
+```
+
+Check the invariant — the first card's top must always meet the settings row's bottom:
+
+```
+first card top   = boardTop + contentPos - scroll = S + H - collapse
+settings bottom  = (H - collapse) + S                       ✓ equal for every value of collapse
+```
+
+At `collapse == 0` the board's top strip is hidden behind the opaque `SetFullHeader`; at
+`collapse == H` the settings row sits at y=0 and the pinned column header sits at y=S. Both
+resting states then match the Grid screenshots exactly.
+
+### Why the column header goes *inside* the column scroll (pinned)
+
+Keep `SetKanbanColumn`'s header (`Waiting Response 13 …`) inside the column's `ScrollView`, as a
+`Section(header:)` of a `LazyVStack(pinnedViews: [.sectionHeaders])`, rather than as a sibling
+above it (where `SetKanbanColumn.swift:22` has it today). Two reasons: it then pins to the column
+viewport top for free with no offset math, and — more importantly — the 44pt header strip stays
+part of the scroll view, so drags starting on it still drive the collapse. A header outside the
+scroll view would be a dead zone across the top of every column.
+
+Note the earlier failed experiment used a pinned `LazyVStack` too, but *cross-axis* (inside a
+horizontal scroll). Here it is inside a matching-axis vertical `ScrollView`, which is the supported
+configuration Grid already relies on. Preserve the tint/rounded-corner treatment
+(`SetKanbanColumn.swift:24-27, 33-36`): the pinned header must stay opaque so cards pass under it.
+
+### Cross-column synchronization
+
+Columns scroll independently, but there is one shared header. Rules:
+
+- The column currently being dragged/decelerating is the driver; it sets `collapse`.
+- Any *other* column whose `contentOffset.y < collapse` must be set to `collapse` (non-animated) so
+  its spacer is consumed by the same amount — otherwise switching to it would show an `H`-tall hole
+  where the header used to be.
+- Columns already scrolled past `collapse` are left alone; their deeper scroll position persists
+  (Trello behaves this way). When the header re-expands, their cards slide under the opaque header,
+  which is fine.
+- Guard against feedback loops: programmatic `setContentOffset` re-enters the observer. Gate on
+  `isDragging`/`isTracking`/`isDecelerating` or an explicit re-entrancy flag.
+
+Reading the offsets: use the introspection pattern already in the repo —
+`ScrollAxisLock.swift` (`ScrollAxisLockUIView.enclosingScrollView`, lines 52-59) walks up from a
+zero-size background view to the enclosing `UIScrollView`. Observe `contentOffset` with KVO
+(deployment target is iOS 17, so `onScrollGeometryChange` is unavailable). A small shared
+coordinator object (`@State` in `SetKanbanView`, passed down) that registers each column's scroll
+view and owns `collapse` is the natural shape.
+
+### Short columns
+
+A column whose content is shorter than its viewport cannot scroll, so it can neither drive nor
+follow the collapse. Give every column's scroll content a minimum height of `viewport + H` (a
+trailing flexible spacer, or `.frame(minHeight:)` on the content) so `H` points of scroll always
+exist. Do not remove `.scrollBounceBehavior(.basedOnSize)` without re-checking this interaction.
+
+## Invariants that must not regress
+
+From the previous round — re-verify each before declaring done:
+
+1. **Virtualization.** Columns lazy in `LazyHStack`, cards lazy in `LazyVStack`, each lazy
+   container directly inside a matching-axis `ScrollView`. This is the actual FPS fix.
+2. **Axis lock.** `.scrollAxisLock(.vertical)` on column content and `.scrollAxisLock(.horizontal)`
+   on the board (`ScrollAxisLock.swift`) — stops a decelerating scroll view from swallowing
+   cross-axis drags. Still required; verify horizontal swipes work mid-collapse.
+3. **No per-card `GeometryReader`.** `SetGalleryViewCell` must not regain `readSize`.
+4. **`AnytypeNavigationSpacer()`** at the end of each column's content — the floating home panel's
+   blur intercepts touches full-width, so "+ New" is untappable without it.
+5. **Top fade** (`SetKanbanColumn.topFade`) still aligned to the column viewport top.
+6. Card tap, `.onDrag` reordering across columns, "Show more" pagination, empty-column drop area.
+
+## Edge cases
+
+- **`isEmptyViews` / `.loading` / `.error` states** (`SetKanbanView.swift:31-40`) have no columns,
+  so nothing can drive the collapse. Decide deliberately: simplest is to keep those states
+  non-collapsing (header expanded), since there is nothing to scroll to.
+- **View-type switching.** `offset` is shared `@State` in `EditorSetView` across Grid/List/Board.
+  Publishing `offset.y = -collapse` replaces the `onAppear { offset = .zero }` hack, but check the
+  Board→Grid→Board round trip leaves the header in a sane position.
+- **"Show more"** changes a column's content height mid-scroll; make sure `collapse` is not
+  disturbed.
+- **Drag-and-drop auto-scroll** may drive `contentOffset` programmatically — make sure that path
+  does not fight the sync rules.
+- **Rotation / dynamic type** change `H`, `S` and `V`; `collapse` must be re-clamped.
+
+## Verification
+
+- Both resting states must match the Grid screenshots: expanded (header visible, settings row
+  under it) and collapsed (settings row flush under the nav bar, then column headers, then cards).
+- Drag once, slowly, from a card: header and cards must move together at 1:1 with the finger (a 2:1
+  rate means the board container is moving *and* the content is scrolling — the classic failure of
+  this design; re-check the geometry table above).
+- Collapse via column A, then swipe to column B: no hole at the top of B.
+- Real device only for FPS claims, and re-run the trace comparison from the previous handoff
+  (`"waiting on GPU and VSync"` / `"in render server"` hitch counts) — the added spacer and
+  coordinator must not reintroduce hitching.
+
+## Update (2026-07-20, later session) — implemented
+
+The recommended design was implemented as specified (working tree, uncommitted, on `develop` —
+the prior kanban branch is already merged):
+
+- **`KanbanCollapseCoordinator.swift`** (new) — `@MainActor` class owning `collapse`. Columns
+  register their enclosing `UIScrollView` via a `.kanbanCollapseSync(_:)` background view (same
+  superview-walk introspection as `ScrollAxisLock`). KVO on `contentOffset`; offsets are read
+  relative to `adjustedContentInset.top`. Driver rules: a tracking/dragging/decelerating scroll
+  view drives; a merely decelerating one cannot steal from a finger-driven one. Followers (and
+  any non-finger programmatic/layout-induced movement, incl. lazily materialized columns at
+  registration) are raised to `collapse` when behind, never lowered — deeper positions persist.
+  Re-entrancy gated with an `isSyncing` flag.
+- **`SetKanbanView.swift`** — ready state is now `GeometryReader { ZStack(top) }`: board fixed
+  below the settings row (`.padding(.top, S)`), `compoundHeader` overlaid at
+  `y = H - collapse` (measured via `readSize`), and the coordinator callback publishes
+  `collapse` + `offset.y = -collapse` (replaces the `onAppear { offset = .zero }` hack).
+  Loading/error/empty keep the old static expanded layout and reset collapse/offset to zero.
+  Coordinator callback is cleared in `onDisappear` (retain cycle: closure → view → @State
+  storage → coordinator). `H` changes flow in via `.onChange(of: collapseDistance, initial:
+  true)` and re-clamp `collapse`.
+- **`SetKanbanColumn.swift`** — column is now a single vertical `ScrollView`:
+  `Spacer(H)` + `LazyVStack(spacing: 8, pinnedViews: [.sectionHeaders])` with the column header
+  as the pinned `Section` header. Header background is made opaque (Background.primary underlay
+  + tint in a top-rounded shape) since cards pass under it; `topFade` moved from the scroll
+  viewport top to an overlay hanging below the header. Cards tint comes from a single
+  all-corners-rounded background on the LazyVStack (top corners hidden behind the header's own
+  rounding); rows are inset with `.padding(.horizontal, 8)` (cell fills width — equivalent to
+  the old `.frame(width: 254)`). Content gets `.frame(minHeight: viewport + H, alignment: .top)`
+  so short columns can always drive/follow the full collapse.
+
+Not yet done (needs device): both resting states vs Grid screenshots, 1:1 finger tracking,
+collapse-then-swipe hole check, invariants 1–6, and the Instruments hitch-count comparison.
+
+### Fix after first device test: header must keep sliding past `H`
+
+First on-device test showed the header's bottom content (title/properties/type buttons) staying
+visible at the top after collapse. Cause: this doc's `collapse = clamp(offset, 0, H)` stops the
+header at `offset == -H`, where its bottom edge is merely *flush* with the nav bar bottom — and
+the nav bar (`NavigationHeader`) has only a `HomeBlurEffectView` background, so the header's
+bottom `navHeight + safeArea` points sit permanently behind the blur. Grid doesn't have this
+problem because it publishes the **raw** scroll offset unbounded: scrolling into the rows keeps
+sliding the header up until it is fully off-screen.
+
+Fix: the coordinator now tracks the driver 1:1 as `headerTravel = clamp(rel, -∞,
+fullHeaderHeight)` where `fullHeaderHeight = tableHeaderFullSize.height` (passed down from
+`EditorSetView`) is the travel at which the header is completely off-screen (also where updates
+stop, so deep card scrolling publishes nothing). `collapse = clamp(headerTravel, 0, H)` remains
+the settle line for the settings row and follower sync. Side benefit: negative travel is
+published raw, so the header + settings row follow the driver's rubber-band bounce 1:1 like
+Grid (the geometry stays glued: header bottom == settings top == `H + bounce`).
+
+Known accepted quirk: switching drivers between columns scrolled to different depths ≥ `H` can
+pop the header's position, but both endpoints lie behind the nav blur, so it isn't visible
+mid-screen. Short columns (content < viewport + fullHeaderHeight of scroll range) can't push the
+header fully away — same limitation Grid has with short content.
+
+## Key files
+
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift`
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift`
+- `Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/ScrollAxisLock.swift`
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetView.swift` (header ZStack, `offset`)
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/SetTableView.swift` (reference impl)
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Header/SetFullHeader.swift`
+- `Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/OffsetAwareScrollView.swift`
+- Prior handoff: `docs/plans/20260714-ios-6579-kanban-scroll-fps-handoff.md`

--- a/docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md
+++ b/docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md
@@ -256,6 +256,34 @@ pop the header's position, but both endpoints lie behind the nav blur, so it isn
 mid-screen. Short columns (content < viewport + fullHeaderHeight of scroll range) can't push the
 header fully away — same limitation Grid has with short content.
 
+### Second device round: delta-driven header, two-way page lock, single active fling
+
+Two more field bugs, both rooted in this doc's original cross-column rules:
+
+1. **Header flicker + garbage states with two decelerating columns.** The driver arbitration
+   let a decelerating column steal the header back, so two settling columns alternated as
+   driver every frame. Fix: only finger contact claims drivership, and claiming stops the
+   previous driver's fling dead (`setContentOffset(_, animated: false)` — the canonical
+   deceleration kill). One active scroller at a time, like UIKit's own touch-stops-fling rule.
+2. **Deep columns made the header jump, and columns could never be restored to their group
+   headers.** The spec's `collapse = clamp(driver's offset, 0, H)` maps the driver's *absolute*
+   offset — so touching a column scrolled deeper than the page teleported the header to its
+   depth. And follower sync was one-way (raise only), so once a column was pushed deeper it
+   could never be walked back. Fix, the current model in `KanbanCollapseCoordinator`:
+   - `headerTravel` moves by the driver's scroll **deltas** (KVO old/new), clamped to
+     `[0, fullHeaderHeight]`; it is continuous across driver changes — no jumps by construction.
+     A floor of `min(rel, 0)` lets a top-bouncing column drag the header down 1:1 and back;
+     upward deltas coming out of the rubber band are dropped so the snap-back can't re-collapse
+     what the stretch expanded (this also lets a range-exhausted column finish expanding the
+     header with repeated pulls).
+   - `pageCollapse = clamp(headerTravel, 0, H)` is the page line. Columns sitting **on** the
+     line follow it in *both* directions — that's the page illusion, and it's what returns
+     every synced column to its own top when the page expands. Columns behind the new line are
+     caught up (no-hole invariant); deeper columns keep their position until the line reaches
+     them.
+   - Net effect: dragging any column down with the header expanded scrolls only that column's
+     cards (header pinned at 0), and the "all group headers visible" state is always reachable.
+
 ## Key files
 
 - `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift`


### PR DESCRIPTION
## Summary
- Restores the whole-page collapsing object header on Board layout (lost by the scroll virtualization restructure): every column reserves the collapse distance with a top spacer, the actively scrolled column drives the shared `headerTravel` by its scroll **deltas**, and the settings row + `SetFullHeader` are overlays slaved to it — dragging anywhere collapses the header first, then scrolls cards, matching Grid/List/Gallery, with the header sliding fully off-screen like the other view types. New `KanbanCollapseCoordinator` keeps columns in sync (finger-only drivership + fling-stop on claim, two-way page lock so the all-group-headers state is always recoverable, deep columns keep their position, over-drag bounces only the dragged column, observers unregister on window detach); column header moved inside the column scroll as a pinned opaque section header. TODO IOS-6595 tracks moving the KVO/introspection plumbing to iOS 18 scroll APIs.
- Fixes card drag-and-drop, broken on the virtualized board: the axis-lock gate never resolved on a stationary press, blocking the drag lift (and its haptic) for the whole touch — it now fails itself after 0.3s of a stationary hold. The whole column is now a drop target (previously releasing over the top spacer, pinned header, card gaps or the empty bottom area performed no drop — card stayed dimmed and the move silently never persisted), a background target no longer teleports a card to the end of its own column, and the drag dim engages only once a real drop target is entered so phantom `onDrag` payload invocations can't leave a dropped card greyed out.
- Adds a "Move to" context menu on cards: stationary long-press → menu listing the other columns by name; moving during the press still lifts into the normal drag. Reuses the exact drag-drop move pipeline (optimistic move, persistence, revert, analytics); hidden without move permissions or on single-column boards.

Design doc + field-test log: `docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md`