### PR TITLE
Port ios-6579, ios-6594, ios-6596 to release

### DIFF
--- a/Anytype.xcodeproj/project.pbxproj
+++ b/Anytype.xcodeproj/project.pbxproj
@@ -209,14 +209,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		2E30581A2D81DF7F00BF4F25 /* Exceptions for "AnytypeNotificationServiceExtension" folder in "AnytypeNotificationServiceExtension" target */ = {
+		2E30581A2D81DF7F00BF4F25 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 			);
 			target = 2E30580C2D81DF7E00BF4F25 /* AnytypeNotificationServiceExtension */;
 		};
-		3D0DC1052DFC9BC000E555FD /* Exceptions for "AnytypeTests" folder in "AnytypeTests" target */ = {
+		3D0DC1052DFC9BC000E555FD /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				AnytypeTests.xctestplan,
@@ -229,7 +229,7 @@
 			);
 			target = 03C5C53F22DFD90C00DD91DE /* AnytypeTests */;
 		};
-		3D69777F2CAE9EC5003F5A91 /* Exceptions for "Supporting files" folder in "Anytype" target */ = {
+		3D69777F2CAE9EC5003F5A91 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				/Localized/LaunchScreen.storyboard,
@@ -238,7 +238,7 @@
 			);
 			target = 0303ECFA22D8EDAA005C552B /* Anytype */;
 		};
-		3D6989E52CAEA5E1003F5A91 /* Exceptions for "AnytypeShareExtension" folder in "AnytypeShareExtension" target */ = {
+		3D6989E52CAEA5E1003F5A91 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				/Localized/MainInterface.storyboard,
@@ -249,66 +249,14 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		2E30580E2D81DF7E00BF4F25 /* AnytypeNotificationServiceExtension */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				2E30581A2D81DF7F00BF4F25 /* Exceptions for "AnytypeNotificationServiceExtension" folder in "AnytypeNotificationServiceExtension" target */,
-			);
-			path = AnytypeNotificationServiceExtension;
-			sourceTree = "<group>";
-		};
-		3D0DC0E12DFC9BC000E555FD /* AnytypeTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				3D0DC1052DFC9BC000E555FD /* Exceptions for "AnytypeTests" folder in "AnytypeTests" target */,
-			);
-			path = AnytypeTests;
-			sourceTree = "<group>";
-		};
-		3D69777D2CAE9EC5003F5A91 /* Supporting files */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				3D69777F2CAE9EC5003F5A91 /* Exceptions for "Supporting files" folder in "Anytype" target */,
-			);
-			path = "Supporting files";
-			sourceTree = "<group>";
-		};
-		3D6977812CAE9ED0003F5A91 /* Video */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			path = Video;
-			sourceTree = "<group>";
-		};
-		3D6977912CAE9EEC003F5A91 /* Preview Content */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		3D6989E22CAEA5E1003F5A91 /* AnytypeShareExtension */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				3D6989E52CAEA5E1003F5A91 /* Exceptions for "AnytypeShareExtension" folder in "AnytypeShareExtension" target */,
-			);
-			path = AnytypeShareExtension;
-			sourceTree = "<group>";
-		};
-		3D69B4E82CAEA9CB003F5A91 /* Sources */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-		7424EFB92D79C71B00E51377 /* Modules */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
-			path = Modules;
-			sourceTree = "<group>";
-		};
+		2E30580E2D81DF7E00BF4F25 /* AnytypeNotificationServiceExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (2E30581A2D81DF7F00BF4F25 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = AnytypeNotificationServiceExtension; sourceTree = "<group>"; };
+		3D0DC0E12DFC9BC000E555FD /* AnytypeTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3D0DC1052DFC9BC000E555FD /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = AnytypeTests; sourceTree = "<group>"; };
+		3D69777D2CAE9EC5003F5A91 /* Supporting files */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3D69777F2CAE9EC5003F5A91 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = "Supporting files"; sourceTree = "<group>"; };
+		3D6977812CAE9ED0003F5A91 /* Video */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Video; sourceTree = "<group>"; };
+		3D6977912CAE9EEC003F5A91 /* Preview Content */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Preview Content"; sourceTree = "<group>"; };
+		3D6989E22CAEA5E1003F5A91 /* AnytypeShareExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3D6989E52CAEA5E1003F5A91 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = AnytypeShareExtension; sourceTree = "<group>"; };
+		3D69B4E82CAEA9CB003F5A91 /* Sources */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Sources; sourceTree = "<group>"; };
+		7424EFB92D79C71B00E51377 /* Modules */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Modules; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -628,8 +576,6 @@
 			);
 			dependencies = (
 			);
-			fileSystemSynchronizedGroups = (
-			);
 			name = AnytypeShareExtension;
 			packageProductDependencies = (
 				2ACDC9B32B553F840063BFBD /* SharedContentManager */,
@@ -653,8 +599,6 @@
 			buildRules = (
 			);
 			dependencies = (
-			);
-			fileSystemSynchronizedGroups = (
 			);
 			name = AnytypeWidgetExtension;
 			packageProductDependencies = (

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/ScrollAxisLock.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/ScrollAxisLock.swift
@@ -66,6 +66,7 @@ private final class ScrollAxisLockUIView: UIView {
 private final class CrossAxisDragGate: UIGestureRecognizer {
     private let scrollAxis: Axis
     private var startLocation = CGPoint.zero
+    private var stationaryHoldTimeout: DispatchWorkItem?
 
     init(scrollAxis: Axis) {
         self.scrollAxis = scrollAxis
@@ -83,6 +84,18 @@ private final class CrossAxisDragGate: UIGestureRecognizer {
             return
         }
         startLocation = touch.location(in: view)
+
+        // A press that hasn't moved is not a scroll - fail before the system's ~0.5s
+        // drag-lift/context-menu timers, or anything made to wait for this gate's resolution
+        // (it otherwise resolves only on movement or touch end) never fires on a long press.
+        let timeout = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, self.state == .possible else { return }
+                self.state = .failed
+            }
+        }
+        stationaryHoldTimeout = timeout
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.stationaryHoldTimeout, execute: timeout)
     }
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
@@ -112,6 +125,12 @@ private final class CrossAxisDragGate: UIGestureRecognizer {
         state = state == .began ? .cancelled : .failed
     }
 
+    override func reset() {
+        super.reset()
+        stationaryHoldTimeout?.cancel()
+        stationaryHoldTimeout = nil
+    }
+
     // A gate that can't be the wrong gate: a scroll view with nothing to scroll along its axis
     // needs no arbitration, and neither does one we attached to by mistake.
     private var canScrollAlongAxis: Bool {
@@ -132,5 +151,8 @@ private final class CrossAxisDragGate: UIGestureRecognizer {
 private extension CrossAxisDragGate {
     enum Constants {
         static let directionThreshold: CGFloat = 6
+        // Below the ~0.5s system long-press timers, above any hesitation between touch-down
+        // and the start of a deliberate swipe.
+        static let stationaryHoldTimeout: TimeInterval = 0.3
     }
 }

--- a/Anytype/Sources/PresentationLayer/Common/UIKit/TextView/CustomTextView+UITextViewDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/Common/UIKit/TextView/CustomTextView+UITextViewDelegate.swift
@@ -17,6 +17,7 @@ extension CustomTextView: UITextViewDelegate {
     }
 
     func textViewDidChangeSelection(_ textView: UITextView) {
+        (textView as? TextViewWithPlaceholder)?.trackSelectionAnchor()
         if textView.isFirstResponder {
             delegate?.changeCaretPosition(textView.selectedRange)
         }

--- a/Anytype/Sources/PresentationLayer/Common/UIKit/TextView/CustomTextViewDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/Common/UIKit/TextView/CustomTextViewDelegate.swift
@@ -24,4 +24,6 @@ protocol CustomTextViewDelegate: AnyObject {
     func shouldPaste(range: NSRange) -> Bool
     func copy(range: NSRange)
     func cut(range: NSRange)
+
+    func escalateToBlockSelection()
 }

--- a/Anytype/Sources/PresentationLayer/Common/UIKit/TextView/Views/TextViewWithPlaceholder.swift
+++ b/Anytype/Sources/PresentationLayer/Common/UIKit/TextView/Views/TextViewWithPlaceholder.swift
@@ -32,6 +32,14 @@ final class TextViewWithPlaceholder: UITextView {
         }
     }
     var isLockedForEditing = false
+
+    // Where the selection is pinned while the user shift+arrows: UITextView exposes only the
+    // NSRange, so without the anchor a shift+Down that natively shrinks an upward selection is
+    // indistinguishable from one that has nothing left to extend and should escalate.
+    private var selectionAnchorLocation: Int?
+    private var previousSelectedRange: NSRange?
+    private let selectionProbe = UIPanGestureRecognizer()
+    private let handleSniffer = SelectionHandleSniffer()
     
     // MARK: - Internal variables
     
@@ -123,10 +131,83 @@ final class TextViewWithPlaceholder: UITextView {
         guard let customTextViewDelegate else {
             return super.copy(sender)
         }
-        
+
         customTextViewDelegate.cut(range: selectedRange)
     }
-    
+
+    // Arrow keys are "system behavior" inside a text view — the text input system consumes
+    // them before press events, so interception must happen at the key-command layer. UIKit
+    // queries this property per key press; the commands are offered only when the selection
+    // has nothing left to extend inside this block.
+    override var keyCommands: [UIKeyCommand]? {
+        var commands = super.keyCommands ?? []
+        if canEscalateSelection(down: true) {
+            commands.append(escalationCommand(input: UIKeyCommand.inputDownArrow))
+        }
+        if canEscalateSelection(down: false) {
+            commands.append(escalationCommand(input: UIKeyCommand.inputUpArrow))
+        }
+        return commands
+    }
+
+    private func escalationCommand(input: String) -> UIKeyCommand {
+        let command = UIKeyCommand(input: input, modifierFlags: .shift, action: #selector(escalateSelectionBeyondBoundary))
+        command.wantsPriorityOverSystemBehavior = true
+        return command
+    }
+
+    @objc private func escalateSelectionBeyondBoundary() {
+        customTextViewDelegate?.escalateToBlockSelection()
+    }
+
+    private func canEscalateSelection(down: Bool) -> Bool {
+        let selection = selectedRange
+        if down {
+            guard selection.location + selection.length == textStorage.length else { return false }
+            return selection.length == 0 || selectionAnchorLocation == selection.location
+        } else {
+            guard selection.location == 0 else { return false }
+            return selection.length == 0 || selectionAnchorLocation == selection.location + selection.length
+        }
+    }
+
+    func trackSelectionAnchor() {
+        let new = selectedRange
+        let old = previousSelectedRange
+        previousSelectedRange = new
+        if new.length == 0 {
+            selectionAnchorLocation = new.location
+        } else if let old, old.location == new.location {
+            selectionAnchorLocation = new.location
+        } else if let old, old.location + old.length == new.location + new.length {
+            selectionAnchorLocation = new.location + new.length
+        } else {
+            // A fresh selection (double-tap word, programmatic set) has no history; treating the
+            // start as the anchor matches how a subsequent shift+Down extends it natively.
+            selectionAnchorLocation = new.location
+        }
+    }
+
+    // MARK: - Selection handle escalation
+
+    /// The system's selection-handle drags never reach recognizers added to the editor view
+    /// hierarchy, but UIKit does consult a probe recognizer attached to the text view about
+    /// simultaneous recognition — handing over a live reference to the private range-adjustment
+    /// recognizer, which public `addTarget` can then observe. (Runestone/Steve Shepard pattern.)
+    var onSelectionHandlePan: ((UIPanGestureRecognizer) -> Void)?
+
+    private func setupSelectionHandleSniffer() {
+        handleSniffer.textView = self
+        selectionProbe.cancelsTouchesInView = false
+        selectionProbe.delaysTouchesBegan = false
+        selectionProbe.delegate = handleSniffer
+        addGestureRecognizer(selectionProbe)
+    }
+
+    fileprivate func handleSelectionHandlePan(_ recognizer: UIPanGestureRecognizer) {
+        onSelectionHandlePan?(recognizer)
+    }
+
     // MARK: - Initialization
     override init(
         frame: CGRect,
@@ -155,6 +236,7 @@ private extension TextViewWithPlaceholder {
     
     func setup() {
         textStorage.delegate = self
+        setupSelectionHandleSniffer()
         addSubview(placeholderLabel)
         
         placeholderLabel.layoutUsing.anchors {
@@ -193,6 +275,41 @@ extension TextViewWithPlaceholder: NSTextStorageDelegate {
     }
 }
 
+// The scroll view is the delegate of its own internal recognizers, so this must not be
+// implemented on the text view itself. For every touch the probe participates in, UIKit asks
+// about each peer recognizer — including private system ones — and that callback is the only
+// public place a reference to the selection-handle drag recognizer can be obtained.
+@MainActor
+private final class SelectionHandleSniffer: NSObject, UIGestureRecognizerDelegate {
+    weak var textView: TextViewWithPlaceholder?
+    private let observedRecognizers = NSHashTable<UIGestureRecognizer>.weakObjects()
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        sniff(otherGestureRecognizer)
+        return true
+    }
+
+    private func sniff(_ recognizer: UIGestureRecognizer) {
+        guard textView != nil, !observedRecognizers.contains(recognizer) else { return }
+        let className = String(describing: type(of: recognizer))
+        let rangeAdjustmentClass = NSClassFromString("UITextRangeAdjustmentGestureRecognizer")
+        let matchesClass = rangeAdjustmentClass.map { recognizer.isKind(of: $0) } ?? false
+        guard matchesClass || className.contains("RangeAdjustment") else { return }
+        // The target must not be the text view: the system recognizer is attached to that same
+        // text view and addTarget retains its target, which would close a retain cycle
+        // (textView → recognizer → textView). The sniffer only holds the text view weakly.
+        recognizer.addTarget(self, action: #selector(handleObservedRecognizer(_:)))
+        observedRecognizers.add(recognizer)
+    }
+
+    @objc private func handleObservedRecognizer(_ recognizer: UIPanGestureRecognizer) {
+        textView?.handleSelectionHandlePan(recognizer)
+    }
+}
+
 extension TextViewWithPlaceholder {
     override func addGestureRecognizer(_ gestureRecognizer: UIGestureRecognizer) {
         if gestureRecognizer.isKind(of: UILongPressGestureRecognizer.self) {
@@ -216,6 +333,11 @@ extension TextViewWithPlaceholder {
     
     func update(placeholder: NSAttributedString?) {
         placeholderLabel.attributedText = placeholder
+        // Visibility must be resynced synchronously here: cell (re)configuration sets the text
+        // programmatically before this call, and the didProcessEditing-driven sync below is a
+        // deferred task — a reused cell that last showed a placeholder would otherwise render
+        // it under the new non-empty text until that task wins the race.
+        syncPlaceholder()
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/SimpleTable/Block/TextBlock/SimpleTablesTextBlockActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/SimpleTable/Block/TextBlock/SimpleTablesTextBlockActionHandler.swift
@@ -144,7 +144,10 @@ final class SimpleTablesTextBlockActionHandler: TextBlockActionHandlerProtocol, 
             },
             tapOnCalloutIcon: { [weak self] in
                 self?.showTextIconPicker()
-            }
+            },
+            // Table cell text lives inside the table's own selection model; boundary escalation
+            // to page-level block multi-select does not apply here.
+            escalateToBlockSelection: { }
         )
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockActionHandler.swift
@@ -298,8 +298,17 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
             },
             tapOnCalloutIcon: { [weak self] in
                 self?.showTextIconPicker()
+            },
+            escalateToBlockSelection: { [weak self] in
+                self?.escalateToBlockSelection()
             }
         )
+    }
+
+    private func escalateToBlockSelection() {
+        guard !isVirtualUnmaterialized else { return }
+        guard info.content.type != .text(.title), info.content.type != .text(.description) else { return }
+        onEnterSelectionMode(info)
     }
 
     private func accessoryConfiguration(using textView: UITextView) -> TextViewAccessoryConfiguration {
@@ -713,6 +722,10 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
 
     @MainActor
     private func textViewDidChangeCaretPosition(textView: UITextView, range: NSRange) {
+        // A cleared selection (selectedTextRange = nil during the Enter/fork focus handoff) is
+        // not a caret position: recording NSNotFound would leave a poisoned pending focus that
+        // a later reconfigure consumes, stealing first responder back with an invalid caret.
+        guard range.location != NSNotFound else { return }
         accessoryViewStateManager.selectionDidChange(range: range)
         // A pending focus for a not-yet-created block would shadow the focus handoff to the
         // real block set during materialization.

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentConfiguration.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentConfiguration.swift
@@ -31,6 +31,8 @@ struct TextBlockContentConfiguration: BlockConfiguration {
         let toggleCheckBox: () -> Void
         let toggleDropDown: () -> Void
         let tapOnCalloutIcon: () -> Void
+
+        let escalateToBlockSelection: () -> Void
     }
     
     var blockId: String
@@ -138,7 +140,8 @@ extension TextBlockContentConfiguration {
             textViewShouldReplaceText: { _, _, _ in false },
             toggleCheckBox: { },
             toggleDropDown: { },
-            tapOnCalloutIcon: { }
+            tapOnCalloutIcon: { },
+            escalateToBlockSelection: { }
         )
     )
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView+TextViewDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView+TextViewDelegate.swift
@@ -49,6 +49,10 @@ extension TextBlockContentView: CustomTextViewDelegate {
     func keyboardAction(_ action: CustomTextView.KeyboardAction) {
         actions?.handleKeyboardAction(action, textView.textView)
     }
+
+    func escalateToBlockSelection() {
+        actions?.escalateToBlockSelection()
+    }
     
     func showObject(objectId: String) {
         actions?.showObject(objectId)

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView.swift
@@ -90,6 +90,13 @@ final class TextBlockContentView: UIView, BlockContentView, DynamicHeightView, F
     
     // MARK: - Apply configuration
     
+    /// Synchronous first-responder grab for the fork focus handoff. Runs right after the apply
+    /// that inserted this cell — outside the dequeue pass, where a synchronous
+    /// becomeFirstResponder is unsafe (see applyNewConfiguration).
+    func takeFocus(at position: BlockFocusPosition) {
+        textView.textView.setFocus(position)
+    }
+
     private func applyNewConfiguration(configuration: TextBlockContentConfiguration) {
         textView.textView.textStorage.setAttributedString(configuration.attributedString)
                 

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController+SelectionEscalation.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController+SelectionEscalation.swift
@@ -1,0 +1,348 @@
+import UIKit
+
+// Escalates an in-block text selection into block multi-select at the block boundary
+// (cross-block selection, phase 0). Entry points:
+// - a native selection drag (grabber or selection body) that leaves the focused text block,
+// - shift+arrow at the block edge, routed from TextViewWithPlaceholder through
+//   `escalateToBlockSelection`; further shift+arrows here grow the block selection.
+// Both end in the existing `.selecting` state, so copy/style/move work unchanged.
+
+struct SelectionEscalationPanContext {
+    let startedNearSelectionEdge: Bool
+    var isEscalated: Bool
+}
+
+extension EditorPageController {
+
+    private enum EscalationConstants {
+        static let edgeGrabSlop: CGFloat = 60
+        static let escapeThreshold: CGFloat = 32
+        static let autoscrollBand: CGFloat = 100
+        static let autoscrollMaxStep: CGFloat = 10
+        static let handoffProximity: CGFloat = 140
+    }
+
+    // MARK: - Grabber-drag escalation
+
+    @objc func handleSelectionEscalationPan(_ recognizer: UIPanGestureRecognizer) {
+        // A sniffed system range-adjustment recognizer IS the user dragging a selection handle —
+        // no start-proximity heuristic needed. It can also join mid-gesture (addTarget lands
+        // after its .began on the first drag), so the context bootstraps on .changed as well.
+        let isSystemHandleDrag = recognizer !== selectionEscalationPan
+        switch recognizer.state {
+        case .began:
+            beginEscalationContext(with: recognizer, isSystemHandleDrag: isSystemHandleDrag)
+        case .changed:
+            if selectionEscalationPanContext == nil {
+                beginEscalationContext(with: recognizer, isSystemHandleDrag: isSystemHandleDrag)
+            }
+            if selectionEscalationPanContext?.isEscalated == true {
+                updateEscalatedBlockSelection(with: recognizer)
+            } else {
+                escalateBlockSelectionIfNeeded(with: recognizer)
+            }
+        case .ended, .cancelled, .failed:
+            // Entering .selecting tears down the text selection UI, which cancels the system
+            // drag recognizer mid-touch. The same touch then resurfaces through the collection
+            // pan — open a short window for it to be adopted as the continuation.
+            var handoffOpened = false
+            if recognizer.state != .ended,
+               selectionEscalationPanContext?.isEscalated == true,
+               case .selecting = viewModel.blocksStateManager.editingState {
+                selectionEscalationHandoffDeadline = CACurrentMediaTime() + 0.25
+                handoffOpened = true
+            } else if recognizer.state == .ended {
+                selectionEscalationHandoffDeadline = 0
+            }
+            if !handoffOpened {
+                stopEscalationAutoscroll()
+            }
+            selectionEscalationPanContext = nil
+        default:
+            break
+        }
+    }
+
+    private func beginEscalationContext(with recognizer: UIPanGestureRecognizer, isSystemHandleDrag: Bool) {
+        // A second recognizer joining the same touch (e.g. the collection pan beginning while
+        // the system drag is still escalated) must not clobber live escalation state.
+        guard selectionEscalationPanContext?.isEscalated != true else { return }
+        selectionEscalationPanContext = SelectionEscalationPanContext(
+            startedNearSelectionEdge: isSystemHandleDrag || panStartedNearSelectionEdge(recognizer),
+            isEscalated: false
+        )
+        adoptContinuationPanIfHandingOff(with: recognizer)
+    }
+
+    private func adoptContinuationPanIfHandingOff(with recognizer: UIPanGestureRecognizer) {
+        guard CACurrentMediaTime() < selectionEscalationHandoffDeadline,
+              selectionEscalationAnchor != nil,
+              case .selecting = viewModel.blocksStateManager.editingState else { return }
+        // Only the resurfaced touch continues the drag: it reappears where the escalating drag
+        // last was. A stray tap elsewhere inside the window must not hijack the selection.
+        if let lastTouch = selectionEscalationLastTouchInView {
+            let location = recognizer.location(in: view)
+            guard hypot(location.x - lastTouch.x, location.y - lastTouch.y) < EscalationConstants.handoffProximity else { return }
+        }
+        selectionEscalationHandoffDeadline = 0
+        selectionEscalationPanContext?.isEscalated = true
+        startEscalationAutoscroll()
+    }
+
+    private func panStartedNearSelectionEdge(_ recognizer: UIPanGestureRecognizer) -> Bool {
+        guard let textView = firstResponderView as? UITextView,
+              textView.isFirstResponder,
+              textView.selectedRange.length > 0,
+              let selectedTextRange = textView.selectedTextRange else { return false }
+        let location = recognizer.location(in: collectionView)
+        let edgeRects = [
+            textView.caretRect(for: selectedTextRange.start),
+            textView.caretRect(for: selectedTextRange.end)
+        ]
+        return edgeRects.contains { rect in
+            guard !rect.isNull, !rect.isInfinite else { return false }
+            let converted = textView.convert(rect, to: collectionView)
+            return converted.insetBy(dx: -EscalationConstants.edgeGrabSlop, dy: -EscalationConstants.edgeGrabSlop)
+                .contains(location)
+        }
+    }
+
+    private func escalateBlockSelectionIfNeeded(with recognizer: UIPanGestureRecognizer) {
+        guard let anchorIndexPath = escalationAnchorIfEligible(with: recognizer) else { return }
+        selectionEscalationAnchor = anchorIndexPath
+        selectionEscalationPanContext?.isEscalated = true
+        startEscalationAutoscroll()
+        viewModel.blocksStateManager.didLongTap(at: anchorIndexPath)
+        updateEscalatedBlockSelection(with: recognizer)
+    }
+
+    private func escalationAnchorIfEligible(with recognizer: UIPanGestureRecognizer) -> IndexPath? {
+        guard case .editing = viewModel.blocksStateManager.editingState,
+              selectionEscalationPanContext?.startedNearSelectionEdge == true,
+              !collectionView.isLocked,
+              let textView = firstResponderView as? UITextView,
+              textView.isFirstResponder,
+              textView.selectedRange.length > 0 else { return nil }
+
+        // Screen space, deliberately: a grabber drag auto-scrolls the collection view, so in
+        // content coordinates the block runs away from the finger. On the stationary root view
+        // the geometry sorts itself out — during a plain scroll finger and block move together
+        // (no escape), while a grabber drag (or its autoscroll) moves the finger relative to
+        // the block until it escapes. There is no "selection pinned at text end" requirement
+        // either: below the last line UITextView maps the drag to the character at that x, so
+        // the selection never reaches the text end on a straight-down drag.
+        let locationInView = recognizer.location(in: view)
+        let textFrameInView = textView.convert(textView.bounds, to: view)
+        let escapedDown = locationInView.y > textFrameInView.maxY + EscalationConstants.escapeThreshold
+        let escapedUp = locationInView.y < textFrameInView.minY - EscalationConstants.escapeThreshold
+        guard escapedDown || escapedUp else { return nil }
+
+        guard let cell = textView.containingCollectionViewCell,
+              let anchorIndexPath = collectionView.indexPath(for: cell),
+              viewModel.blocksStateManager.canSelectBlock(at: anchorIndexPath) else { return nil }
+        return anchorIndexPath
+    }
+
+    private func updateEscalatedBlockSelection(with recognizer: UIPanGestureRecognizer) {
+        selectionEscalationLastTouchInView = recognizer.location(in: view)
+        updateEscalatedBlockSelection(atContentPoint: recognizer.location(in: collectionView))
+    }
+
+    private func updateEscalatedBlockSelection(atContentPoint location: CGPoint) {
+        guard case .selecting = viewModel.blocksStateManager.editingState,
+              let anchor = selectionEscalationAnchor,
+              let target = escalationTarget(for: location, anchor: anchor) else { return }
+
+        let lower = min(anchor.row, target.row)
+        let upper = max(anchor.row, target.row)
+        let desired = Set(
+            (lower...upper)
+                .map { IndexPath(row: $0, section: anchor.section) }
+                .filter { canSelect(indexPath: $0) }
+        )
+        let current = Set(
+            (collectionView.indexPathsForSelectedItems ?? []).filter { $0.section == anchor.section }
+        )
+        guard desired != current else { return }
+
+        desired.subtracting(current).forEach {
+            collectionView.selectItem(at: $0, animated: false, scrollPosition: [])
+        }
+        current.subtracting(desired).forEach {
+            collectionView.deselectItem(at: $0, animated: false)
+        }
+        viewModel.blocksStateManager.didUpdateSelectedIndexPaths(
+            collectionView.indexPathsForSelectedItems ?? [],
+            allSelected: isAllSelected()
+        )
+    }
+
+    private func escalationTarget(for location: CGPoint, anchor: IndexPath) -> IndexPath? {
+        if let hit = collectionView.indexPathForItem(at: location), hit.section == anchor.section {
+            return hit
+        }
+        let rows = collectionView.numberOfItems(inSection: anchor.section)
+        guard rows > 0,
+              let firstFrame = collectionView.layoutAttributesForItem(at: IndexPath(row: 0, section: anchor.section))?.frame,
+              let lastFrame = collectionView.layoutAttributesForItem(at: IndexPath(row: rows - 1, section: anchor.section))?.frame
+        else { return nil }
+        if location.y < firstFrame.minY { return IndexPath(row: 0, section: anchor.section) }
+        if location.y > lastFrame.maxY { return IndexPath(row: rows - 1, section: anchor.section) }
+        // A gap between cells: keep the current selection until the finger reaches a cell.
+        return nil
+    }
+
+    // MARK: - Scroll lock + edge autoscroll while extending
+
+    private func startEscalationAutoscroll() {
+        guard selectionEscalationAutoscroll == nil else { return }
+        collectionView.isScrollEnabled = false
+        let link = CADisplayLink(target: self, selector: #selector(escalationAutoscrollTick))
+        // .common: the run loop sits in tracking mode for the whole drag.
+        link.add(to: .main, forMode: .common)
+        selectionEscalationAutoscroll = link
+    }
+
+    func stopEscalationAutoscroll() {
+        selectionEscalationAutoscroll?.invalidate()
+        selectionEscalationAutoscroll = nil
+        selectionEscalationLastTouchInView = nil
+        collectionView.isScrollEnabled = true
+    }
+
+    @objc private func escalationAutoscrollTick() {
+        guard selectionEscalationPanContext?.isEscalated == true else {
+            // A stationary finger produces no pan events, so the handoff cannot be adopted by
+            // an event while the user pauses mid-drag. The collection pan still tracks the
+            // touch, so keep the window open while it lives; self-heal once the touch is gone.
+            if selectionEscalationPan.numberOfTouches > 0 {
+                selectionEscalationHandoffDeadline = CACurrentMediaTime() + 0.25
+            } else if CACurrentMediaTime() > selectionEscalationHandoffDeadline {
+                stopEscalationAutoscroll()
+            }
+            return
+        }
+        guard let touch = selectionEscalationLastTouchInView else { return }
+
+        let topActivation = view.safeAreaInsets.top + EscalationConstants.autoscrollBand
+        let bottomActivation = view.bounds.maxY - view.safeAreaInsets.bottom - EscalationConstants.autoscrollBand
+        var step: CGFloat = 0
+        if touch.y > bottomActivation {
+            step = min(1, (touch.y - bottomActivation) / EscalationConstants.autoscrollBand) * EscalationConstants.autoscrollMaxStep
+        } else if touch.y < topActivation {
+            step = -min(1, (topActivation - touch.y) / EscalationConstants.autoscrollBand) * EscalationConstants.autoscrollMaxStep
+        }
+        guard step != 0 else { return }
+
+        let insets = collectionView.adjustedContentInset
+        let minOffset = -insets.top
+        let maxOffset = max(minOffset, collectionView.contentSize.height - collectionView.bounds.height + insets.bottom)
+        let newOffset = min(max(collectionView.contentOffset.y + step, minOffset), maxOffset)
+        guard newOffset != collectionView.contentOffset.y else { return }
+
+        collectionView.contentOffset.y = newOffset
+        // The finger is stationary while content moves under it; retarget from screen space.
+        updateEscalatedBlockSelection(atContentPoint: view.convert(touch, to: collectionView))
+    }
+
+    // MARK: - Keyboard extension while selecting
+
+    override var canBecomeFirstResponder: Bool {
+        true
+    }
+
+    override var keyCommands: [UIKeyCommand]? {
+        guard case .selecting = viewModel.blocksStateManager.editingState else { return super.keyCommands }
+        let commands = [
+            UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: .shift, action: #selector(extendBlockSelectionDown)),
+            UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: .shift, action: #selector(extendBlockSelectionUp))
+        ]
+        commands.forEach { $0.wantsPriorityOverSystemBehavior = true }
+        return (super.keyCommands ?? []) + commands
+    }
+
+    @objc private func extendBlockSelectionDown() {
+        extendBlockSelection(down: true)
+    }
+
+    @objc private func extendBlockSelectionUp() {
+        extendBlockSelection(down: false)
+    }
+
+    private func extendBlockSelection(down: Bool) {
+        guard case .selecting = viewModel.blocksStateManager.editingState else { return }
+        let selected = (collectionView.indexPathsForSelectedItems ?? []).sorted()
+        guard let first = selected.first, let last = selected.last else { return }
+
+        // Escalation remembers its anchor; a selection begun by long tap anchors at its top row.
+        let anchor = selectionEscalationAnchor ?? first
+        if selectionEscalationAnchor == nil {
+            selectionEscalationAnchor = anchor
+        }
+
+        var changed = false
+        if down {
+            if first.row < anchor.row {
+                collectionView.deselectItem(at: first, animated: false)
+                changed = true
+            } else if let next = nextSelectableRow(from: last, forward: true) {
+                collectionView.selectItem(at: next, animated: false, scrollPosition: [])
+                revealRow(at: next)
+                changed = true
+            }
+        } else {
+            if last.row > anchor.row {
+                collectionView.deselectItem(at: last, animated: false)
+                changed = true
+            } else if let previous = nextSelectableRow(from: first, forward: false) {
+                collectionView.selectItem(at: previous, animated: false, scrollPosition: [])
+                revealRow(at: previous)
+                changed = true
+            }
+        }
+        guard changed else { return }
+
+        viewModel.blocksStateManager.didUpdateSelectedIndexPaths(
+            collectionView.indexPathsForSelectedItems ?? [],
+            allSelected: isAllSelected()
+        )
+    }
+
+    private func nextSelectableRow(from indexPath: IndexPath, forward: Bool) -> IndexPath? {
+        let rows = collectionView.numberOfItems(inSection: indexPath.section)
+        var row = indexPath.row + (forward ? 1 : -1)
+        while row >= 0 && row < rows {
+            let candidate = IndexPath(row: row, section: indexPath.section)
+            if canSelect(indexPath: candidate) { return candidate }
+            row += forward ? 1 : -1
+        }
+        return nil
+    }
+
+    private func revealRow(at indexPath: IndexPath) {
+        guard let frame = collectionView.layoutAttributesForItem(at: indexPath)?.frame else { return }
+        collectionView.scrollRectToVisible(frame.insetBy(dx: 0, dy: -8), animated: true)
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension EditorPageController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        gestureRecognizer === selectionEscalationPan
+    }
+}
+
+private extension UIView {
+    var containingCollectionViewCell: UICollectionViewCell? {
+        var current: UIView? = self
+        while let view = current {
+            if let cell = view as? UICollectionViewCell { return cell }
+            current = view.superview
+        }
+        return nil
+    }
+}

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
@@ -12,7 +12,7 @@ final class EditorPageController: UIViewController {
     
     let bottomNavigationManager: any EditorBottomNavigationManagerProtocol
     private(set) lazy var dataSource = makeCollectionViewDataSource()
-    private weak var firstResponderView: UIView?
+    private(set) weak var firstResponderView: UIView?
     private let layout = EditorCollectionFlowLayout()
     @Injected(\.keyboardHeightListener)
     private var keyboardListener: KeyboardHeightListener
@@ -51,6 +51,22 @@ final class EditorPageController: UIViewController {
         recognizer.minimumPressDuration = 0.3
         return recognizer
     }()
+
+    // Watches a native selection-grabber drag leave the focused text block and escalates it
+    // into block multi-select. Recognizes alongside the system text-selection gestures without
+    // consuming their touches; see EditorPageController+SelectionEscalation.
+    lazy var selectionEscalationPan: UIPanGestureRecognizer = {
+        let recognizer = UIPanGestureRecognizer(target: self, action: #selector(EditorPageController.handleSelectionEscalationPan))
+        recognizer.cancelsTouchesInView = false
+        recognizer.delaysTouchesBegan = false
+        recognizer.delegate = self
+        return recognizer
+    }()
+    var selectionEscalationAnchor: IndexPath?
+    var selectionEscalationPanContext: SelectionEscalationPanContext?
+    var selectionEscalationHandoffDeadline: CFTimeInterval = 0
+    var selectionEscalationAutoscroll: CADisplayLink?
+    var selectionEscalationLastTouchInView: CGPoint?
 
     private lazy var navigationBarHelper: EditorNavigationBarHelper = EditorNavigationBarHelper(
         navigationBarView: navigationBarView,
@@ -155,6 +171,9 @@ final class EditorPageController: UIViewController {
         UIApplication.shared.hideKeyboard()
         firstResponderView?.resignFirstResponder()
         view.endEditing(true)
+        // The autoscroll display link retains this controller and disables scrolling; an
+        // escalation drag interrupted by dismissal must not leave either behind.
+        stopEscalationAutoscroll()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -183,6 +202,13 @@ final class EditorPageController: UIViewController {
     }
     
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        // The controller becoming first responder in .selecting made motion events reachable
+        // there; shake-to-undo was only ever live while editing (text view first responder),
+        // so keep it that way.
+        guard case .editing = viewModel.blocksStateManager.editingState else {
+            shakeGestureStartDate = nil
+            return
+        }
         if motion == .motionShake && UIAccessibility.isShakeToUndoEnabled {
             if let startDate = shakeGestureStartDate {
                 defer { shakeGestureStartDate = nil }
@@ -215,7 +241,12 @@ final class EditorPageController: UIViewController {
             blocksSelectionOverlayView.isHidden = false
             collectionView.isLocked = false
             view.isUserInteractionEnabled = true
+            // With no text view active, the controller must sit at the head of the responder
+            // chain for the shift+arrow key commands that grow the block selection.
+            becomeFirstResponder()
         case .editing:
+            selectionEscalationAnchor = nil
+            stopEscalationAutoscroll()
             collectionView.deselectAllMovingItems()
             dividerCursorController.movingMode = .none
             setEditing(true, animated: true)
@@ -223,6 +254,7 @@ final class EditorPageController: UIViewController {
             collectionView.isLocked = false
             view.isUserInteractionEnabled = true
         case .moving(let indexPaths):
+            stopEscalationAutoscroll()
             dividerCursorController.movingMode = .drum
             setEditing(false, animated: true)
             indexPaths.forEach { indexPath in
@@ -232,6 +264,7 @@ final class EditorPageController: UIViewController {
             collectionView.isLocked = false
             view.isUserInteractionEnabled = true
         case .readonly:
+            stopEscalationAutoscroll()
             view.endEditing(true)
             collectionView.isLocked = true
             view.isUserInteractionEnabled = true
@@ -240,6 +273,7 @@ final class EditorPageController: UIViewController {
             view.endEditing(true)
             collectionView.isLocked = true
         case .loading:
+            stopEscalationAutoscroll()
             view.endEditing(true)
             view.isUserInteractionEnabled = false
         }
@@ -397,6 +431,17 @@ extension EditorPageController: EditorPageViewInput {
     
     func textBlockDidBeginEditing(firstResponderView: UIView) {
         self.firstResponderView = firstResponderView
+        // A selection display deactivated during a past Enter handoff (takeFocus) must come
+        // back the moment this block is edited again, in case UIKit does not re-activate it
+        // on its own — otherwise the block would edit with an invisible caret.
+        if let textView = firstResponderView as? UITextView {
+            setSelectionDisplay(true, for: textView)
+        }
+        if let textView = firstResponderView as? TextViewWithPlaceholder {
+            textView.onSelectionHandlePan = { [weak self] recognizer in
+                self?.handleSelectionEscalationPan(recognizer)
+            }
+        }
     }
 
     func itemDidChangeFrame(item: EditorItem) {
@@ -419,8 +464,69 @@ extension EditorPageController: EditorPageViewInput {
               let indexPath = dataSource.indexPath(for: item),
               let cell = collectionView.cellForItem(at: indexPath),
               let contentView = firstTextBlockContentView(in: cell) else { return false }
-        contentView.takeFocus(at: position)
+        // Switch the outgoing selection UI off at the interaction level before the responder
+        // moves: the caret is a self-perpetuating interaction-owned animation that ignores
+        // transaction suppression, but a deactivated interaction has nothing left to fade.
+        // This is the documented whole-interaction switch — not the cursorView subview, whose
+        // direct mutation leaves ghost carets. Reactivation happens on the next begin-editing
+        // of that block (see textBlockDidBeginEditing).
+        if let oldTextView = firstResponderView as? UITextView {
+            setSelectionDisplay(false, for: oldTextView)
+        }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        UIView.performWithoutAnimation {
+            contentView.takeFocus(at: position)
+        }
+        CATransaction.commit()
         return true
+    }
+
+    func isFirstResponderNearBottom() -> Bool {
+        guard let firstResponderView else { return false }
+        let frame = firstResponderView.convert(firstResponderView.bounds, to: collectionView)
+        let visibleMaxY = collectionView.contentOffset.y + collectionView.bounds.height - collectionView.adjustedContentInset.bottom
+        // Room below the focused block for one more row of roughly its own height?
+        return frame.maxY + frame.height > visibleMaxY
+    }
+
+    private func setSelectionDisplay(_ activated: Bool, for textView: UITextView) {
+        guard #available(iOS 17.0, *) else { return }
+        for interaction in textView.interactions {
+            guard let selectionDisplay = interaction as? UITextSelectionDisplayInteraction,
+                  selectionDisplay.isActivated != activated else { continue }
+            selectionDisplay.isActivated = activated
+            selectionDisplay.setNeedsSelectionUpdate()
+        }
+    }
+
+    func revealBlock(blockId: String) {
+        guard let item = dataSourceItem(for: blockId),
+              let indexPath = dataSource.indexPath(for: item) else { return }
+        // Runs in the same runloop iteration as the updates it follows, so the scroll lands in
+        // the same render commit: UIKit's own first-responder reveal comes a tick later, which
+        // renders the row change and the scroll as two visible steps.
+        UIView.performWithoutAnimation {
+            collectionView.layoutIfNeeded()
+            guard let cellFrame = collectionView.layoutAttributesForItem(at: indexPath)?.frame else { return }
+            let insets = collectionView.adjustedContentInset
+            let visibleMinY = collectionView.contentOffset.y + insets.top
+            let visibleMaxY = collectionView.contentOffset.y + collectionView.bounds.height - insets.bottom
+            var offsetY = collectionView.contentOffset.y
+            if cellFrame.maxY > visibleMaxY {
+                offsetY += cellFrame.maxY - visibleMaxY
+            } else if cellFrame.minY < visibleMinY {
+                offsetY -= visibleMinY - cellFrame.minY
+            }
+            // setContentOffset does not clamp: revealing a row near the document end would
+            // otherwise park the view overscrolled past the bottom inset.
+            let minOffsetY = -insets.top
+            let maxOffsetY = max(minOffsetY, collectionView.contentSize.height - collectionView.bounds.height + insets.bottom)
+            offsetY = min(max(offsetY, minOffsetY), maxOffsetY)
+            if offsetY != collectionView.contentOffset.y {
+                collectionView.setContentOffset(CGPoint(x: collectionView.contentOffset.x, y: offsetY), animated: false)
+            }
+        }
     }
 
     private func firstTextBlockContentView(in view: UIView) -> TextBlockContentView? {
@@ -495,6 +601,7 @@ private extension EditorPageController {
         collectionView.addGestureRecognizer(listViewTapGestureRecognizer)
 
         collectionView.addGestureRecognizer(longTapGestureRecognizer)
+        collectionView.addGestureRecognizer(selectionEscalationPan)
     }
     
     func setupLayout() {

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageController.swift
@@ -413,6 +413,24 @@ extension EditorPageController: EditorPageViewInput {
         self.firstResponderView = nil
     }
 
+    @discardableResult
+    func takeFocus(blockId: String, position: BlockFocusPosition) -> Bool {
+        guard let item = dataSourceItem(for: blockId),
+              let indexPath = dataSource.indexPath(for: item),
+              let cell = collectionView.cellForItem(at: indexPath),
+              let contentView = firstTextBlockContentView(in: cell) else { return false }
+        contentView.takeFocus(at: position)
+        return true
+    }
+
+    private func firstTextBlockContentView(in view: UIView) -> TextBlockContentView? {
+        if let view = view as? TextBlockContentView { return view }
+        for subview in view.subviews {
+            if let found = firstTextBlockContentView(in: subview) { return found }
+        }
+        return nil
+    }
+
     // MARK: -
     func endEditing() {
         view.endEditing(true)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewInput.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewInput.swift
@@ -42,4 +42,11 @@ protocol EditorPageViewInput: EditorCollectionReloadable {
     /// Returns false when the block's cell is not currently on screen.
     @discardableResult
     func takeFocus(blockId: String, position: BlockFocusPosition) -> Bool
+
+    /// Synchronously scrolls the block's row into the visible area without animation.
+    func revealBlock(blockId: String)
+
+    /// Whether a row inserted below the focused block would land past the visible bottom
+    /// (behind the keyboard), i.e. the insert will need a caret-visibility scroll.
+    func isFirstResponderNearBottom() -> Bool
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewInput.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewInput.swift
@@ -37,4 +37,9 @@ protocol EditorPageViewInput: EditorCollectionReloadable {
     func adjustContentOffset(relatively: UIView)
 
     func restoreEditingState()
+
+    /// Synchronously moves first responder into the on-screen text cell of `blockId`.
+    /// Returns false when the block's cell is not currently on screen.
+    @discardableResult
+    func takeFocus(blockId: String, position: BlockFocusPosition) -> Bool
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
@@ -47,11 +47,12 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
     private var didScrollToInitialBlock = false
     private var publishState: PublishState?
     private var trailingBlockPlaceholder: (session: VirtualTrailingBlockSession, item: EditorItem)?
-    // Old rows of just-consumed identity forks, kept in the snapshot until the replacing
-    // block's cell takes first responder over; see retainStaleForkRows.
-    private var staleForkHandoffs = [ForkFocusHandoff]()
+    // Focus handoffs for just-consumed arrivals (empty-block identity forks, Enter-created
+    // rows), completed synchronously right after the apply; fork entries additionally keep
+    // their old row in the snapshot meanwhile. See finishArrivalFocusHandoffs.
+    private var pendingFocusHandoffs = [ArrivalFocusHandoff]()
 
-    private struct ForkFocusHandoff {
+    private struct ArrivalFocusHandoff {
         let swap: BlockIdentitySwap
         let focusPosition: BlockFocusPosition
     }
@@ -160,11 +161,16 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
     }
     
     private func handleUpdate(ids: [String]) {
-        // An identity swap (virtual placeholder → real block, empty-block fork) must not be
-        // rendered as an animated delete+insert of the same visible content.
+        // An identity swap (virtual placeholder → real block, empty-block fork) must not render
+        // as an animated delete+insert of the same visible content. An Enter-created row keeps
+        // UIKit's native animated insert and caret move except at the bottom edge, where the
+        // insert competes with the caret-visibility scroll and renders as a jump — only there
+        // the unanimated one-commit pipeline takes over.
         let identitySwaps = blockIdentitySwapStorage.consumeSwaps(in: ids)
+        let needsBottomHandling = identitySwaps.contains(where: \.isKeyboardInsert) && viewInput?.isFirstResponderNearBottom() == true
+        let activeSwaps = identitySwaps.filter { !$0.isKeyboardInsert || needsBottomHandling }
         var blocksViewModels = blockBuilder.buildEditorItems(infos: ids, ignoreCache: false)
-        retainStaleForkRows(newSwaps: identitySwaps, in: &blocksViewModels)
+        retainStaleForkRows(newSwaps: activeSwaps, in: &blocksViewModels)
         if let trailingBlockPlaceholder {
             if let materializedId = trailingBlockPlaceholder.session.materializedBlockId,
                ids.contains(materializedId),
@@ -198,32 +204,34 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
             return
         }
 
-        viewInput?.update(changes: difference, allModels: modelsHolder.items, isRealData: true, animated: identitySwaps.isEmpty) { [weak self] in
+        viewInput?.update(changes: difference, allModels: modelsHolder.items, isRealData: true, animated: activeSwaps.isEmpty) { [weak self] in
             guard let self else { return }
             cursorManager.handleGeneralUpdate(with: modelsHolder.items, type: document.details?.type)
             initialScrollToBlockIfNeeded()
             removeStaleForkRowsAfterFocusHandoff()
         }
-        finishForkFocusHandoffs()
+        finishArrivalFocusHandoffs()
     }
 
     /// The empty-block identity fork replaces the focused block's row with a fresh id. Deleting
     /// the first responder's cell in that apply briefly dismisses the keyboard, so while a focus
     /// handoff to the forked id is pending, the old row stays in the snapshot — the trailing
-    /// placeholder's awaitingFocusHandoff trick. finishForkFocusHandoffs completes the swap right
-    /// after the apply, within the same render commit.
+    /// placeholder's awaitingFocusHandoff trick. finishArrivalFocusHandoffs completes the swap
+    /// right after the apply, within the same render commit.
     private func retainStaleForkRows(newSwaps: [BlockIdentitySwap], in items: inout [EditorItem]) {
-        // A pending focus for the new id means the old block's cell holds the keyboard; without
-        // it there is nothing to hand off (e.g. the fork ran on defocus).
+        // A pending focus for the new id means the arrival wants the keyboard: the old block's
+        // cell holds it (fork), or the caret is about to move into the created row (Enter).
         if let blockFocus = cursorManager.blockFocus {
-            staleForkHandoffs += newSwaps
-                .filter { $0.oldBlockId.isNotNil && blockFocus.id == $0.newBlockId }
-                .map { ForkFocusHandoff(swap: $0, focusPosition: blockFocus.position) }
+            pendingFocusHandoffs += newSwaps
+                .filter { blockFocus.id == $0.newBlockId }
+                .map { ArrivalFocusHandoff(swap: $0, focusPosition: blockFocus.position) }
         }
-        guard staleForkHandoffs.isNotEmpty else { return }
-        staleForkHandoffs.removeAll { handoff in
-            guard let oldBlockId = handoff.swap.oldBlockId,
-                  let oldModel = modelsHolder.blocksMapping[oldBlockId],
+        guard pendingFocusHandoffs.isNotEmpty else { return }
+        pendingFocusHandoffs.removeAll { handoff in
+            // Only fork rows have an old row to keep alive; Enter-created rows just wait for
+            // their synchronous focus in finishArrivalFocusHandoffs.
+            guard let oldBlockId = handoff.swap.oldBlockId else { return false }
+            guard let oldModel = modelsHolder.blocksMapping[oldBlockId],
                   items.firstIndex(blockId: oldBlockId) == nil,
                   let newIndex = items.firstIndex(blockId: handoff.swap.newBlockId) else { return true }
             // The old row keeps its position; the new block's row slides into it on removal.
@@ -232,42 +240,49 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
         }
     }
 
-    /// Runs right after the unanimated snapshot apply that inserted the replacing cells — the
-    /// apply is synchronous on the main queue, so the new cells are already on screen but nothing
-    /// has been committed to the render server yet. Moving first responder into the new cell and
-    /// dropping the stale row here keeps the whole swap inside one render commit: the transient
-    /// two-row layout never reaches the screen and the keyboard never dips.
-    private func finishForkFocusHandoffs() {
-        guard staleForkHandoffs.isNotEmpty, let viewInput else { return }
+    /// Runs right after the unanimated snapshot apply that inserted the arrived cells — the
+    /// apply is synchronous on the main queue, so the new cells are already on screen but
+    /// nothing has been committed to the render server yet. Moving first responder into the new
+    /// cell (with its caret scrolled visible) and dropping a fork's stale row here keeps the
+    /// whole arrival inside one render commit: no transient two-row layout, no keyboard dip,
+    /// and no separate insert-then-scroll step.
+    private func finishArrivalFocusHandoffs() {
+        guard pendingFocusHandoffs.isNotEmpty, let viewInput else { return }
         var removedIds = Set<String>()
-        staleForkHandoffs.removeAll { handoff in
-            guard let oldBlockId = handoff.swap.oldBlockId else { return true }
+        var focusedIds = [String]()
+        pendingFocusHandoffs.removeAll { handoff in
             guard viewInput.takeFocus(blockId: handoff.swap.newBlockId, position: handoff.focusPosition) else {
-                // Cell not on screen — removeStaleForkRowsAfterFocusHandoff picks it up.
-                return false
+                // Cell not on screen: the deferred initial focus covers Enter rows; fork rows
+                // stay pending for removeStaleForkRowsAfterFocusHandoff.
+                return handoff.swap.oldBlockId == nil
             }
-            removedIds.insert(oldBlockId)
+            handoff.swap.oldBlockId.map { removedIds.insert($0) }
+            focusedIds.append(handoff.swap.newBlockId)
             return true
         }
-        guard removedIds.isNotEmpty else { return }
-        let items = modelsHolder.items.filter { !removedIds.contains($0.blockId) }
-        guard items.count != modelsHolder.items.count else { return }
-        modelsHolder.items = items
-        guard document.isOpened else { return }
-        viewInput.update(changes: nil, allModels: items, isRealData: true, animated: false, completion: {})
+        if removedIds.isNotEmpty {
+            let items = modelsHolder.items.filter { !removedIds.contains($0.blockId) }
+            if items.count != modelsHolder.items.count, document.isOpened {
+                modelsHolder.items = items
+                viewInput.update(changes: nil, allModels: items, isRealData: true, animated: false, completion: {})
+            }
+        }
+        // Reveal only after the stale fork rows are gone: measuring the focused cell against a
+        // layout still inflated by a retained duplicate row scrolls one row too far.
+        focusedIds.forEach { viewInput.revealBlock(blockId: $0) }
     }
 
-    /// Fallback for handoffs finishForkFocusHandoffs could not complete synchronously (the new
-    /// cell was not on screen). Runs in the apply's completion: the new cell's deferred initial
-    /// focus was enqueued on the main queue during that apply, so after one more hop the old
-    /// text view has already handed first responder over and its row can be deleted without
+    /// Fallback for fork handoffs finishArrivalFocusHandoffs could not complete synchronously
+    /// (the new cell was not on screen). Runs in the apply's completion: the new cell's deferred
+    /// initial focus was enqueued on the main queue during that apply, so after one more hop the
+    /// old text view has already handed first responder over and its row can be deleted without
     /// touching the keyboard.
     private func removeStaleForkRowsAfterFocusHandoff() {
-        guard staleForkHandoffs.isNotEmpty else { return }
+        guard pendingFocusHandoffs.isNotEmpty else { return }
         DispatchQueue.main.async { [weak self] in
-            guard let self, staleForkHandoffs.isNotEmpty else { return }
-            let staleIds = Set(staleForkHandoffs.compactMap(\.swap.oldBlockId))
-            staleForkHandoffs.removeAll()
+            guard let self, pendingFocusHandoffs.isNotEmpty else { return }
+            let staleIds = Set(pendingFocusHandoffs.compactMap(\.swap.oldBlockId))
+            pendingFocusHandoffs.removeAll()
             let items = modelsHolder.items.filter { !staleIds.contains($0.blockId) }
             guard items.count != modelsHolder.items.count else { return }
             modelsHolder.items = items

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
@@ -47,6 +47,14 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
     private var didScrollToInitialBlock = false
     private var publishState: PublishState?
     private var trailingBlockPlaceholder: (session: VirtualTrailingBlockSession, item: EditorItem)?
+    // Old rows of just-consumed identity forks, kept in the snapshot until the replacing
+    // block's cell takes first responder over; see retainStaleForkRows.
+    private var staleForkHandoffs = [ForkFocusHandoff]()
+
+    private struct ForkFocusHandoff {
+        let swap: BlockIdentitySwap
+        let focusPosition: BlockFocusPosition
+    }
 
     @Published var bottomPanelHidden: Bool = false
     @Published var bottomPanelHiddenAnimated: Bool = true
@@ -154,8 +162,9 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
     private func handleUpdate(ids: [String]) {
         // An identity swap (virtual placeholder → real block, empty-block fork) must not be
         // rendered as an animated delete+insert of the same visible content.
-        let containsIdentitySwap = blockIdentitySwapStorage.consumeSwap(in: ids)
+        let identitySwaps = blockIdentitySwapStorage.consumeSwaps(in: ids)
         var blocksViewModels = blockBuilder.buildEditorItems(infos: ids, ignoreCache: false)
+        retainStaleForkRows(newSwaps: identitySwaps, in: &blocksViewModels)
         if let trailingBlockPlaceholder {
             if let materializedId = trailingBlockPlaceholder.session.materializedBlockId,
                ids.contains(materializedId),
@@ -189,10 +198,81 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
             return
         }
 
-        viewInput?.update(changes: difference, allModels: modelsHolder.items, isRealData: true, animated: !containsIdentitySwap) { [weak self] in
+        viewInput?.update(changes: difference, allModels: modelsHolder.items, isRealData: true, animated: identitySwaps.isEmpty) { [weak self] in
             guard let self else { return }
             cursorManager.handleGeneralUpdate(with: modelsHolder.items, type: document.details?.type)
             initialScrollToBlockIfNeeded()
+            removeStaleForkRowsAfterFocusHandoff()
+        }
+        finishForkFocusHandoffs()
+    }
+
+    /// The empty-block identity fork replaces the focused block's row with a fresh id. Deleting
+    /// the first responder's cell in that apply briefly dismisses the keyboard, so while a focus
+    /// handoff to the forked id is pending, the old row stays in the snapshot — the trailing
+    /// placeholder's awaitingFocusHandoff trick. finishForkFocusHandoffs completes the swap right
+    /// after the apply, within the same render commit.
+    private func retainStaleForkRows(newSwaps: [BlockIdentitySwap], in items: inout [EditorItem]) {
+        // A pending focus for the new id means the old block's cell holds the keyboard; without
+        // it there is nothing to hand off (e.g. the fork ran on defocus).
+        if let blockFocus = cursorManager.blockFocus {
+            staleForkHandoffs += newSwaps
+                .filter { $0.oldBlockId.isNotNil && blockFocus.id == $0.newBlockId }
+                .map { ForkFocusHandoff(swap: $0, focusPosition: blockFocus.position) }
+        }
+        guard staleForkHandoffs.isNotEmpty else { return }
+        staleForkHandoffs.removeAll { handoff in
+            guard let oldBlockId = handoff.swap.oldBlockId,
+                  let oldModel = modelsHolder.blocksMapping[oldBlockId],
+                  items.firstIndex(blockId: oldBlockId) == nil,
+                  let newIndex = items.firstIndex(blockId: handoff.swap.newBlockId) else { return true }
+            // The old row keeps its position; the new block's row slides into it on removal.
+            items.insert(.block(oldModel), at: newIndex)
+            return false
+        }
+    }
+
+    /// Runs right after the unanimated snapshot apply that inserted the replacing cells — the
+    /// apply is synchronous on the main queue, so the new cells are already on screen but nothing
+    /// has been committed to the render server yet. Moving first responder into the new cell and
+    /// dropping the stale row here keeps the whole swap inside one render commit: the transient
+    /// two-row layout never reaches the screen and the keyboard never dips.
+    private func finishForkFocusHandoffs() {
+        guard staleForkHandoffs.isNotEmpty, let viewInput else { return }
+        var removedIds = Set<String>()
+        staleForkHandoffs.removeAll { handoff in
+            guard let oldBlockId = handoff.swap.oldBlockId else { return true }
+            guard viewInput.takeFocus(blockId: handoff.swap.newBlockId, position: handoff.focusPosition) else {
+                // Cell not on screen — removeStaleForkRowsAfterFocusHandoff picks it up.
+                return false
+            }
+            removedIds.insert(oldBlockId)
+            return true
+        }
+        guard removedIds.isNotEmpty else { return }
+        let items = modelsHolder.items.filter { !removedIds.contains($0.blockId) }
+        guard items.count != modelsHolder.items.count else { return }
+        modelsHolder.items = items
+        guard document.isOpened else { return }
+        viewInput.update(changes: nil, allModels: items, isRealData: true, animated: false, completion: {})
+    }
+
+    /// Fallback for handoffs finishForkFocusHandoffs could not complete synchronously (the new
+    /// cell was not on screen). Runs in the apply's completion: the new cell's deferred initial
+    /// focus was enqueued on the main queue during that apply, so after one more hop the old
+    /// text view has already handed first responder over and its row can be deleted without
+    /// touching the keyboard.
+    private func removeStaleForkRowsAfterFocusHandoff() {
+        guard staleForkHandoffs.isNotEmpty else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self, staleForkHandoffs.isNotEmpty else { return }
+            let staleIds = Set(staleForkHandoffs.compactMap(\.swap.oldBlockId))
+            staleForkHandoffs.removeAll()
+            let items = modelsHolder.items.filter { !staleIds.contains($0.blockId) }
+            guard items.count != modelsHolder.items.count else { return }
+            modelsHolder.items = items
+            guard document.isOpened else { return }
+            viewInput?.update(changes: nil, allModels: items, isRealData: true, animated: false, completion: {})
         }
     }
     

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/NavigationBar/EditorNavigationBarTitleView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/NavigationBar/EditorNavigationBarTitleView.swift
@@ -12,6 +12,8 @@ final class EditorNavigationBarTitleView: UIView {
     private let glassBackground = GlassEffectViewIOS26()
     private let stackView = UIStackView()
     private let spacerView = UIView()
+    private let leadingSpacerView = UIView()
+    private var spacersEqualWidthConstraint: NSLayoutConstraint?
 
     private let iconImageView = IconViewUIKit()
     private let titleLabel = AnytypeLabel(style: .uxCalloutRegular)
@@ -72,6 +74,8 @@ extension EditorNavigationBarTitleView: ConfigurableView {
             iconImageView.isHidden = titleModel.icon.isNil
             iconImageView.icon = titleModel.icon
             arrowImageView.isHidden = true
+            leadingSpacerView.isHidden = true
+            spacersEqualWidthConstraint?.isActive = false
             stackViewLeadingConstraint?.constant = 6
         case let .modeTitle(text):
             titleLabel.setText(text, style: .uxTitle1Semibold)
@@ -79,6 +83,10 @@ extension EditorNavigationBarTitleView: ConfigurableView {
             stackView.isUserInteractionEnabled = false
             iconImageView.isHidden = true
             arrowImageView.isHidden = true
+            // No icon in this mode: without a leading counterweight the trailing spacer pins
+            // the text to the capsule's left edge; equal spacers center it instead.
+            leadingSpacerView.isHidden = false
+            spacersEqualWidthConstraint?.isActive = true
             stackViewLeadingConstraint?.constant = 6
         case let .templates(model):
             titleLabel.setText(Loc.TemplateSelection.Header.title, style: .caption1Medium)
@@ -86,6 +94,8 @@ extension EditorNavigationBarTitleView: ConfigurableView {
             stackView.addTapGesture { _ in model.onTap() }
             arrowImageView.isHidden = false
             iconImageView.isHidden = true
+            leadingSpacerView.isHidden = true
+            spacersEqualWidthConstraint?.isActive = false
             stackViewLeadingConstraint?.constant = 12
         }
         mode = model
@@ -153,6 +163,7 @@ private extension EditorNavigationBarTitleView {
         )
         stackViewLeadingConstraint?.isActive = true
 
+        stackView.addArrangedSubview(leadingSpacerView)
         stackView.addArrangedSubview(iconImageView)
         stackView.addArrangedSubview(titleLabel)
         stackView.addArrangedSubview(lockImageView)
@@ -162,6 +173,12 @@ private extension EditorNavigationBarTitleView {
         // Spacer expands to push content left
         spacerView.setContentHuggingPriority(.defaultLow, for: .horizontal)
         spacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        // Shown only in modeTitle, where matching the trailing spacer centers the label.
+        leadingSpacerView.isHidden = true
+        leadingSpacerView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        leadingSpacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        spacersEqualWidthConstraint = leadingSpacerView.widthAnchor.constraint(equalTo: spacerView.widthAnchor)
 
         iconImageView.layoutUsing.anchors {
             $0.size(CGSize(width: 32, height: 32))

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/VirtualTrailingBlock/VirtualTrailingBlockSession.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/VirtualTrailingBlock/VirtualTrailingBlockSession.swift
@@ -154,7 +154,7 @@ final class VirtualTrailingBlockSession: VirtualTrailingBlockSessionProtocol {
             position: .bottom
         )
         SessionCreatedBlockIdsStorage.shared.register(blockId)
-        blockIdentitySwapStorage.register(newBlockId: blockId, replacingBlockId: nil)
+        blockIdentitySwapStorage.register(newBlockId: blockId, replacingBlockId: nil, keyboardInsert: false)
         if let containerInfo = document.infoContainer.get(id: blockId),
            containerInfo.configurationData.parentId.isNotNil {
             return containerInfo

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/VirtualTrailingBlock/VirtualTrailingBlockSession.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/VirtualTrailingBlock/VirtualTrailingBlockSession.swift
@@ -154,7 +154,7 @@ final class VirtualTrailingBlockSession: VirtualTrailingBlockSessionProtocol {
             position: .bottom
         )
         SessionCreatedBlockIdsStorage.shared.register(blockId)
-        blockIdentitySwapStorage.register(blockId)
+        blockIdentitySwapStorage.register(newBlockId: blockId, replacingBlockId: nil)
         if let containerInfo = document.infoContainer.get(id: blockId),
            containerInfo.configurationData.parentId.isNotNil {
             return containerInfo

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetView.swift
@@ -114,7 +114,8 @@ struct EditorSetView: View {
                 model: model,
                 tableHeaderSize: $tableHeaderSize,
                 offset: $offset,
-                headerMinimizedSize: headerMinimizedSize
+                headerMinimizedSize: headerMinimizedSize,
+                fullHeaderHeight: tableHeaderFullSize.height
             )
         }
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel+DragAndDropDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetViewModel+DragAndDropDelegate.swift
@@ -35,6 +35,17 @@ extension EditorSetViewModel: SetDragAndDropDelegate {
         revertOptimisticCardMoves()
     }
 
+    // Menu-driven variant of a drag to another column: same optimistic move to the target's
+    // end, same persistence and revert-on-failure path.
+    func moveCard(_ configurationId: String, fromGroupId: String, toGroupId: String) {
+        guard canDragCards, fromGroupId != toGroupId else { return }
+        onDrag(
+            from: SetDragAndDropConfiguration(groupId: fromGroupId, configurationId: configurationId),
+            to: SetDragAndDropConfiguration(groupId: toGroupId, configurationId: nil)
+        )
+        _ = onDrop(configurationId: configurationId, fromGroupId: fromGroupId, toGroupId: toGroupId)
+    }
+
     func onDrop(configurationId: String, fromGroupId: String, toGroupId: String) -> Bool {
         guard canDragCards else {
             revertOptimisticCardMoves()

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/KanbanCollapseCoordinator.swift
@@ -1,0 +1,249 @@
+import SwiftUI
+import UIKit
+
+/// Drives the shared collapsing object header from the kanban columns' own scroll views.
+///
+/// The board has no whole-page vertical scroll. Every column reserves the collapse distance with
+/// a transparent top spacer in its scroll content, and the column the user is scrolling becomes
+/// the driver: its scroll *deltas* move `headerTravel`, which positions the shared object
+/// header. Deltas, not absolute offsets - a column scrolled deeper than the page must not make
+/// the header jump to its depth the moment it starts driving, and dragging any column down with
+/// the header already expanded must scroll only that column's cards.
+///
+/// Columns sitting exactly on the page line follow it in both directions - that is the
+/// whole-page scroll illusion, and it is what brings every synced column back to its own top
+/// when the page re-expands. Columns scrolled deeper keep their position until the page line
+/// catches them. Over-dragging past fully expanded bounces only the dragged column under a
+/// static header: followers cannot mirror a rubber band (UIKit re-clamps a non-interacting
+/// scroll view's out-of-range offset on every layout pass, which reads as flicker), so the
+/// header does not follow it either.
+///
+/// TODO: IOS-6595 - the introspection + KVO + setContentOffset plumbing exists only because
+/// SwiftUI on iOS 17 exposes neither scroll offsets nor pixel-level scroll control. Once the
+/// deployment target reaches iOS 18, replace it with `onScrollGeometryChange` (observation),
+/// `onScrollPhaseChange` (driver detection) and `ScrollPosition` (follower sync), and delete
+/// `kanbanCollapseSync`. The driver/follower rules stay as they are.
+@MainActor
+final class KanbanCollapseCoordinator {
+    var onHeaderTravelChange: ((CGFloat) -> Void)?
+    private(set) var headerTravel: CGFloat = 0
+
+    private struct Entry {
+        weak var scrollView: UIScrollView?
+        let observation: NSKeyValueObservation
+    }
+
+    private var entries = [ObjectIdentifier: Entry]()
+    // The settle point: the settings row rests at the top once the page has collapsed this far.
+    private var collapseDistance: CGFloat = 0
+    // The travel at which the object header is fully off-screen; tracking stops there so deep
+    // card scrolling doesn't publish useless updates.
+    private var headerTravelDistance: CGFloat = 0
+    private weak var driver: UIScrollView?
+    private var isSyncing = false
+
+    // The page line: how far the settings row and page-locked columns have collapsed. Header
+    // travel beyond it only slides the header's remainder out from behind the nav bar.
+    private var pageCollapse: CGFloat {
+        min(max(headerTravel, 0), collapseDistance)
+    }
+
+    func setDistances(collapse collapseDistance: CGFloat, headerTravel headerTravelDistance: CGFloat) {
+        self.collapseDistance = max(collapseDistance, 0)
+        self.headerTravelDistance = max(headerTravelDistance, self.collapseDistance)
+        applyTravel(min(headerTravel, self.headerTravelDistance), driver: nil)
+    }
+
+    func reset() {
+        headerTravel = 0
+        driver = nil
+    }
+
+    func register(_ scrollView: UIScrollView) {
+        // Backstop for teardown paths that skip `unregister` - the observation token holds the
+        // scroll view weakly, so entries of deallocated columns prune here.
+        entries = entries.filter { $0.value.scrollView != nil }
+
+        let id = ObjectIdentifier(scrollView)
+        guard entries[id] == nil else { return }
+
+        let observation = scrollView.observe(\.contentOffset, options: [.old, .new]) { [weak self] scrollView, change in
+            guard let self, let old = change.oldValue, let new = change.newValue else { return }
+            // UIScrollView reports contentOffset changes on the main thread.
+            MainActor.assumeIsolated {
+                self.offsetChanged(scrollView, delta: new.y - old.y)
+            }
+        }
+        entries[id] = Entry(scrollView: scrollView, observation: observation)
+
+        // A column materialized mid-collapse starts at zero offset; consume its spacer right
+        // away so it doesn't show a hole where the header used to be.
+        catchUp(scrollView)
+    }
+
+    func unregister(_ scrollView: UIScrollView) {
+        entries.removeValue(forKey: ObjectIdentifier(scrollView))?.observation.invalidate()
+        if driver === scrollView {
+            driver = nil
+        }
+    }
+
+    private func offsetChanged(_ scrollView: UIScrollView, delta: CGFloat) {
+        guard !isSyncing else { return }
+
+        let fingerDriven = scrollView.isTracking || scrollView.isDragging
+        let isActive = fingerDriven || scrollView.isDecelerating
+
+        if fingerDriven {
+            claimDriver(scrollView)
+        } else if isActive, driver == nil {
+            // Deceleration without a driver only happens if the driving column was deallocated.
+            driver = scrollView
+        }
+
+        guard driver === scrollView, isActive else {
+            if !fingerDriven {
+                catchUp(scrollView)
+            }
+            return
+        }
+
+        let rel = relativeOffset(scrollView)
+        var newTravel = headerTravel
+        // Upward deltas coming out of the top rubber band are dropped: the snap-back must not
+        // re-collapse what the stretch just expanded, or a column with no scroll range left
+        // could never finish expanding the header.
+        if delta < 0 || rel - delta >= 0 {
+            newTravel += delta
+        }
+        applyTravel(min(max(newTravel, 0), headerTravelDistance), driver: scrollView)
+    }
+
+    private func applyTravel(_ newTravel: CGFloat, driver: UIScrollView?) {
+        guard newTravel != headerTravel else { return }
+        let oldPage = pageCollapse
+        headerTravel = newTravel
+        let newPage = pageCollapse
+        if newPage != oldPage {
+            syncColumns(oldPage: oldPage, newPage: newPage, except: driver)
+        }
+        onHeaderTravelChange?(newTravel)
+    }
+
+    private func syncColumns(oldPage: CGFloat, newPage: CGFloat, except driver: UIScrollView?) {
+        for entry in entries.values {
+            guard
+                let scrollView = entry.scrollView,
+                scrollView !== driver,
+                !scrollView.isTracking, !scrollView.isDragging
+            else { continue }
+            let rel = relativeOffset(scrollView)
+            // Columns on the page line move with it in both directions; columns behind the new
+            // line are caught up so their spacer never shows as a hole; deeper columns keep
+            // their position until the line reaches them (Trello-style persistence).
+            if abs(rel - oldPage) <= Constants.lockTolerance || rel < newPage {
+                scroll(scrollView, to: newPage)
+            }
+        }
+    }
+
+    private func catchUp(_ scrollView: UIScrollView) {
+        let page = pageCollapse
+        guard relativeOffset(scrollView) < page - Constants.lockTolerance else { return }
+        scroll(scrollView, to: page)
+    }
+
+    private func scroll(_ scrollView: UIScrollView, to rel: CGFloat) {
+        isSyncing = true
+        // setContentOffset (not a plain assignment) also kills any in-flight deceleration, so a
+        // synced column doesn't keep drifting and fight the correction.
+        let target = CGPoint(
+            x: scrollView.contentOffset.x,
+            y: rel - scrollView.adjustedContentInset.top
+        )
+        scrollView.setContentOffset(target, animated: false)
+        isSyncing = false
+    }
+
+    // Only finger contact claims the header - a decelerating column never takes it back. The
+    // previous driver's fling is stopped dead (the same way a scroll view's own deceleration
+    // ends the moment you touch it): without this, two decelerating columns both feed deltas
+    // into the header and it flickers.
+    private func claimDriver(_ scrollView: UIScrollView) {
+        guard driver !== scrollView else { return }
+        if let previous = driver, previous.isDecelerating {
+            isSyncing = true
+            previous.setContentOffset(previous.contentOffset, animated: false)
+            isSyncing = false
+        }
+        driver = scrollView
+    }
+
+    private func relativeOffset(_ scrollView: UIScrollView) -> CGFloat {
+        scrollView.contentOffset.y + scrollView.adjustedContentInset.top
+    }
+}
+
+private extension KanbanCollapseCoordinator {
+    enum Constants {
+        // Columns are placed on the page line by our own setContentOffset, so matches are
+        // near-exact; the tolerance only absorbs float noise.
+        static let lockTolerance: CGFloat = 1
+    }
+}
+
+extension View {
+    /// Registers the enclosing scroll view as one of the kanban columns driving the header
+    /// collapse. Apply to the column scroll view's *content*, like `scrollAxisLock`.
+    func kanbanCollapseSync(_ coordinator: KanbanCollapseCoordinator) -> some View {
+        background(KanbanCollapseSyncView(coordinator: coordinator))
+    }
+}
+
+private struct KanbanCollapseSyncView: UIViewRepresentable {
+    let coordinator: KanbanCollapseCoordinator
+
+    func makeUIView(context: Context) -> UIView {
+        KanbanCollapseSyncUIView(coordinator: coordinator)
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}
+
+private final class KanbanCollapseSyncUIView: UIView {
+    private let coordinator: KanbanCollapseCoordinator
+    private weak var registeredScrollView: UIScrollView?
+
+    init(coordinator: KanbanCollapseCoordinator) {
+        self.coordinator = coordinator
+        super.init(frame: .zero)
+        isUserInteractionEnabled = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil {
+            guard let scrollView = enclosingScrollView else { return }
+            registeredScrollView = scrollView
+            coordinator.register(scrollView)
+        } else if let scrollView = registeredScrollView {
+            // Deterministic cleanup on teardown and on the whole board leaving the window
+            // (navigation push); reattachment re-registers and catches the column up.
+            registeredScrollView = nil
+            coordinator.unregister(scrollView)
+        }
+    }
+
+    private var enclosingScrollView: UIScrollView? {
+        var ancestor: UIView? = superview
+        while let current = ancestor {
+            if let scrollView = current as? UIScrollView { return scrollView }
+            ancestor = current.superview
+        }
+        return nil
+    }
+}

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift
@@ -9,34 +9,103 @@ struct SetKanbanView: View {
     @Binding var offset: CGPoint
 
     @State private var dropData = SetCardDropData()
+    @State private var headerTravel: CGFloat = 0
+    @State private var settingsHeaderSize = CGSize.zero
+    @State private var collapseCoordinator = KanbanCollapseCoordinator()
 
     var headerMinimizedSize: CGSize
+    // Full object header height including the top safe area - the travel at which the header
+    // has slid completely off-screen.
+    var fullHeaderHeight: CGFloat
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer.fixedHeight(max(tableHeaderSize.height - headerMinimizedSize.height, 0))
-            if !model.isEmptyViews {
-                compoundHeader
-                boardView
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .onAppear {
+                collapseCoordinator.onHeaderTravelChange = { travel in
+                    headerTravel = travel
+                    offset = CGPoint(x: 0, y: -travel)
+                }
             }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .onAppear {
-            // The board doesn't scroll vertically as a whole, so the shared
-            // offset must be reset after switching from a scrolled view type.
-            offset = .zero
-        }
+            .onDisappear {
+                // The closure captures the view, whose @State storage owns the coordinator -
+                // break the cycle or the coordinator outlives the board.
+                collapseCoordinator.onHeaderTravelChange = nil
+            }
+            .onChange(of: collapseDistance, initial: true) { _, _ in
+                updateCoordinatorDistances()
+            }
+            .onChange(of: fullHeaderHeight) { _, _ in
+                updateCoordinatorDistances()
+            }
+            .onChange(of: showsBoard, initial: true) { _, showsBoard in
+                if showsBoard {
+                    offset = CGPoint(x: 0, y: -headerTravel)
+                } else {
+                    collapseCoordinator.reset()
+                    headerTravel = 0
+                    offset = .zero
+                }
+            }
+    }
+
+    // The distance the page must scroll before the settings row rests at the top. The object
+    // header keeps sliding past this point (up to fullHeaderHeight) as cards scroll on.
+    private var collapseDistance: CGFloat {
+        max(tableHeaderSize.height - headerMinimizedSize.height, 0)
+    }
+
+    private func updateCoordinatorDistances() {
+        collapseCoordinator.setDistances(collapse: collapseDistance, headerTravel: fullHeaderHeight)
+    }
+
+    private var showsBoard: Bool {
+        !model.isEmptyViews && model.boardState == .ready
     }
 
     @ViewBuilder
-    private var boardView: some View {
-        switch model.boardState {
-        case .loading:
-            loadingView
-        case .error:
-            errorView
-        case .ready:
-            boardContent
+    private var content: some View {
+        if showsBoard {
+            board
+        } else {
+            staticHeader
+        }
+    }
+
+    // Loading/error/empty states have no columns to drive the collapse, so the header stays
+    // expanded and the settings row keeps its resting position below it.
+    private var staticHeader: some View {
+        VStack(spacing: 0) {
+            Spacer.fixedHeight(collapseDistance)
+            if !model.isEmptyViews {
+                compoundHeader
+                switch model.boardState {
+                case .loading:
+                    loadingView
+                case .error:
+                    errorView
+                case .ready:
+                    EmptyView()
+                }
+            }
+        }
+    }
+
+    // The board never scrolls vertically as a page. Each column reserves `collapseDistance`
+    // points with a top spacer inside its own scroll content, the actively scrolled column
+    // publishes the shared `headerTravel`, and the settings row + object header are overlays
+    // slaved to it - so the whole page visually scrolls as one, like the other view types.
+    private var board: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .top) {
+                boardContent(viewportHeight: geometry.size.height)
+                    .padding(.top, settingsHeaderSize.height)
+
+                compoundHeader
+                    .readSize { settingsHeaderSize = $0 }
+                    // Stops at the top once the collapse is consumed.
+                    .offset(y: collapseDistance - min(headerTravel, collapseDistance))
+            }
         }
     }
 
@@ -59,8 +128,11 @@ struct SetKanbanView: View {
         .padding(.top, 60)
     }
 
-    private var boardContent: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
+    private func boardContent(viewportHeight: CGFloat) -> some View {
+        let moveTargets = model.configurationsDict.keys.map { groupId in
+            SetKanbanMoveTarget(id: groupId, title: model.headerType(for: groupId).title)
+        }
+        return ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(alignment: .top, spacing: 8) {
                 ForEach(model.configurationsDict.keys, id: \.self) { groupId in
                     if let configurations = model.configurationsDict[groupId] {
@@ -72,6 +144,10 @@ struct SetKanbanView: View {
                             isGroupBackgroundColors: model.isGroupBackgroundColors,
                             backgroundColor: model.groupBackgroundColor(for: groupId),
                             showPagingView: model.pagitationData(by: groupId).pageCount > 1,
+                            collapseDistance: collapseDistance,
+                            minContentHeight: viewportHeight - settingsHeaderSize.height + collapseDistance,
+                            collapseCoordinator: collapseCoordinator,
+                            moveTargets: moveTargets,
                             dragAndDropDelegate: model,
                             dropData: $dropData,
                             onShowMoreTap: {
@@ -82,6 +158,9 @@ struct SetKanbanView: View {
                             },
                             onCreateTap: model.canCreateCardInColumn ? {
                                 model.onCreateObjectInColumnTap(groupId)
+                            } : nil,
+                            onMoveTap: model.canDragCards ? { configurationId, toGroupId in
+                                model.moveCard(configurationId, fromGroupId: groupId, toGroupId: toGroupId)
                             } : nil
                         )
                     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift
@@ -9,44 +9,80 @@ struct SetKanbanColumn: View {
     let isGroupBackgroundColors: Bool
     let backgroundColor: BlockBackgroundColor
     let showPagingView: Bool
-    
+    // The first `collapseDistance` points of this column's scroll collapse the shared object
+    // header instead of moving cards: a same-height top spacer reserves that travel, and the
+    // coordinator mirrors the offset into the header overlays.
+    let collapseDistance: CGFloat
+    // Viewport height + collapseDistance, so even a short column can always scroll far enough
+    // to fully collapse the header.
+    let minContentHeight: CGFloat
+    let collapseCoordinator: KanbanCollapseCoordinator
+
+    // Every column of the board, for the card's "Move to" menu; this column filters itself out.
+    let moveTargets: [SetKanbanMoveTarget]
+
     let dragAndDropDelegate: any SetDragAndDropDelegate
     @Binding var dropData: SetCardDropData
-    
+
     let onShowMoreTap: () -> Void
     let onSettingsTap: () -> Void
     let onCreateTap: (() -> Void)?
+    let onMoveTap: ((_ configurationId: String, _ toGroupId: String) -> Void)?
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-                .padding(.horizontal, 8)
-                .background(
-                    columnBackgroundColor,
-                    in: .rect(topLeadingRadius: 4, topTrailingRadius: 4)
-                )
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 0) {
-                    column
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, configurations.isEmpty ? 0 : Constants.contentInset)
-                        .background(
-                            columnBackgroundColor,
-                            in: .rect(bottomLeadingRadius: 4, bottomTrailingRadius: 4)
-                        )
-                    if configurations.isEmpty {
-                        emptyDroppableArea
+        ScrollView(.vertical, showsIndicators: false) {
+            // The whole column is a drop target: without it, a release over the top spacer,
+            // the pinned header, the gaps between cards or the empty bottom area performs no
+            // drop - the card stays dimmed and the move never persists.
+            SetDragAndDropView(
+                dropData: $dropData,
+                configuration: nil,
+                groupId: groupId,
+                dragAndDropDelegate: dragAndDropDelegate,
+                content: {
+                    VStack(spacing: 0) {
+                        Spacer.fixedHeight(collapseDistance)
+                        LazyVStack(spacing: 8, pinnedViews: [.sectionHeaders]) {
+                            Section(header: pinnedHeader) {
+                                cards
+                            }
+                        }
+                        .padding(.bottom, configurations.isEmpty ? 0 : Constants.contentInset)
+                        .background(columnBackgroundColor, in: .rect(cornerRadius: 4))
+                        // Room to scroll the last card and the create button clear of the
+                        // floating home panel, whose blur intercepts touches full-width.
+                        AnytypeNavigationSpacer()
                     }
-                    // Room to scroll the last card and the create button clear of the floating
-                    // home panel, whose blur intercepts touches across the full width.
-                    AnytypeNavigationSpacer()
+                    .frame(minHeight: minContentHeight, alignment: .top)
                 }
-                .scrollAxisLock(.vertical)
-            }
-            .scrollBounceBehavior(.basedOnSize)
-            .overlay(alignment: .top) { topFade }
+            )
+            .scrollAxisLock(.vertical)
+            .kanbanCollapseSync(collapseCoordinator)
         }
+        .scrollBounceBehavior(.basedOnSize)
         .frame(width: 270)
+    }
+
+    // Stays inside the scroll view so drags starting on it still drive the collapse, and pins to
+    // the column viewport top once the header travel is consumed.
+    private var pinnedHeader: some View {
+        header
+            .padding(.horizontal, 8)
+            .background {
+                // Opaque even when the group tint is translucent - cards scroll under the
+                // pinned header.
+                ZStack {
+                    headerBackgroundShape.fill(Color.Background.primary)
+                    headerBackgroundShape.fill(columnBackgroundColor)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                topFade.offset(y: Constants.contentInset)
+            }
+    }
+
+    private var headerBackgroundShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(topLeadingRadius: 4, topTrailingRadius: 4)
     }
 
     private var columnBackgroundColor: Color {
@@ -55,9 +91,10 @@ struct SetKanbanColumn: View {
         Color.Background.primary
     }
 
-    // Softens the hard clip under the header: cards dissolve into the column's own color instead
-    // of being cut off. The group tint is translucent, so the fade has to be its composite over
-    // the board background - fading to the tint alone would leave cards showing through it.
+    // Softens the hard clip under the pinned header: cards dissolve into the column's own color
+    // instead of being cut off. The group tint is translucent, so the fade has to be its
+    // composite over the board background - fading to the tint alone would leave cards showing
+    // through it.
     private var topFade: some View {
         ZStack {
             Color.Background.primary
@@ -70,27 +107,52 @@ struct SetKanbanColumn: View {
         .allowsHitTesting(false)
     }
 
-    private var column: some View {
-        LazyVStack(spacing: 8) {
-            ForEach(configurations) { configuration in
-                SetDragAndDropView(
-                    dropData: $dropData,
-                    configuration: configuration,
-                    groupId: groupId,
-                    dragAndDropDelegate: dragAndDropDelegate,
-                    content: {
-                        SetGalleryViewCell(configuration: configuration)
+    @ViewBuilder
+    private var cards: some View {
+        ForEach(configurations) { configuration in
+            SetDragAndDropView(
+                dropData: $dropData,
+                configuration: configuration,
+                groupId: groupId,
+                dragAndDropDelegate: dragAndDropDelegate,
+                content: {
+                    SetGalleryViewCell(configuration: configuration)
+                }
+            )
+            // A stationary long press opens the menu; moving during the press still starts
+            // the drag - the underlying UIKit interactions arbitrate between the two.
+            .ifLet(onMoveTap) { view, onMoveTap in
+                view.contextMenu {
+                    moveMenu(for: configuration, onMoveTap: onMoveTap)
+                }
+            }
+            .padding(.horizontal, 8)
+        }
+        if showPagingView {
+            pagingView
+                .padding(.horizontal, 8)
+        }
+        if let onCreateTap {
+            createView(onCreateTap)
+                .padding(.horizontal, 8)
+        }
+    }
+
+    @ViewBuilder
+    private func moveMenu(
+        for configuration: SetContentViewItemConfiguration,
+        onMoveTap: @escaping (_ configurationId: String, _ toGroupId: String) -> Void
+    ) -> some View {
+        let targets = moveTargets.filter { $0.id != groupId }
+        if !targets.isEmpty {
+            Menu(Loc.moveTo) {
+                ForEach(targets) { target in
+                    Button(target.title) {
+                        onMoveTap(configuration.id, target.id)
                     }
-                )
-            }
-            if showPagingView {
-                pagingView
-            }
-            if let onCreateTap {
-                createView(onCreateTap)
+                }
             }
         }
-        .frame(width: 254)
     }
 
     private func createView(_ onTap: @escaping () -> Void) -> some View {
@@ -118,7 +180,7 @@ struct SetKanbanColumn: View {
             }
         )
     }
-    
+
     private var header: some View {
         Button {
             onSettingsTap()
@@ -129,7 +191,7 @@ struct SetKanbanColumn: View {
         .frame(height: 44)
         .buttonStyle(LightDimmingButtonStyle())
     }
-    
+
     private var headerContent: some View {
         HStack(spacing: 0) {
             switch headerType {
@@ -172,7 +234,7 @@ struct SetKanbanColumn: View {
         }
         .padding(.horizontal, 10)
     }
-    
+
     private var pagingView: some View {
         Button {
             onShowMoreTap()
@@ -196,20 +258,7 @@ struct SetKanbanColumn: View {
             }
         }
     }
-    
-    private var emptyDroppableArea: some View {
-        SetDragAndDropView(
-            dropData: $dropData,
-            configuration: nil,
-            groupId: groupId,
-            dragAndDropDelegate: dragAndDropDelegate,
-            content: {
-                Rectangle()
-                    .fill(Color.Background.primary)
-                    .frame(height: 44)
-            }
-        )
-    }
+
 }
 
 extension SetKanbanColumn {

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumnHeaderType.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumnHeaderType.swift
@@ -3,4 +3,28 @@ enum SetKanbanColumnHeaderType {
     case status([Property.Status.Option])
     case tag([Property.Tag.Option])
     case checkbox(title: String, isChecked: Bool)
+
+    // Plain-text column name for places that can't render the styled header, like the card's
+    // "Move to" menu.
+    var title: String {
+        switch self {
+        case .uncategorized:
+            return Loc.Set.View.Kanban.Column.Title.uncategorized
+        case let .status(options):
+            let title = options.map(\.text).joined(separator: ", ")
+            return title.isEmpty ? Loc.Set.View.Kanban.Column.Title.uncategorized : title
+        case let .tag(options):
+            let title = options.map(\.text).joined(separator: ", ")
+            return title.isEmpty ? Loc.Set.View.Kanban.Column.Title.uncategorized : title
+        case let .checkbox(title, isChecked):
+            return isChecked ?
+            Loc.Set.View.Kanban.Column.Title.checked(title) :
+            Loc.Set.View.Kanban.Column.Title.unchecked(title)
+        }
+    }
+}
+
+struct SetKanbanMoveTarget: Identifiable {
+    let id: String
+    let title: String
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetCardDropInsideDelegate.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Models/SetCardDropInsideDelegate.swift
@@ -23,22 +23,28 @@ final class SetCardDropInsideDelegate: DropDelegate {
             return
         }
 
-        dragAndDropDelegate.onDrag(
-            from: SetDragAndDropConfiguration(
-                groupId: fromGroupId,
-                configurationId: draggingCard.id
-            ),
-            to: SetDragAndDropConfiguration(
-                groupId: toGroupId,
-                configurationId: droppingCard?.id
+        // A background target (no specific card under the drag) appends only when coming from
+        // another column; inside the card's own column it must not teleport the card to the
+        // end - it just arms performDrop for a release over the column's empty areas.
+        let movesCard = droppingCard != nil || fromGroupId != toGroupId
+        if movesCard {
+            dragAndDropDelegate.onDrag(
+                from: SetDragAndDropConfiguration(
+                    groupId: fromGroupId,
+                    configurationId: draggingCard.id
+                ),
+                to: SetDragAndDropConfiguration(
+                    groupId: toGroupId,
+                    configurationId: droppingCard?.id
+                )
             )
-        )
 
-        if fromGroupId != toGroupId {
-            data.fromGroupId = toGroupId
+            if fromGroupId != toGroupId {
+                data.fromGroupId = toGroupId
+            }
+
+            UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
         }
-
-        UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
 
         data.droppingCard = droppingCard
         data.toGroupId = toGroupId

--- a/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/SetDragAndDropView/SetDragAndDropView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Set/Views/SetDragAndDropView/SetDragAndDropView.swift
@@ -47,7 +47,11 @@ struct SetDragAndDropView<Content>: View where Content: View {
                             }
                             return provider
                         }
-                        .opacity(dropData.draggingCard?.id == configuration.id ? 0.4 : 1)
+                        // Dim only once a drop target has been entered, not on payload
+                        // creation alone: SwiftUI may invoke the onDrag closure without a real
+                        // drag (e.g. the armed context-menu interaction re-requesting the
+                        // payload after a drop), and that must not re-dim the card.
+                        .opacity(dropData.draggingCard?.id == configuration.id && dropData.toGroupId != nil ? 0.4 : 1)
                 }
                 .onDrop(
                     of: SetItemProviderObject.writableTypeIdentifiersForItemProvider,

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionService/BlockActionService.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionService/BlockActionService.swift
@@ -57,7 +57,7 @@ final class BlockActionService: BlockActionServiceProtocol {
     func replaceBlock(info: BlockInformation, blockId: String, focusAt: BlockFocusPosition?) async throws -> String {
         let newBlockId = try await blockService.replaceBlock(contextId: documentId, blockId: blockId, info: info)
         SessionCreatedBlockIdsStorage.shared.register(newBlockId)
-        blockIdentitySwapStorage.register(newBlockId)
+        blockIdentitySwapStorage.register(newBlockId: newBlockId, replacingBlockId: blockId)
 
         if let focusAt {
             cursorManager.blockFocus = BlockFocus(id: newBlockId, position: focusAt)

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionService/BlockActionService.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/BlockActionService/BlockActionService.swift
@@ -57,7 +57,7 @@ final class BlockActionService: BlockActionServiceProtocol {
     func replaceBlock(info: BlockInformation, blockId: String, focusAt: BlockFocusPosition?) async throws -> String {
         let newBlockId = try await blockService.replaceBlock(contextId: documentId, blockId: blockId, info: info)
         SessionCreatedBlockIdsStorage.shared.register(newBlockId)
-        blockIdentitySwapStorage.register(newBlockId: newBlockId, replacingBlockId: blockId)
+        blockIdentitySwapStorage.register(newBlockId: newBlockId, replacingBlockId: blockId, keyboardInsert: false)
 
         if let focusAt {
             cursorManager.blockFocus = BlockFocus(id: newBlockId, position: focusAt)
@@ -88,8 +88,18 @@ final class BlockActionService: BlockActionServiceProtocol {
         )
         SessionCreatedBlockIdsStorage.shared.register(blockId)
 
+        // The events bunch below renders the created row while this task is suspended, so the
+        // unanimated-arrival registration and the focus intent must both be in place first —
+        // the editor then shows the row, moves the caret into it and scrolls it visible in one
+        // render commit instead of three visible steps.
+        blockIdentitySwapStorage.register(newBlockId: blockId, replacingBlockId: nil, keyboardInsert: true)
         cursorManager.focus(at: blockId, position: .beginning)
         cursorManager.blockFocus = BlockFocus(id: blockId, position: .beginning)
+
+        await EventsBunch(
+            contextId: documentId,
+            localEvents: [.general]
+        ).send()
     }
 
     func duplicate(blockId: String) {

--- a/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/KeyboardActionHandler/KeyboardActionHandler.swift
+++ b/Anytype/Sources/ServiceLayer/Block/BlockActionHandler/KeyboardActionHandler/KeyboardActionHandler.swift
@@ -25,8 +25,10 @@ final class KeyboardActionHandler: KeyboardActionHandlerProtocol {
     
     @Injected(\.blockService)
     private var blockService: any BlockServiceProtocol
-    
-    
+    @Injected(\.blockIdentitySwapStorage)
+    private var blockIdentitySwapStorage: any BlockIdentitySwapStorageProtocol
+
+
     init(
         documentId: String,
         spaceId: String,
@@ -70,7 +72,8 @@ final class KeyboardActionHandler: KeyboardActionHandlerProtocol {
             }
             
             if info.childrenIds.isNotEmpty {
-                try await service.add(info: .emptyText, targetBlockId: info.id, position: .top, setFocus: false)
+                let newBlockId = try await service.add(info: .emptyText, targetBlockId: info.id, position: .top, setFocus: false)
+                registerUnanimatedArrival(newBlockId)
             } else {
                 try await service.setAndSplit(
                     NSAttributedString(string: "").sendable(),
@@ -100,16 +103,19 @@ final class KeyboardActionHandler: KeyboardActionHandlerProtocol {
                 try await enterForEmpty(text: text, info: info)
                 return
             }
+            // No scrollToTextViewIfNotVisible here: the editor reveals the created row
+            // synchronously during the focus handoff, and this delayed pass — aimed at the
+            // pre-split block's text view — would nudge the settled position a beat later.
             try await onEnterAtTheEndOfContent(info: info, text: text, range: range, action: action, newString: string.sendable())
-            editorCollectionController.scrollToTextViewIfNotVisible(textView: textView)
         case .enterAtTheBegining:
-            try await service.add(
+            let newBlockId = try await service.add(
                 info: .empty(content: .text(.empty(contentType: text.contentType))),
                 targetBlockId: info.id,
                 position: .top,
                 setFocus: false
             )
-            
+            registerUnanimatedArrival(newBlockId)
+
             editorCollectionController.scrollToTextViewIfNotVisible(textView: textView)
         case .delete:
             try await onDelete(text: text, info: info, parent: parent, textView: textView)
@@ -159,8 +165,9 @@ final class KeyboardActionHandler: KeyboardActionHandlerProtocol {
             logChangeBlockTextStyle()
             return
         }
-        
-        try await service.add(info: .emptyText, targetBlockId: info.id, position: .top, setFocus: false)
+
+        let newBlockId = try await service.add(info: .emptyText, targetBlockId: info.id, position: .top, setFocus: false)
+        registerUnanimatedArrival(newBlockId)
     }
     
     private func onEnterAtTheEndOfContent(
@@ -176,18 +183,21 @@ final class KeyboardActionHandler: KeyboardActionHandlerProtocol {
         
         if needChildForToggle {
             if info.childrenIds.isEmpty {
-                try await service.addChild(info: BlockInformation.emptyText, parentId: info.id)
+                let newBlockId = try await service.addChild(info: BlockInformation.emptyText, parentId: info.id)
+                registerUnanimatedArrival(newBlockId)
             } else {
                 let firstChildId = info.childrenIds[0]
-                try await service.add(info: BlockInformation.emptyText, targetBlockId: firstChildId, position: .top)
+                let newBlockId = try await service.add(info: BlockInformation.emptyText, targetBlockId: firstChildId, position: .top)
+                registerUnanimatedArrival(newBlockId)
             }
         } else if needChildForList {
             let firstChildId = info.childrenIds[0]
-            try await service.add(
+            let newBlockId = try await service.add(
                 info: BlockInformation.emptyText,
                 targetBlockId: firstChildId,
                 position: .top
             )
+            registerUnanimatedArrival(newBlockId)
         } else {
             let type = text.contentType.isList ? text.contentType : .text
 
@@ -200,6 +210,14 @@ final class KeyboardActionHandler: KeyboardActionHandlerProtocol {
             )
             logCreateBlock(with: type)
         }
+    }
+
+    /// A row created by a keyboard Enter appears right at the user's caret, often together with
+    /// an unanimated scroll that keeps the caret visible. Animating the row's expansion on top of
+    /// that reads as a jump — the row below shows through and is then slowly pushed away — so
+    /// Enter-created rows must arrive on screen instantly.
+    private func registerUnanimatedArrival(_ blockId: String) {
+        blockIdentitySwapStorage.register(newBlockId: blockId, replacingBlockId: nil, keyboardInsert: true)
     }
     
     private func logChangeBlockTextStyle() {

--- a/Anytype/Sources/ServiceLayer/Block/SessionCreatedBlocks/BlockIdentitySwapStorage.swift
+++ b/Anytype/Sources/ServiceLayer/Block/SessionCreatedBlocks/BlockIdentitySwapStorage.swift
@@ -6,22 +6,29 @@ struct BlockIdentitySwap: Equatable {
     /// Id of the document block the new one replaced in place. Nil when the swapped-out row is
     /// not a document block (virtual trailing placeholder — its row removal is session-managed).
     let oldBlockId: String?
+    /// True for rows created by a keyboard Enter. Unlike identity swaps — which must always
+    /// render unanimated — these look right with UIKit's native animated insert, except at the
+    /// bottom edge where the insert competes with the caret-visibility scroll; the editor
+    /// applies the unanimated one-commit pipeline only there.
+    let isKeyboardInsert: Bool
 }
 
 @MainActor
 protocol BlockIdentitySwapStorageProtocol: AnyObject {
-    func register(newBlockId: String, replacingBlockId: String?)
+    func register(newBlockId: String, replacingBlockId: String?, keyboardInsert: Bool)
     /// Swaps whose new block id appears in `ids`; matches are consumed.
     func consumeSwaps(in ids: [String]) -> [BlockIdentitySwap]
 }
 
-/// Block ids that just replaced another block in place (virtual trailing placeholder → real
-/// block, empty-block identity fork via BlockReplace).
+/// Block ids whose arrival must render without the animated insert: blocks that just replaced
+/// another block in place (virtual trailing placeholder → real block, empty-block identity
+/// fork via BlockReplace) and rows created at the user's caret by a keyboard Enter.
 ///
 /// The collection view renders an id change as an animated delete+insert — the old row fades
-/// out below the new one. The editor consumes these ids to apply the swap snapshot without
-/// animation, so the swap is invisible; a consumed swap's `oldBlockId` also lets the editor
-/// keep the old — still focused — row alive until the new cell takes the keyboard over.
+/// out below the new one — and an Enter-created row as a slow expansion over the row below.
+/// The editor consumes these ids to apply the snapshot without animation; a consumed swap's
+/// `oldBlockId` also lets the editor keep the old — still focused — row alive until the new
+/// cell takes the keyboard over.
 ///
 /// Ids are normally consumed on the very next update batch. `consumeSwaps` may never see one
 /// (the editor tears down before the create/replace event round-trips), so registration is
@@ -33,9 +40,9 @@ final class BlockIdentitySwapStorage: BlockIdentitySwapStorageProtocol {
     private var pendingSwaps = [String: BlockIdentitySwap]()
     private var order = [String]()
 
-    func register(newBlockId: String, replacingBlockId: String?) {
+    func register(newBlockId: String, replacingBlockId: String?, keyboardInsert: Bool) {
         guard pendingSwaps[newBlockId] == nil else { return }
-        pendingSwaps[newBlockId] = BlockIdentitySwap(newBlockId: newBlockId, oldBlockId: replacingBlockId)
+        pendingSwaps[newBlockId] = BlockIdentitySwap(newBlockId: newBlockId, oldBlockId: replacingBlockId, isKeyboardInsert: keyboardInsert)
         order.append(newBlockId)
         if order.count > capacity {
             let evicted = order.removeFirst()

--- a/Anytype/Sources/ServiceLayer/Block/SessionCreatedBlocks/BlockIdentitySwapStorage.swift
+++ b/Anytype/Sources/ServiceLayer/Block/SessionCreatedBlocks/BlockIdentitySwapStorage.swift
@@ -1,11 +1,18 @@
 import Foundation
 import Factory
 
+struct BlockIdentitySwap: Equatable {
+    let newBlockId: String
+    /// Id of the document block the new one replaced in place. Nil when the swapped-out row is
+    /// not a document block (virtual trailing placeholder — its row removal is session-managed).
+    let oldBlockId: String?
+}
+
 @MainActor
 protocol BlockIdentitySwapStorageProtocol: AnyObject {
-    func register(_ blockId: String)
-    /// True when `ids` contains a block that just swapped identity; matches are consumed.
-    func consumeSwap(in ids: [String]) -> Bool
+    func register(newBlockId: String, replacingBlockId: String?)
+    /// Swaps whose new block id appears in `ids`; matches are consumed.
+    func consumeSwaps(in ids: [String]) -> [BlockIdentitySwap]
 }
 
 /// Block ids that just replaced another block in place (virtual trailing placeholder → real
@@ -13,33 +20,37 @@ protocol BlockIdentitySwapStorageProtocol: AnyObject {
 ///
 /// The collection view renders an id change as an animated delete+insert — the old row fades
 /// out below the new one. The editor consumes these ids to apply the swap snapshot without
-/// animation, so the swap is invisible.
+/// animation, so the swap is invisible; a consumed swap's `oldBlockId` also lets the editor
+/// keep the old — still focused — row alive until the new cell takes the keyboard over.
 ///
-/// Ids are normally consumed on the very next update batch. `consumeSwap` may never see one
+/// Ids are normally consumed on the very next update batch. `consumeSwaps` may never see one
 /// (the editor tears down before the create/replace event round-trips), so registration is
 /// bounded: past `capacity` the oldest still-pending id is evicted. Eviction only ever
 /// discards ids that were never consumed, so it cannot affect visible behavior.
 @MainActor
 final class BlockIdentitySwapStorage: BlockIdentitySwapStorageProtocol {
     private let capacity = 64
-    private var pendingBlockIds = Set<String>()
+    private var pendingSwaps = [String: BlockIdentitySwap]()
     private var order = [String]()
 
-    func register(_ blockId: String) {
-        guard pendingBlockIds.insert(blockId).inserted else { return }
-        order.append(blockId)
+    func register(newBlockId: String, replacingBlockId: String?) {
+        guard pendingSwaps[newBlockId] == nil else { return }
+        pendingSwaps[newBlockId] = BlockIdentitySwap(newBlockId: newBlockId, oldBlockId: replacingBlockId)
+        order.append(newBlockId)
         if order.count > capacity {
             let evicted = order.removeFirst()
-            pendingBlockIds.remove(evicted)
+            pendingSwaps.removeValue(forKey: evicted)
         }
     }
 
-    func consumeSwap(in ids: [String]) -> Bool {
-        let matched = pendingBlockIds.intersection(ids)
-        guard !matched.isEmpty else { return false }
-        pendingBlockIds.subtract(matched)
-        order.removeAll { matched.contains($0) }
-        return true
+    func consumeSwaps(in ids: [String]) -> [BlockIdentitySwap] {
+        let swaps = ids.compactMap { pendingSwaps[$0] }
+        guard !swaps.isEmpty else { return [] }
+        for swap in swaps {
+            pendingSwaps.removeValue(forKey: swap.newBlockId)
+        }
+        order.removeAll { pendingSwaps[$0] == nil }
+        return swaps
     }
 }
 

--- a/Anytype/Sources/ServiceLayer/Block/TextServiceHandler/TextServiceHandler.swift
+++ b/Anytype/Sources/ServiceLayer/Block/TextServiceHandler/TextServiceHandler.swift
@@ -23,14 +23,10 @@ final class TextServiceHandler: TextServiceProtocol {
     }
     
     func split(contextId: String, blockId: String, range: NSRange, style: Style, mode: SplitMode) async throws -> String {
-        let blockID = try await textService.split(contextId: contextId, blockId: blockId, range: range, style: style, mode: mode)
-        
-        await EventsBunch(
-            contextId: contextId,
-            localEvents: [.general]
-        ).send()
-
-        return blockID
+        // No local events here: the render pass they trigger must only run after the caller
+        // (setAndSplit) has recorded the unanimated-arrival registration and the focus intent
+        // for the created block — see BlockActionService.setAndSplit.
+        try await textService.split(contextId: contextId, blockId: blockId, range: range, style: style, mode: mode)
     }
 
     func merge(contextId: String, firstBlockId: String, secondBlockId: String) async throws {

--- a/docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md
+++ b/docs/plans/20260720-ios-6579-kanban-collapsing-header-handoff.md
@@ -1,0 +1,302 @@
+# Handoff — Kanban collapsing object header (IOS-6579, follow-up)
+
+## Context
+
+Branch: `ios-6579-kanban-view-audit-and-fix-dormant-implementation-enable-by`
+Last commit: `a38b3bb66f` "IOS-6579 Virtualize Kanban board scrolling to fix scroll jank"
+
+The prior work (see `20260714-ios-6579-kanban-scroll-fps-handoff.md`, read it first) fixed scroll
+jank by restructuring the board into `ScrollView(.horizontal) { LazyHStack { columns } }` where
+each column is its own `ScrollView(.vertical) { LazyVStack { cards } }`. That fixed FPS but
+**removed the whole-page vertical scroll**, and with it the collapsing object header.
+
+**The bug**: on Board layout the object header (cover/icon, title, Layout/Properties/Templates
+chips) is permanently pinned in place and eats ~40% of the screen. Every other Set view type
+(Grid/List/Gallery) scrolls that header away and leaves the view-settings row (`Board ⌄ … New`)
+stuck to the top under the nav bar. Kanban must behave the same.
+
+**Required behavior**: dragging vertically anywhere on the board first scrolls the *page* — the
+object header slides up under the nav bar and the settings row + column headers come to rest at the
+top — and only after that does continued dragging scroll *inside the column*. Dragging back down
+reverses it.
+
+## How the other views do it (this is the contract to match)
+
+Nothing in kanban gets to invent its own header behavior — `EditorSetView` owns the header and the
+shared `offset` binding, and each content view drives it. Mechanism, using Grid as the reference:
+
+`EditorSetView.swift:53-79` builds a `ZStack(alignment: .top)`:
+- `contentView` — a `VStack` whose first child is `Spacer.fixedHeight(headerMinimizedSize.height)`,
+  so the content area starts below the nav bar (`EditorSetView.swift:86-91`).
+- `SetFullHeader` — the big object header, drawn *over* the content, positioned by
+  `.offset(x: 0, y: offset.y)` and `.ignoresSafeArea(edges: .top)` (`EditorSetView.swift:58-64`).
+  It is opaque (`SetFullHeader.swift:17` — `.background(Color.Background.primary)`).
+- `SetMinimizedHeader` — the always-visible nav bar; reports its height into
+  `headerMinimizedSize` (`SetMinimizedHeader.swift:31`).
+
+`SetTableView.swift:18-43` then does the actual trick inside its vertical `OffsetAwareScrollView`:
+```swift
+Spacer.fixedHeight(tableHeaderSize.height)          // reserves room for SetFullHeader
+LazyVStack(pinnedViews: [.sectionHeaders]) {
+    content                                         // Section(header: compoundHeader) { rows }
+    pagination
+}
+.padding(.top, -headerMinimizedSize.height)         // pulls the list up under the nav bar
+```
+and publishes `offsetChanged: { offset.y = $0.y }`.
+
+So the header is *not* scrolled by being inside the scroll view — it is an overlay slaved to the
+scroll offset, and a spacer inside the scroll content reserves its space. `tableHeaderSize` is the
+full header height minus the top safe area (`EditorSetView.swift:143-145`).
+
+**The single most important derived quantity** — the total collapse distance:
+
+```
+H = tableHeaderSize.height - headerMinimizedSize.height
+```
+
+At `offset.y == -H` the full header's bottom edge is exactly flush with the nav bar's bottom, and
+the pinned section header (settings row) has reached the top of the scroll viewport. That is the
+resting collapsed state in screenshot 2. Verify this equation before building on it.
+
+## Why kanban lost it, and why the obvious fix does not work
+
+`SetKanbanView.swift:15-29` currently has no scroll view at all — a plain `VStack` with a fixed
+`Spacer.fixedHeight(max(tableHeaderSize.height - headerMinimizedSize.height, 0))` (i.e. a
+permanently-expanded `H`), plus an `onAppear { offset = .zero }` hack to stop the shared header
+from being left mispositioned by a previously-scrolled view type. **Both must go.**
+
+**Do not "just wrap the board in an outer vertical ScrollView".** It compiles, it looks right, and
+it does not work: iOS has no nested-scroll chaining (no equivalent of Android's
+`NestedScrollingParent`). With a vertical `ScrollView` containing a column that is itself a
+vertical `ScrollView`, the innermost scroll view wins the pan for any touch that starts on it, and
+when it hits its top edge it bounces rather than handing the drag to the parent. Result: dragging
+on cards would scroll only the column and never collapse the header — which is the bug we are
+trying to fix. The page would collapse only when dragging the few dead pixels between columns.
+
+The standard UIKit remedy (both scroll views recognize simultaneously, then redistribute
+`contentOffset` in the scroll callbacks) requires owning the scroll views' pan delegates.
+SwiftUI owns them, and `UIScrollView` requires its `panGestureRecognizer.delegate` to be the scroll
+view itself, so that route is closed without replacing the ScrollViews with UIKit.
+
+## Recommended design: let the column's own scroll be the page scroll
+
+The insight that makes this simple: **put a `H`-tall transparent spacer at the top of every
+column's scroll content.** The first `H` points of any column's scroll then move nothing that the
+user can see inside the column, and we slave the header overlays to that same offset. Visually the
+whole page moves as one — identical to Grid — and after `H` the column just keeps scrolling its
+cards. No nested same-axis scroll views, no gesture arbitration, no delegate ownership.
+
+### Geometry
+
+Symbols (all in the coordinate space of `contentTypeView`, i.e. y=0 is just under the nav bar):
+
+- `H` = `tableHeaderSize.height - headerMinimizedSize.height` — total collapse distance.
+- `S` = measured height of `compoundHeader` (settings row + its 16pt spacer).
+- `V` = height of the content area (take it from a `GeometryReader` in `SetKanbanView`).
+- `collapse` = `clamp(driving column's contentOffset.y, 0, H)` — shared state, 0 = expanded.
+
+Layout:
+
+```
+board container:  fixed at y = S, height = V - S          (never moves)
+settings row:     overlay at y = H - collapse, height S    (opaque, slides up, stops at 0)
+SetFullHeader:    driven by publishing offset.y = -collapse to the shared binding
+column content:   Spacer(H) + Section(header: columnHeader) { cards … }  in a pinned LazyVStack
+```
+
+Check the invariant — the first card's top must always meet the settings row's bottom:
+
+```
+first card top   = boardTop + contentPos - scroll = S + H - collapse
+settings bottom  = (H - collapse) + S                       ✓ equal for every value of collapse
+```
+
+At `collapse == 0` the board's top strip is hidden behind the opaque `SetFullHeader`; at
+`collapse == H` the settings row sits at y=0 and the pinned column header sits at y=S. Both
+resting states then match the Grid screenshots exactly.
+
+### Why the column header goes *inside* the column scroll (pinned)
+
+Keep `SetKanbanColumn`'s header (`Waiting Response 13 …`) inside the column's `ScrollView`, as a
+`Section(header:)` of a `LazyVStack(pinnedViews: [.sectionHeaders])`, rather than as a sibling
+above it (where `SetKanbanColumn.swift:22` has it today). Two reasons: it then pins to the column
+viewport top for free with no offset math, and — more importantly — the 44pt header strip stays
+part of the scroll view, so drags starting on it still drive the collapse. A header outside the
+scroll view would be a dead zone across the top of every column.
+
+Note the earlier failed experiment used a pinned `LazyVStack` too, but *cross-axis* (inside a
+horizontal scroll). Here it is inside a matching-axis vertical `ScrollView`, which is the supported
+configuration Grid already relies on. Preserve the tint/rounded-corner treatment
+(`SetKanbanColumn.swift:24-27, 33-36`): the pinned header must stay opaque so cards pass under it.
+
+### Cross-column synchronization
+
+Columns scroll independently, but there is one shared header. Rules:
+
+- The column currently being dragged/decelerating is the driver; it sets `collapse`.
+- Any *other* column whose `contentOffset.y < collapse` must be set to `collapse` (non-animated) so
+  its spacer is consumed by the same amount — otherwise switching to it would show an `H`-tall hole
+  where the header used to be.
+- Columns already scrolled past `collapse` are left alone; their deeper scroll position persists
+  (Trello behaves this way). When the header re-expands, their cards slide under the opaque header,
+  which is fine.
+- Guard against feedback loops: programmatic `setContentOffset` re-enters the observer. Gate on
+  `isDragging`/`isTracking`/`isDecelerating` or an explicit re-entrancy flag.
+
+Reading the offsets: use the introspection pattern already in the repo —
+`ScrollAxisLock.swift` (`ScrollAxisLockUIView.enclosingScrollView`, lines 52-59) walks up from a
+zero-size background view to the enclosing `UIScrollView`. Observe `contentOffset` with KVO
+(deployment target is iOS 17, so `onScrollGeometryChange` is unavailable). A small shared
+coordinator object (`@State` in `SetKanbanView`, passed down) that registers each column's scroll
+view and owns `collapse` is the natural shape.
+
+### Short columns
+
+A column whose content is shorter than its viewport cannot scroll, so it can neither drive nor
+follow the collapse. Give every column's scroll content a minimum height of `viewport + H` (a
+trailing flexible spacer, or `.frame(minHeight:)` on the content) so `H` points of scroll always
+exist. Do not remove `.scrollBounceBehavior(.basedOnSize)` without re-checking this interaction.
+
+## Invariants that must not regress
+
+From the previous round — re-verify each before declaring done:
+
+1. **Virtualization.** Columns lazy in `LazyHStack`, cards lazy in `LazyVStack`, each lazy
+   container directly inside a matching-axis `ScrollView`. This is the actual FPS fix.
+2. **Axis lock.** `.scrollAxisLock(.vertical)` on column content and `.scrollAxisLock(.horizontal)`
+   on the board (`ScrollAxisLock.swift`) — stops a decelerating scroll view from swallowing
+   cross-axis drags. Still required; verify horizontal swipes work mid-collapse.
+3. **No per-card `GeometryReader`.** `SetGalleryViewCell` must not regain `readSize`.
+4. **`AnytypeNavigationSpacer()`** at the end of each column's content — the floating home panel's
+   blur intercepts touches full-width, so "+ New" is untappable without it.
+5. **Top fade** (`SetKanbanColumn.topFade`) still aligned to the column viewport top.
+6. Card tap, `.onDrag` reordering across columns, "Show more" pagination, empty-column drop area.
+
+## Edge cases
+
+- **`isEmptyViews` / `.loading` / `.error` states** (`SetKanbanView.swift:31-40`) have no columns,
+  so nothing can drive the collapse. Decide deliberately: simplest is to keep those states
+  non-collapsing (header expanded), since there is nothing to scroll to.
+- **View-type switching.** `offset` is shared `@State` in `EditorSetView` across Grid/List/Board.
+  Publishing `offset.y = -collapse` replaces the `onAppear { offset = .zero }` hack, but check the
+  Board→Grid→Board round trip leaves the header in a sane position.
+- **"Show more"** changes a column's content height mid-scroll; make sure `collapse` is not
+  disturbed.
+- **Drag-and-drop auto-scroll** may drive `contentOffset` programmatically — make sure that path
+  does not fight the sync rules.
+- **Rotation / dynamic type** change `H`, `S` and `V`; `collapse` must be re-clamped.
+
+## Verification
+
+- Both resting states must match the Grid screenshots: expanded (header visible, settings row
+  under it) and collapsed (settings row flush under the nav bar, then column headers, then cards).
+- Drag once, slowly, from a card: header and cards must move together at 1:1 with the finger (a 2:1
+  rate means the board container is moving *and* the content is scrolling — the classic failure of
+  this design; re-check the geometry table above).
+- Collapse via column A, then swipe to column B: no hole at the top of B.
+- Real device only for FPS claims, and re-run the trace comparison from the previous handoff
+  (`"waiting on GPU and VSync"` / `"in render server"` hitch counts) — the added spacer and
+  coordinator must not reintroduce hitching.
+
+## Update (2026-07-20, later session) — implemented
+
+The recommended design was implemented as specified (working tree, uncommitted, on `develop` —
+the prior kanban branch is already merged):
+
+- **`KanbanCollapseCoordinator.swift`** (new) — `@MainActor` class owning `collapse`. Columns
+  register their enclosing `UIScrollView` via a `.kanbanCollapseSync(_:)` background view (same
+  superview-walk introspection as `ScrollAxisLock`). KVO on `contentOffset`; offsets are read
+  relative to `adjustedContentInset.top`. Driver rules: a tracking/dragging/decelerating scroll
+  view drives; a merely decelerating one cannot steal from a finger-driven one. Followers (and
+  any non-finger programmatic/layout-induced movement, incl. lazily materialized columns at
+  registration) are raised to `collapse` when behind, never lowered — deeper positions persist.
+  Re-entrancy gated with an `isSyncing` flag.
+- **`SetKanbanView.swift`** — ready state is now `GeometryReader { ZStack(top) }`: board fixed
+  below the settings row (`.padding(.top, S)`), `compoundHeader` overlaid at
+  `y = H - collapse` (measured via `readSize`), and the coordinator callback publishes
+  `collapse` + `offset.y = -collapse` (replaces the `onAppear { offset = .zero }` hack).
+  Loading/error/empty keep the old static expanded layout and reset collapse/offset to zero.
+  Coordinator callback is cleared in `onDisappear` (retain cycle: closure → view → @State
+  storage → coordinator). `H` changes flow in via `.onChange(of: collapseDistance, initial:
+  true)` and re-clamp `collapse`.
+- **`SetKanbanColumn.swift`** — column is now a single vertical `ScrollView`:
+  `Spacer(H)` + `LazyVStack(spacing: 8, pinnedViews: [.sectionHeaders])` with the column header
+  as the pinned `Section` header. Header background is made opaque (Background.primary underlay
+  + tint in a top-rounded shape) since cards pass under it; `topFade` moved from the scroll
+  viewport top to an overlay hanging below the header. Cards tint comes from a single
+  all-corners-rounded background on the LazyVStack (top corners hidden behind the header's own
+  rounding); rows are inset with `.padding(.horizontal, 8)` (cell fills width — equivalent to
+  the old `.frame(width: 254)`). Content gets `.frame(minHeight: viewport + H, alignment: .top)`
+  so short columns can always drive/follow the full collapse.
+
+Not yet done (needs device): both resting states vs Grid screenshots, 1:1 finger tracking,
+collapse-then-swipe hole check, invariants 1–6, and the Instruments hitch-count comparison.
+
+### Fix after first device test: header must keep sliding past `H`
+
+First on-device test showed the header's bottom content (title/properties/type buttons) staying
+visible at the top after collapse. Cause: this doc's `collapse = clamp(offset, 0, H)` stops the
+header at `offset == -H`, where its bottom edge is merely *flush* with the nav bar bottom — and
+the nav bar (`NavigationHeader`) has only a `HomeBlurEffectView` background, so the header's
+bottom `navHeight + safeArea` points sit permanently behind the blur. Grid doesn't have this
+problem because it publishes the **raw** scroll offset unbounded: scrolling into the rows keeps
+sliding the header up until it is fully off-screen.
+
+Fix: the coordinator now tracks the driver 1:1 as `headerTravel = clamp(rel, -∞,
+fullHeaderHeight)` where `fullHeaderHeight = tableHeaderFullSize.height` (passed down from
+`EditorSetView`) is the travel at which the header is completely off-screen (also where updates
+stop, so deep card scrolling publishes nothing). `collapse = clamp(headerTravel, 0, H)` remains
+the settle line for the settings row and follower sync. Side benefit: negative travel is
+published raw, so the header + settings row follow the driver's rubber-band bounce 1:1 like
+Grid (the geometry stays glued: header bottom == settings top == `H + bounce`).
+
+Known accepted quirk: switching drivers between columns scrolled to different depths ≥ `H` can
+pop the header's position, but both endpoints lie behind the nav blur, so it isn't visible
+mid-screen. Short columns (content < viewport + fullHeaderHeight of scroll range) can't push the
+header fully away — same limitation Grid has with short content.
+
+### Second device round: delta-driven header, two-way page lock, single active fling
+
+Two more field bugs, both rooted in this doc's original cross-column rules:
+
+1. **Header flicker + garbage states with two decelerating columns.** The driver arbitration
+   let a decelerating column steal the header back, so two settling columns alternated as
+   driver every frame. Fix: only finger contact claims drivership, and claiming stops the
+   previous driver's fling dead (`setContentOffset(_, animated: false)` — the canonical
+   deceleration kill). One active scroller at a time, like UIKit's own touch-stops-fling rule.
+2. **Deep columns made the header jump, and columns could never be restored to their group
+   headers.** The spec's `collapse = clamp(driver's offset, 0, H)` maps the driver's *absolute*
+   offset — so touching a column scrolled deeper than the page teleported the header to its
+   depth. And follower sync was one-way (raise only), so once a column was pushed deeper it
+   could never be walked back. Fix, the current model in `KanbanCollapseCoordinator`:
+   - `headerTravel` moves by the driver's scroll **deltas** (KVO old/new), clamped to
+     `[0, fullHeaderHeight]`; it is continuous across driver changes — no jumps by construction.
+     Upward deltas coming out of the top rubber band are dropped so the snap-back can't
+     re-collapse what the stretch expanded (this also lets a range-exhausted column finish
+     expanding the header with repeated pulls).
+   - `pageCollapse = clamp(headerTravel, 0, H)` is the page line. Columns sitting **on** the
+     line follow it in *both* directions — that's the page illusion, and it's what returns
+     every synced column to its own top when the page expands. Columns behind the new line are
+     caught up (no-hole invariant); deeper columns keep their position until the line reaches
+     them.
+   - Net effect: dragging any column down with the header expanded scrolls only that column's
+     cards (header pinned at 0), and the "all group headers visible" state is always reachable.
+   - Over-drag past fully expanded bounces ONLY the dragged column under a static header.
+     Whole-sheet stretch was tried and reverted: a non-interacting `UIScrollView` won't hold an
+     out-of-range (negative) contentOffset — UIKit re-clamps it to 0 on every layout pass, so
+     mirrored followers flickered between the pushed position and the clamp ("columns jump
+     up"). Only the actively-panned scroll view can sit in the rubber-band zone. If the
+     whole-sheet look is ever wanted, it must be done with SwiftUI `.offset` on non-driver
+     columns (needs driver identity plumbed up), not with contentOffset.
+
+## Key files
+
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Board/SetKanbanView.swift`
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Kanban/Column/SetKanbanColumn.swift`
+- `Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/ScrollAxisLock.swift`
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/EditorSetView.swift` (header ZStack, `offset`)
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Table/SetTableView.swift` (reference impl)
+- `Anytype/Sources/PresentationLayer/TextEditor/Set/Views/Header/SetFullHeader.swift`
+- `Anytype/Sources/PresentationLayer/Common/SwiftUI/BasicComponents/OffsetAwareScrollView.swift`
+- Prior handoff: `docs/plans/20260714-ios-6579-kanban-scroll-fps-handoff.md`


### PR DESCRIPTION
## Summary
- IOS-6579: kanban collapsing object header
- IOS-6594: fix keyboard reopening when typing in a new checked list
- IOS-6596: multi-block selection UX phase 0