### PR TITLE
IOS-6594 Fix keyboard flicker when typing the first symbol into an empty block

### DIFF
--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView.swift
@@ -90,6 +90,13 @@ final class TextBlockContentView: UIView, BlockContentView, DynamicHeightView, F
     
     // MARK: - Apply configuration
     
+    /// Synchronous first-responder grab for the fork focus handoff. Runs right after the apply
+    /// that inserted this cell — outside the dequeue pass, where a synchronous
+    /// becomeFirstResponder is unsafe (see applyNewConfiguration).
+    func takeFocus(at position: BlockFocusPosition) {
+        textView.textView.setFocus(position)
+    }
+
     private func applyNewConfiguration(configuration: TextBlockContentConfiguration) {
         textView.textView.textStorage.setAttributedString(configuration.attributedString)
                 

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
@@ -413,6 +413,24 @@ extension EditorPageController: EditorPageViewInput {
         self.firstResponderView = nil
     }
 
+    @discardableResult
+    func takeFocus(blockId: String, position: BlockFocusPosition) -> Bool {
+        guard let item = dataSourceItem(for: blockId),
+              let indexPath = dataSource.indexPath(for: item),
+              let cell = collectionView.cellForItem(at: indexPath),
+              let contentView = firstTextBlockContentView(in: cell) else { return false }
+        contentView.takeFocus(at: position)
+        return true
+    }
+
+    private func firstTextBlockContentView(in view: UIView) -> TextBlockContentView? {
+        if let view = view as? TextBlockContentView { return view }
+        for subview in view.subviews {
+            if let found = firstTextBlockContentView(in: subview) { return found }
+        }
+        return nil
+    }
+
     // MARK: -
     func endEditing() {
         view.endEditing(true)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewInput.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewInput.swift
@@ -37,4 +37,9 @@ protocol EditorPageViewInput: EditorCollectionReloadable {
     func adjustContentOffset(relatively: UIView)
 
     func restoreEditingState()
+
+    /// Synchronously moves first responder into the on-screen text cell of `blockId`.
+    /// Returns false when the block's cell is not currently on screen.
+    @discardableResult
+    func takeFocus(blockId: String, position: BlockFocusPosition) -> Bool
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
@@ -47,6 +47,14 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
     private var didScrollToInitialBlock = false
     private var publishState: PublishState?
     private var trailingBlockPlaceholder: (session: VirtualTrailingBlockSession, item: EditorItem)?
+    // Old rows of just-consumed identity forks, kept in the snapshot until the replacing
+    // block's cell takes first responder over; see retainStaleForkRows.
+    private var staleForkHandoffs = [ForkFocusHandoff]()
+
+    private struct ForkFocusHandoff {
+        let swap: BlockIdentitySwap
+        let focusPosition: BlockFocusPosition
+    }
 
     @Published var bottomPanelHidden: Bool = false
     @Published var bottomPanelHiddenAnimated: Bool = true
@@ -154,8 +162,9 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
     private func handleUpdate(ids: [String]) {
         // An identity swap (virtual placeholder → real block, empty-block fork) must not be
         // rendered as an animated delete+insert of the same visible content.
-        let containsIdentitySwap = blockIdentitySwapStorage.consumeSwap(in: ids)
+        let identitySwaps = blockIdentitySwapStorage.consumeSwaps(in: ids)
         var blocksViewModels = blockBuilder.buildEditorItems(infos: ids, ignoreCache: false)
+        retainStaleForkRows(newSwaps: identitySwaps, in: &blocksViewModels)
         if let trailingBlockPlaceholder {
             if let materializedId = trailingBlockPlaceholder.session.materializedBlockId,
                ids.contains(materializedId),
@@ -189,10 +198,81 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
             return
         }
 
-        viewInput?.update(changes: difference, allModels: modelsHolder.items, isRealData: true, animated: !containsIdentitySwap) { [weak self] in
+        viewInput?.update(changes: difference, allModels: modelsHolder.items, isRealData: true, animated: identitySwaps.isEmpty) { [weak self] in
             guard let self else { return }
             cursorManager.handleGeneralUpdate(with: modelsHolder.items, type: document.details?.type)
             initialScrollToBlockIfNeeded()
+            removeStaleForkRowsAfterFocusHandoff()
+        }
+        finishForkFocusHandoffs()
+    }
+
+    /// The empty-block identity fork replaces the focused block's row with a fresh id. Deleting
+    /// the first responder's cell in that apply briefly dismisses the keyboard, so while a focus
+    /// handoff to the forked id is pending, the old row stays in the snapshot — the trailing
+    /// placeholder's awaitingFocusHandoff trick. finishForkFocusHandoffs completes the swap right
+    /// after the apply, within the same render commit.
+    private func retainStaleForkRows(newSwaps: [BlockIdentitySwap], in items: inout [EditorItem]) {
+        // A pending focus for the new id means the old block's cell holds the keyboard; without
+        // it there is nothing to hand off (e.g. the fork ran on defocus).
+        if let blockFocus = cursorManager.blockFocus {
+            staleForkHandoffs += newSwaps
+                .filter { $0.oldBlockId.isNotNil && blockFocus.id == $0.newBlockId }
+                .map { ForkFocusHandoff(swap: $0, focusPosition: blockFocus.position) }
+        }
+        guard staleForkHandoffs.isNotEmpty else { return }
+        staleForkHandoffs.removeAll { handoff in
+            guard let oldBlockId = handoff.swap.oldBlockId,
+                  let oldModel = modelsHolder.blocksMapping[oldBlockId],
+                  items.firstIndex(blockId: oldBlockId) == nil,
+                  let newIndex = items.firstIndex(blockId: handoff.swap.newBlockId) else { return true }
+            // The old row keeps its position; the new block's row slides into it on removal.
+            items.insert(.block(oldModel), at: newIndex)
+            return false
+        }
+    }
+
+    /// Runs right after the unanimated snapshot apply that inserted the replacing cells — the
+    /// apply is synchronous on the main queue, so the new cells are already on screen but nothing
+    /// has been committed to the render server yet. Moving first responder into the new cell and
+    /// dropping the stale row here keeps the whole swap inside one render commit: the transient
+    /// two-row layout never reaches the screen and the keyboard never dips.
+    private func finishForkFocusHandoffs() {
+        guard staleForkHandoffs.isNotEmpty, let viewInput else { return }
+        var removedIds = Set<String>()
+        staleForkHandoffs.removeAll { handoff in
+            guard let oldBlockId = handoff.swap.oldBlockId else { return true }
+            guard viewInput.takeFocus(blockId: handoff.swap.newBlockId, position: handoff.focusPosition) else {
+                // Cell not on screen — removeStaleForkRowsAfterFocusHandoff picks it up.
+                return false
+            }
+            removedIds.insert(oldBlockId)
+            return true
+        }
+        guard removedIds.isNotEmpty else { return }
+        let items = modelsHolder.items.filter { !removedIds.contains($0.blockId) }
+        guard items.count != modelsHolder.items.count else { return }
+        modelsHolder.items = items
+        guard document.isOpened else { return }
+        viewInput.update(changes: nil, allModels: items, isRealData: true, animated: false, completion: {})
+    }
+
+    /// Fallback for handoffs finishForkFocusHandoffs could not complete synchronously (the new
+    /// cell was not on screen). Runs in the apply's completion: the new cell's deferred initial
+    /// focus was enqueued on the main queue during that apply, so after one more hop the old
+    /// text view has already handed first responder over and its row can be deleted without
+    /// touching the keyboard.
+    private func removeStaleForkRowsAfterFocusHandoff() {
+        guard staleForkHandoffs.isNotEmpty else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self, staleForkHandoffs.isNotEmpty else { return }
+            let staleIds = Set(staleForkHandoffs.compactMap(\.swap.oldBlockId))
+            staleForkHandoffs.removeAll()
+            let items = modelsHolder.items.filter { !staleIds.contains($0.blockId) }
+            guard items.count != modelsHolder.items.count else { return }
+            modelsHolder.items = items
+            guard document.isOpened else { return }
+            viewInput?.update(changes: nil, allModels: items, isRealData: true, animated: false, completion: {})
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/VirtualTrailingBlock/VirtualTrailingBlockSession.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/VirtualTrailingBlock/VirtualTrailingBlockSession.swift
@@ -154,7 +154,7 @@ final class VirtualTrailingBlockSession: VirtualTrailingBlockSessionProtocol {
             position: .bottom
         )
         SessionCreatedBlockIdsStorage.shared.register(blockId)
-        blockIdentitySwapStorage.register(blockId)
+        blockIdentitySwapStorage.register(newBlockId: blockId, replacingBlockId: nil)
         if let containerInfo = document.infoContainer.get(id: blockId),
            containerInfo.configurationData.parentId.isNotNil {
             return containerInfo

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionService/BlockActionService.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionService/BlockActionService.swift
@@ -57,7 +57,7 @@ final class BlockActionService: BlockActionServiceProtocol {
     func replaceBlock(info: BlockInformation, blockId: String, focusAt: BlockFocusPosition?) async throws -> String {
         let newBlockId = try await blockService.replaceBlock(contextId: documentId, blockId: blockId, info: info)
         SessionCreatedBlockIdsStorage.shared.register(newBlockId)
-        blockIdentitySwapStorage.register(newBlockId)
+        blockIdentitySwapStorage.register(newBlockId: newBlockId, replacingBlockId: blockId)
 
         if let focusAt {
             cursorManager.blockFocus = BlockFocus(id: newBlockId, position: focusAt)

--- a/Anytype/Sources/ServiceLayer/Block/SessionCreatedBlocks/BlockIdentitySwapStorage.swift
+++ b/Anytype/Sources/ServiceLayer/Block/SessionCreatedBlocks/BlockIdentitySwapStorage.swift
@@ -1,11 +1,18 @@
 import Foundation
 import Factory
 
+struct BlockIdentitySwap: Equatable {
+    let newBlockId: String
+    /// Id of the document block the new one replaced in place. Nil when the swapped-out row is
+    /// not a document block (virtual trailing placeholder — its row removal is session-managed).
+    let oldBlockId: String?
+}
+
 @MainActor
 protocol BlockIdentitySwapStorageProtocol: AnyObject {
-    func register(_ blockId: String)
-    /// True when `ids` contains a block that just swapped identity; matches are consumed.
-    func consumeSwap(in ids: [String]) -> Bool
+    func register(newBlockId: String, replacingBlockId: String?)
+    /// Swaps whose new block id appears in `ids`; matches are consumed.
+    func consumeSwaps(in ids: [String]) -> [BlockIdentitySwap]
 }
 
 /// Block ids that just replaced another block in place (virtual trailing placeholder → real
@@ -13,33 +20,37 @@ protocol BlockIdentitySwapStorageProtocol: AnyObject {
 ///
 /// The collection view renders an id change as an animated delete+insert — the old row fades
 /// out below the new one. The editor consumes these ids to apply the swap snapshot without
-/// animation, so the swap is invisible.
+/// animation, so the swap is invisible; a consumed swap's `oldBlockId` also lets the editor
+/// keep the old — still focused — row alive until the new cell takes the keyboard over.
 ///
-/// Ids are normally consumed on the very next update batch. `consumeSwap` may never see one
+/// Ids are normally consumed on the very next update batch. `consumeSwaps` may never see one
 /// (the editor tears down before the create/replace event round-trips), so registration is
 /// bounded: past `capacity` the oldest still-pending id is evicted. Eviction only ever
 /// discards ids that were never consumed, so it cannot affect visible behavior.
 @MainActor
 final class BlockIdentitySwapStorage: BlockIdentitySwapStorageProtocol {
     private let capacity = 64
-    private var pendingBlockIds = Set<String>()
+    private var pendingSwaps = [String: BlockIdentitySwap]()
     private var order = [String]()
 
-    func register(_ blockId: String) {
-        guard pendingBlockIds.insert(blockId).inserted else { return }
-        order.append(blockId)
+    func register(newBlockId: String, replacingBlockId: String?) {
+        guard pendingSwaps[newBlockId] == nil else { return }
+        pendingSwaps[newBlockId] = BlockIdentitySwap(newBlockId: newBlockId, oldBlockId: replacingBlockId)
+        order.append(newBlockId)
         if order.count > capacity {
             let evicted = order.removeFirst()
-            pendingBlockIds.remove(evicted)
+            pendingSwaps.removeValue(forKey: evicted)
         }
     }
 
-    func consumeSwap(in ids: [String]) -> Bool {
-        let matched = pendingBlockIds.intersection(ids)
-        guard !matched.isEmpty else { return false }
-        pendingBlockIds.subtract(matched)
-        order.removeAll { matched.contains($0) }
-        return true
+    func consumeSwaps(in ids: [String]) -> [BlockIdentitySwap] {
+        let swaps = ids.compactMap { pendingSwaps[$0] }
+        guard !swaps.isEmpty else { return [] }
+        for swap in swaps {
+            pendingSwaps.removeValue(forKey: swap.newBlockId)
+        }
+        order.removeAll { pendingSwaps[$0] == nil }
+        return swaps
     }
 }
 


### PR DESCRIPTION
## Summary
- Typing the first symbol into an empty block triggers the identity fork (`BlockReplace`); rendering it as delete+insert tore down the focused cell before the new one took first responder, so the keyboard closed and immediately reopened.
- `BlockIdentitySwapStorage` now records which block a swap replaced; while a focus handoff to the forked id is pending, the old (focused) row stays in the snapshot through the apply — the trailing placeholder's `awaitingFocusHandoff` trick generalized to the fork.
- Right after the synchronous unanimated apply, `finishForkFocusHandoffs` moves first responder into the new cell directly and removes the stale row within the same render commit, so neither the keyboard dip nor the transient two-row layout ever reaches the screen (a deferred fallback covers off-screen cells).