### PR TITLE
IOS-6597 Fix autocorrect dropping the first letter in new text blocks

### DIFF
--- a/AnyTypeTests/PresentationLayer/EditorPage/BlockRowIdentityMapTests.swift
+++ b/AnyTypeTests/PresentationLayer/EditorPage/BlockRowIdentityMapTests.swift
@@ -1,0 +1,72 @@
+import Testing
+@testable import Anytype
+
+@MainActor
+struct BlockRowIdentityMapTests {
+
+    @Test func unaliasedIdResolvesToItself() {
+        let map = BlockRowIdentityMap()
+        #expect(map.rowId(for: "block-a") == "block-a")
+    }
+
+    @Test func aliasResolvesNewIdToReplacedRow() {
+        let map = BlockRowIdentityMap()
+        #expect(map.alias(newBlockId: "new", toRowOf: "old"))
+        #expect(map.rowId(for: "new") == "old")
+        #expect(map.rowId(for: "old") == "old")
+    }
+
+    @Test func chainResolvesTransitively() {
+        // Virtual placeholder → created block → later fork of that block once it was emptied
+        // again: every incarnation keeps the original row identity.
+        let map = BlockRowIdentityMap()
+        #expect(map.alias(newBlockId: "real", toRowOf: "virtual"))
+        #expect(map.alias(newBlockId: "fork", toRowOf: "real"))
+        #expect(map.rowId(for: "fork") == "virtual")
+        #expect(map.rowId(for: "real") == "virtual")
+    }
+
+    @Test func repeatedAliasIsDeclinedAndKeepsFirstRegistration() {
+        // A row's identity must never change once its identifier sits in an applied snapshot,
+        // so a second registration for the same new id is declined — the caller must not
+        // rebind on top of it.
+        let map = BlockRowIdentityMap()
+        #expect(map.alias(newBlockId: "new", toRowOf: "old-1"))
+        #expect(!map.alias(newBlockId: "new", toRowOf: "old-2"))
+        #expect(map.rowId(for: "new") == "old-1")
+    }
+
+    @Test func removeAliasRestoresOwnIdentityKeepingRestOfChain() {
+        // The undo path removes only the undone link: the fork's id resolves to itself again
+        // while the materialization link below it stays intact.
+        let map = BlockRowIdentityMap()
+        #expect(map.alias(newBlockId: "real", toRowOf: "virtual"))
+        #expect(map.alias(newBlockId: "fork", toRowOf: "real"))
+        map.removeAlias(newBlockId: "fork")
+        #expect(map.rowId(for: "fork") == "fork")
+        #expect(map.rowId(for: "real") == "virtual")
+    }
+
+    @Test func undoneAliasesMatchDirectPairsNotResolvedRoots() {
+        // Undo restores exactly the replaced block, not the chain root: with the fork undone,
+        // "real" is present again while the chain root "virtual" never reappears — the scan
+        // must still match the fork's alias by its direct pair.
+        let map = BlockRowIdentityMap()
+        #expect(map.alias(newBlockId: "real", toRowOf: "virtual"))
+        #expect(map.alias(newBlockId: "fork", toRowOf: "real"))
+        let undone = map.undoneAliases(presentIds: ["real", "other"])
+        #expect(undone.count == 1)
+        #expect(undone.first?.newBlockId == "fork")
+        #expect(undone.first?.replacedBlockId == "real")
+    }
+
+    @Test func undoneAliasesIgnoreLiveAndFullyGonePairs() {
+        let map = BlockRowIdentityMap()
+        #expect(map.alias(newBlockId: "live-new", toRowOf: "live-old"))
+        #expect(map.alias(newBlockId: "gone-new", toRowOf: "gone-old"))
+        // live-new present → its pair is a live rebind; the gone pair's replaced id is absent
+        // → not an undo either.
+        let undone = map.undoneAliases(presentIds: ["live-new"])
+        #expect(undone.isEmpty)
+    }
+}

--- a/AnyTypeTests/PresentationLayer/EditorPage/EditorMainItemModelsHolderRekeyTests.swift
+++ b/AnyTypeTests/PresentationLayer/EditorPage/EditorMainItemModelsHolderRekeyTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import UIKit
+import Services
+@testable import Anytype
+
+// Covers the mapping re-key the identity-swap rebind relies on: after a live model's block id
+// changes in place, updateMappings must key the same instance under the new id so the
+// builder's cache lookup returns it instead of building a duplicate row.
+struct EditorMainItemModelsHolderRekeyTests {
+
+    @MainActor
+    @Test func updateMappingsRekeysReboundModel() {
+        let model = StubBlockViewModel(info: makeInfo(id: "old"))
+        let holder = EditorMainItemModelsHolder()
+        holder.items = [.block(model)]
+        #expect(holder.blocksMapping["old"] as AnyObject === model)
+
+        model.info = makeInfo(id: "new")
+        holder.updateMappings()
+
+        #expect(holder.blocksMapping["new"] as AnyObject === model)
+        #expect(holder.blocksMapping["old"] == nil)
+    }
+
+    private func makeInfo(id: String) -> BlockInformation {
+        .empty(id: id, content: .text(.empty(contentType: .text)))
+    }
+}
+
+private final class StubBlockViewModel: BlockViewModelProtocol {
+    var info: BlockInformation
+    let className = "StubBlockViewModel"
+
+    init(info: BlockInformation) {
+        self.info = info
+    }
+
+    @MainActor
+    func makeContentConfiguration(maxWidth: CGFloat) -> any UIContentConfiguration {
+        UIListContentConfiguration.cell()
+    }
+
+    @MainActor
+    func didSelectRowInTableView(editorEditingState: EditorEditingState) {}
+}

--- a/AnyTypeTests/PresentationLayer/EditorPage/FocusSubjectsHolderAliasTests.swift
+++ b/AnyTypeTests/PresentationLayer/EditorPage/FocusSubjectsHolderAliasTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import Combine
+import Services
+@testable import Anytype
+
+struct FocusSubjectsHolderAliasTests {
+
+    @Test func aliasRoutesNewIdToOldSubject() {
+        let holder = FocusSubjectsHolder()
+        let oldSubject = holder.focusSubject(for: "old")
+        holder.alias(oldId: "old", newId: "new")
+        #expect(holder.focusSubject(for: "new") === oldSubject)
+    }
+
+    @Test func aliasDoesNotOverwriteExistingSubject() {
+        let holder = FocusSubjectsHolder()
+        let existingSubject = holder.focusSubject(for: "new")
+        holder.alias(oldId: "old", newId: "new")
+        #expect(holder.focusSubject(for: "new") === existingSubject)
+    }
+
+    @Test func removeAliasRemovesTheAliasedEntry() {
+        let holder = FocusSubjectsHolder()
+        holder.alias(oldId: "old", newId: "new")
+        holder.removeAlias(oldId: "old", newId: "new")
+        // A fresh subject gets created after removal — the aliased instance is gone.
+        #expect(holder.focusSubject(for: "new") !== holder.focusSubject(for: "old"))
+    }
+
+    @Test func removeAliasKeepsIndependentlyCreatedSubject() {
+        let holder = FocusSubjectsHolder()
+        let independent = holder.focusSubject(for: "new")
+        _ = holder.focusSubject(for: "old")
+        holder.removeAlias(oldId: "old", newId: "new")
+        #expect(holder.focusSubject(for: "new") === independent)
+    }
+}

--- a/AnyTypeTests/PresentationLayer/EditorPage/TextBlockViewModelRebindTests.swift
+++ b/AnyTypeTests/PresentationLayer/EditorPage/TextBlockViewModelRebindTests.swift
@@ -1,0 +1,91 @@
+import Testing
+import Combine
+import UIKit
+import Services
+@testable import Anytype
+
+// Pins the identity-rebind contract on the view model itself: `rowIdentity` (and with it the
+// diffable identifier) survives rebind(to:) while `info` follows the replacing block, and the
+// undo rebind resets the handler's completed fork. Without these, reverting `hashable` to the
+// block id — or dropping the fork reset — would pass every other test.
+@MainActor
+struct TextBlockViewModelRebindTests {
+
+    @Test func rowIdentitySurvivesRebindWhileInfoFollows() {
+        let handler = TextBlockActionHandlerStub()
+        let model = makeModel(blockId: "old", handler: handler)
+        let identifierBeforeRebind = model.hashable
+
+        model.rebind(to: makeInfo(id: "new"))
+
+        #expect(model.info.id == "new")
+        #expect(model.rowIdentity == "old")
+        #expect(model.hashable == identifierBeforeRebind)
+        #expect(!handler.resetEmptyBlockForkCalled)
+    }
+
+    @Test func identityUndoRebindRestoresInfoAndResetsHandlerFork() {
+        let handler = TextBlockActionHandlerStub()
+        let model = makeModel(blockId: "old", handler: handler)
+        let identifierBeforeRebind = model.hashable
+        model.rebind(to: makeInfo(id: "new"))
+
+        model.rebindAfterIdentityUndo(to: makeInfo(id: "old"))
+
+        #expect(model.info.id == "old")
+        #expect(model.hashable == identifierBeforeRebind)
+        #expect(handler.resetEmptyBlockForkCalled)
+    }
+
+    private func makeModel(blockId: String, handler: TextBlockActionHandlerStub) -> TextBlockViewModel {
+        let document = MockBaseDocument()
+        return TextBlockViewModel(
+            document: document,
+            blockInformationProvider: BlockModelInfomationProvider(document: document, info: makeInfo(id: blockId)),
+            actionHandler: handler,
+            cursorManager: EditorCursorManager(focusSubjectHolder: FocusSubjectsHolder()),
+            rowIdentity: blockId
+        )
+    }
+
+    private func makeInfo(id: String) -> BlockInformation {
+        .empty(id: id, content: .text(.empty(contentType: .text)))
+    }
+}
+
+@MainActor
+private final class TextBlockActionHandlerStub: TextBlockActionHandlerProtocol {
+    var info: BlockInformation = .empty(id: "stub", content: .text(.empty(contentType: .text)))
+    let resetSubject = PassthroughSubject<NSAttributedString?, Never>()
+    let focusSubject = PassthroughSubject<BlockFocusPosition, Never>()
+    private(set) var resetEmptyBlockForkCalled = false
+
+    func textBlockActions() -> TextBlockContentConfiguration.Actions {
+        TextBlockContentConfiguration.Actions(
+            shouldPaste: { _, _ in false },
+            copy: { _ in },
+            cut: { _ in },
+            createEmptyBlock: { },
+            showObject: { _ in },
+            openURL: { _ in },
+            handleKeyboardAction: { _, _ in },
+            becomeFirstResponder: { },
+            resignFirstResponder: { },
+            textBlockSetNeedsLayout: { _ in },
+            textViewDidChangeText: { _ in },
+            textViewWillBeginEditing: { _ in },
+            textViewDidBeginEditing: { _ in },
+            textViewDidEndEditing: { _ in },
+            textViewDidChangeCaretPosition: { _, _ in },
+            textViewShouldReplaceText: { _, _, _ in false },
+            toggleCheckBox: { },
+            toggleDropDown: { },
+            tapOnCalloutIcon: { },
+            escalateToBlockSelection: { }
+        )
+    }
+
+    func resetEmptyBlockFork() {
+        resetEmptyBlockForkCalled = true
+    }
+}

--- a/Anytype/Sources/PresentationLayer/TextEditor/Assembly/Page/EditorPageModuleAssembly.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/Assembly/Page/EditorPageModuleAssembly.swift
@@ -81,6 +81,7 @@ final class EditorPageModuleAssembly: EditorPageModuleAssemblyProtocol {
         let modelsHolder = EditorMainItemModelsHolder()
         let markupChanger = BlockMarkupChanger()
         let focusSubjectHolder = FocusSubjectsHolder()
+        let rowIdentityMap = BlockRowIdentityMap()
         
         let cursorManager = EditorCursorManager(focusSubjectHolder: focusSubjectHolder)
         let blockActionService = BlockActionService(
@@ -172,6 +173,7 @@ final class EditorPageModuleAssembly: EditorPageModuleAssemblyProtocol {
             subjectsHolder: focusSubjectHolder,
             infoContainer: document.infoContainer,
             modelsHolder: modelsHolder,
+            rowIdentityMap: rowIdentityMap,
             blockCollectionController: .init(viewInput: viewInput),
             accessoryStateManager: accessoryState.0,
             cursorManager: cursorManager,
@@ -194,6 +196,7 @@ final class EditorPageModuleAssembly: EditorPageModuleAssemblyProtocol {
             router: router,
             modelsHolder: modelsHolder,
             blockBuilder: blocksConverter,
+            rowIdentityMap: rowIdentityMap,
             actionHandler: actionHandler,
             headerModel: headerModel,
             blocksStateManager: blocksStateManager,

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/SimpleTable/Block/SimpleTableCellsBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/SimpleTable/Block/SimpleTableCellsBuilder.swift
@@ -163,7 +163,10 @@ final class SimpleTableCellsBuilder {
             document: document,
             blockInformationProvider: BlockModelInfomationProvider(document: document, info: information),
             actionHandler: textBlockActionHandler,
-            cursorManager: cursorManager
+            cursorManager: cursorManager,
+            // Table cells live in their own data source; the editor's identity-swap rebind
+            // does not reach them, so the block id is the row identity.
+            rowIdentity: information.id
         )
         
         textBlocksMapping[information.id] = .block(textBlockViewModel)

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockActionHandler.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockActionHandler.swift
@@ -49,11 +49,14 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
     // Set only for the trailing "tap to type" placeholder. While unmaterialized, mutating
     // paths must not target `info.id` — the block does not exist in the middleware yet.
     private let virtualBlockSession: (any VirtualTrailingBlockSessionProtocol)?
-    // Refreshes the live on-screen cell for a block id from current model state. After the
-    // empty-block identity fork or the virtual-placeholder materialization, the visible cell is
-    // a freshly built handler; this handler's own `resetSubject` drives the replaced (dead) cell.
-    // A programmatic text write from the paste menu must therefore refresh the live cell
-    // explicitly — this also re-syncs its text view before the next keystroke can read stale text.
+    // Refreshes the live on-screen cell for a block id from current model state. In the
+    // fallback pipeline (stableRowIdentityOnFork off, or a refused rebind) the visible cell
+    // after the empty-block identity fork or the virtual-placeholder materialization belongs
+    // to a freshly built handler, and this handler's own `resetSubject` drives the replaced
+    // (dead) cell; under an in-place rebind the handler keeps its cell and this is just an
+    // ordinary reconfigure. A programmatic text write from the paste menu must refresh the
+    // live cell explicitly either way — this also re-syncs its text view before the next
+    // keystroke can read stale text.
     private let reconfigureLiveBlock: @MainActor (String) -> Void
 
     @Injected(\.linkToSearchHelper)
@@ -77,9 +80,12 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
 
     // First fill of an existing empty block replaces it with a fresh identity; see
     // forkEmptyBlockIfNeeded. Kept for the handler's lifetime — once forked, later calls
-    // only rebind to the already-created block.
+    // only rebind to the already-created block. The generation counter invalidates awaits
+    // that were in flight when resetEmptyBlockFork dissolved the fork: their resumed
+    // continuation must not re-point `info` at the forked (deleted) id.
     private var emptyBlockFork: Task<BlockInformation, any Error>?
     private var pendingForkOldId: String?
+    private var forkGeneration = 0
 
     init(
         document: some BaseDocumentProtocol,
@@ -209,7 +215,11 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
     @discardableResult
     private func forkEmptyBlockIfNeeded(carrying attrText: NSAttributedString, focusAt: BlockFocusPosition?) async throws -> Bool {
         if let emptyBlockFork {
+            let generation = forkGeneration
             let newInfo = try await emptyBlockFork.value
+            // A reset (undo restored the replaced block) while this await was suspended means
+            // newInfo points at a deleted id — rebinding to it would route edits nowhere.
+            guard generation == forkGeneration else { return false }
             // Rebind only while still pointing at the replaced id — repeated calls must not
             // keep resetting `info` to the fork-time snapshot.
             if info.id != newInfo.id {
@@ -221,11 +231,15 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
 
         let middlewareString = AttributedTextConverter.asMiddleware(attributedText: attrText)
         let oldInfo = info
+        let generation = forkGeneration
         let task = Task { try await actionHandler.replaceEmptyBlock(info: oldInfo, middlewareString: middlewareString, focusAt: focusAt) }
         emptyBlockFork = task
         pendingForkOldId = oldInfo.id
         do {
-            info = try await task.value
+            let newInfo = try await task.value
+            // The replace request carried the content either way; only the rebind is stale.
+            guard generation == forkGeneration else { return true }
+            info = newInfo
             return true
         } catch {
             emptyBlockFork = nil
@@ -233,6 +247,15 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
             anytypeAssertionFailure("Empty block identity fork failed", info: ["error": error.localizedDescription])
             throw error
         }
+    }
+
+    /// Undo restored the block this handler forked away from: the completed fork task points
+    /// at a now-deleted id and must not rebind future edits — or a fresh first fill — to it.
+    /// Bumping the generation also invalidates any fork await suspended right now.
+    func resetEmptyBlockFork() {
+        emptyBlockFork = nil
+        pendingForkOldId = nil
+        forkGeneration += 1
     }
 
     /// Ensures a concrete middleware block carries `attrText` before a text mutation: first via the
@@ -590,6 +613,14 @@ final class TextBlockActionHandler: TextBlockActionHandlerProtocol, LinkToSearch
             if pasteResult.isSameBlockCaret || pasteResult.blockIds.isEmpty {
                 let range = NSRange(location: pasteResult.caretPosition, length: 0)
                 textView.setFocus(.at(range))
+                // The response outruns the middleware echo that carries the pasted characters,
+                // so the caret offset is still past the end of the text view's text and lands
+                // clamped. Recording it as the block's pending focus re-applies it on the
+                // reconfigure that brings the text in — after `setFocus`, whose selection
+                // change would otherwise overwrite it with the clamped position.
+                if let self {
+                    cursorManager.blockFocus = BlockFocus(id: info.id, position: .at(range))
+                }
             }
 
             SharingTip.didCopyText = true

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockActionHandlerProtocol.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockActionHandlerProtocol.swift
@@ -6,9 +6,16 @@ import Foundation
 @MainActor
 protocol TextBlockActionHandlerProtocol: AnyObject {
     var info: BlockInformation { get set }
-    
+
     var resetSubject: PassthroughSubject<NSAttributedString?, Never> { get }
     var focusSubject: PassthroughSubject<BlockFocusPosition, Never> { get }
 
     func textBlockActions() -> TextBlockContentConfiguration.Actions
+    /// Forgets a completed empty-block identity fork after undo restored the replaced block;
+    /// see TextBlockViewModel.rebindAfterIdentityUndo. No-op for handlers that never fork.
+    func resetEmptyBlockFork()
+}
+
+extension TextBlockActionHandlerProtocol {
+    func resetEmptyBlockFork() {}
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockContentView.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Combine
 import Services
+import AnytypeCore
 
 
 final class TextBlockContentView: UIView, BlockContentView, DynamicHeightView, FirstResponder {
@@ -98,8 +99,8 @@ final class TextBlockContentView: UIView, BlockContentView, DynamicHeightView, F
     }
 
     private func applyNewConfiguration(configuration: TextBlockContentConfiguration) {
-        textView.textView.textStorage.setAttributedString(configuration.attributedString)
-                
+        applyTextStorage(configuration.attributedString)
+
         textBlockLeadingView.update(blockId: configuration.blockId, style: TextBlockLeadingStyle(with: configuration))
     
         let restrictions = BlockRestrictionsBuilder.build(textContentType: configuration.content.contentType)
@@ -137,6 +138,61 @@ final class TextBlockContentView: UIView, BlockContentView, DynamicHeightView, F
         }
     }
     
+    /// Applies `incoming` to the text storage without needlessly rebuilding the keyboard's
+    /// input session. Reconfiguring the cell being typed in (the identity-rebind refresh, a
+    /// remote echo of the local text) with `setAttributedString` resets autocorrect's word
+    /// buffer even when nothing changed, so:
+    /// - identical characters, identical attributes: no write at all;
+    /// - identical characters, different attributes: attributes are applied in place — an
+    ///   attribute edit does not touch the word buffer. Characters are compared by `string`,
+    ///   not `isEqual(to:)`: UIKit decorates live text with private attributes (e.g.
+    ///   NSOriginalFont on font substitution), and a spuriously unequal comparison would
+    ///   silently reinstate the session reset;
+    /// - different characters: full write — except during an IME composition when `incoming`
+    ///   is a stale prefix of the live text (the view is legitimately ahead by the uncommitted
+    ///   marked text; the commit syncs view → model, so nothing is lost by skipping). A
+    ///   genuinely different non-empty text (undo, a remote edit) still takes the write:
+    ///   losing the composition is the lesser damage.
+    private func applyTextStorage(_ incoming: NSAttributedString) {
+        let liveTextView = textView.textView
+        guard liveTextView.isFirstResponder else {
+            liveTextView.textStorage.setAttributedString(incoming)
+            return
+        }
+        let liveText: NSAttributedString = liveTextView.attributedText ?? NSAttributedString()
+        if liveTextView.markedTextRange != nil {
+            guard incoming.string.isNotEmpty, liveText.string.hasPrefix(incoming.string) else {
+                setAttributedTextKeepingCaret(incoming, in: liveTextView)
+                return
+            }
+            return
+        }
+        guard liveText.string == incoming.string else {
+            setAttributedTextKeepingCaret(incoming, in: liveTextView)
+            return
+        }
+        guard !liveText.isEqual(to: incoming) else { return }
+        let storage = liveTextView.textStorage
+        storage.beginEditing()
+        incoming.enumerateAttributes(in: NSRange(location: 0, length: incoming.length), options: []) { attributes, range, _ in
+            storage.setAttributes(attributes, range: range)
+        }
+        storage.endEditing()
+    }
+
+    /// Replacing the whole storage collapses the selection to the start of the block. While the
+    /// view is first responder that reads as the caret jumping to the beginning — a paste is
+    /// the common case: its response places the caret after the pasted text, then the middleware
+    /// echo reconfigures the cell and the write drops it. Reinstating the offset (clamped to the
+    /// new text) keeps the caret where the edit that caused the write left it.
+    private func setAttributedTextKeepingCaret(_ incoming: NSAttributedString, in textView: UITextView) {
+        let caret = textView.selectedRange
+        textView.textStorage.setAttributedString(incoming)
+        let location = min(caret.location, incoming.length)
+        let length = min(caret.length, incoming.length - location)
+        textView.selectedRange = NSRange(location: location, length: length)
+    }
+
     private func updateAllConstraint(configuration: TextBlockContentConfiguration) {
         let contentInset = TextBlockLayout.contentInset(textBlockStyle: configuration.content.contentType)
         

--- a/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/BlocksViews/Blocks/Text/Base/TextBlockViewModel.swift
@@ -23,6 +23,14 @@ final class BlockModelInfomationProvider: @unchecked Sendable {
         subscription = document.subscribeForBlockInfo(blockId: info.id)
             .sinkOnMain { [weak self] in self?.info = $0 }
     }
+
+    /// Points this provider at the block that replaced `info.id` in place (empty-block
+    /// identity fork, placeholder materialization). The old subscription targets a deleted
+    /// id and would never fire again.
+    func rebind(to info: BlockInformation) {
+        self.info = info
+        setupPublisher()
+    }
 }
 
 @MainActor
@@ -45,15 +53,23 @@ final class TextBlockViewModel: BlockViewModelProtocol {
     private var cursorManager: EditorCursorManager
     
     let className = "TextBlockViewModel"
-    
+    // The row this model renders into, fixed for the model's lifetime: the block id it was
+    // built for, resolved through fork/materialization aliases (BlockRowIdentityMap). Kept
+    // stable across rebind(to:) so the diffable identifier — and with it the live cell and
+    // its keyboard input session — survives the in-place id swap.
+    nonisolated let rowIdentity: String
+
+    nonisolated var hashable: AnyHashable { className + rowIdentity }
+
     private var cancellables = [AnyCancellable]()
-    
-    
+
+
     init(
         document: some BaseDocumentProtocol,
         blockInformationProvider: BlockModelInfomationProvider,
         actionHandler: some TextBlockActionHandlerProtocol,
         cursorManager: EditorCursorManager,
+        rowIdentity: String,
         customBackgroundColor: UIColor? = nil,
         collectionController: EditorBlockCollectionController? = nil
     ) {
@@ -61,6 +77,7 @@ final class TextBlockViewModel: BlockViewModelProtocol {
         self.document = document
         self.actionHandler = actionHandler
         self.cursorManager = cursorManager
+        self.rowIdentity = rowIdentity
         self.customBackgroundColor = customBackgroundColor
         
         document.detailsPublisher.receiveOnMain().sink { [weak self] objectDetails in
@@ -75,6 +92,22 @@ final class TextBlockViewModel: BlockViewModelProtocol {
         
     func set(focus: BlockFocusPosition) {
         actionHandler.focusSubject.send(focus)
+    }
+
+    /// Rebinds this row to the block that replaced its current one in place. The instance —
+    /// and with it the diffable identifier (`rowIdentity`) and the live cell wired to its
+    /// action handler — stays; only the backing block changes. The handler rebinds its own
+    /// `info` when its fork/materialization task completes.
+    func rebind(to info: BlockInformation) {
+        blockInformationProvider.rebind(to: info)
+    }
+
+    /// Inverse of `rebind(to:)` for undo: the replaced block was restored and this row must
+    /// carry it again. The handler's completed fork points at the now-deleted id and is reset
+    /// so a later first fill forks fresh instead of rebinding edits to that id.
+    func rebindAfterIdentityUndo(to info: BlockInformation) {
+        blockInformationProvider.rebind(to: info)
+        actionHandler.resetEmptyBlockFork()
     }
     
     func didSelectRowInTableView(editorEditingState: EditorEditingState) {}

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/EditorPageViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import UIKit
 @preconcurrency import Combine
 import os
 import Services
@@ -34,10 +35,16 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
     private var publishedUrlBuilder: any PublishedUrlBuilderProtocol
     @Injected(\.blockIdentitySwapStorage)
     private var blockIdentitySwapStorage: any BlockIdentitySwapStorageProtocol
+    // Latched at page open: the pipeline choice must stay consistent for the page's lifetime —
+    // models rebound under one identity scheme must not meet the other's swap handling. This
+    // is the only production read of the flag; every refusal path degrades to the fallback
+    // handoff pipeline, which keeps the keyboard alive on its own.
+    private let stableRowIdentityOnFork = FeatureFlags.stableRowIdentityOnFork
     
     
     private let cursorManager: EditorCursorManager
     private let blockBuilder: BlockViewModelBuilder
+    private let rowIdentityMap: BlockRowIdentityMap
     private let headerModel: ObjectHeaderViewModel
     private let editorPageTemplatesHandler: any EditorPageTemplatesHandlerProtocol
     private let configuration: EditorPageViewModelConfiguration
@@ -70,6 +77,7 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
         router: some EditorRouterProtocol,
         modelsHolder: EditorMainItemModelsHolder,
         blockBuilder: BlockViewModelBuilder,
+        rowIdentityMap: BlockRowIdentityMap,
         actionHandler: BlockActionHandler,
         headerModel: ObjectHeaderViewModel,
         blocksStateManager: some EditorPageBlocksStateManagerProtocol,
@@ -83,6 +91,7 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
         self.router = router
         self.modelsHolder = modelsHolder
         self.blockBuilder = blockBuilder
+        self.rowIdentityMap = rowIdentityMap
         self.headerModel = headerModel
         self.blocksStateManager = blocksStateManager
         self.cursorManager = cursorManager
@@ -161,18 +170,40 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
     }
     
     private func handleUpdate(ids: [String]) {
-        // An identity swap (virtual placeholder → real block, empty-block fork) must not render
-        // as an animated delete+insert of the same visible content. An Enter-created row keeps
-        // UIKit's native animated insert and caret move except at the bottom edge, where the
-        // insert competes with the caret-visibility scroll and renders as a jump — only there
-        // the unanimated one-commit pipeline takes over.
+        // Consumed identity swaps (virtual placeholder → real block, empty-block fork) are
+        // normally rebound in place and render as nothing — see rebindIdentitySwaps. When a
+        // rebind declines, the swap must still not render as an animated delete+insert of the
+        // same visible content, so it stays in activeSwaps and forces an unanimated apply. An
+        // Enter-created row keeps UIKit's native animated insert and caret move except at the
+        // bottom edge, where the insert competes with the caret-visibility scroll and renders
+        // as a jump — only there the unanimated one-commit pipeline takes over.
         let identitySwaps = blockIdentitySwapStorage.consumeSwaps(in: ids)
+        let idsSet = Set(ids)
+        rebindUndoneIdentitySwaps(ids: idsSet)
+        let reboundOldIds = rebindIdentitySwaps(identitySwaps, ids: idsSet)
         let needsBottomHandling = identitySwaps.contains(where: \.isKeyboardInsert) && viewInput?.isFirstResponderNearBottom() == true
-        let activeSwaps = identitySwaps.filter { !$0.isKeyboardInsert || needsBottomHandling }
+        let activeSwaps = identitySwaps.compactMap { swap -> BlockIdentitySwap? in
+            if let oldId = swap.oldBlockId, reboundOldIds.contains(oldId) { return nil }
+            if swap.isKeyboardInsert, !needsBottomHandling { return nil }
+            // A placeholder swap the rebind refused takes the session-managed path the
+            // fallback pipeline expects (oldBlockId nil): its old row is not a document
+            // block, and retaining it would duplicate the appended placeholder item.
+            if let oldId = swap.oldBlockId, oldId.hasPrefix(TrailingBlockPlaceholderConstants.idPrefix) {
+                return BlockIdentitySwap(newBlockId: swap.newBlockId, oldBlockId: nil, isKeyboardInsert: swap.isKeyboardInsert)
+            }
+            return swap
+        }
         var blocksViewModels = blockBuilder.buildEditorItems(infos: ids, ignoreCache: false)
         retainStaleForkRows(newSwaps: activeSwaps, in: &blocksViewModels)
         if let trailingBlockPlaceholder {
-            if let materializedId = trailingBlockPlaceholder.session.materializedBlockId,
+            if reboundOldIds.contains(trailingBlockPlaceholder.session.virtualId) {
+                // The placeholder's model was just rebound to the created block: the cell —
+                // still first responder — continues as the real block's cell. Tell the session
+                // its handoff is complete (a later applyFocus must not re-apply a stale caret),
+                // then the bookkeeping can go without touching the cell.
+                trailingBlockPlaceholder.session.focusHandoffCompletedByRebind()
+                cleanupTrailingBlockPlaceholder()
+            } else if let materializedId = trailingBlockPlaceholder.session.materializedBlockId,
                ids.contains(materializedId),
                !trailingBlockPlaceholder.session.awaitingFocusHandoff {
                 cleanupTrailingBlockPlaceholder()
@@ -213,6 +244,108 @@ final class EditorPageViewModel: EditorPageViewModelProtocol, EditorBottomNaviga
         finishArrivalFocusHandoffs()
     }
 
+    /// Consumed identity swaps whose replaced row is live in this editor are applied in place:
+    /// the row's existing view model rebinds to the new block id while its `rowIdentity` keeps
+    /// the diffable identifier constant. The swap then diffs as an empty change — no
+    /// delete+insert, no responder move — so the keyboard input session (autocorrect's
+    /// per-word buffer) survives the first character typed into an empty block. Swaps this
+    /// cannot take (flag off, model not in the holder — e.g. simple-table cells — or
+    /// Enter-created rows) fall through to the arrival-handoff pipeline below.
+    /// Returns the old ids that were rebound.
+    private func rebindIdentitySwaps(_ swaps: [BlockIdentitySwap], ids: Set<String>) -> Set<String> {
+        guard stableRowIdentityOnFork else { return [] }
+        var reboundOldIds = Set<String>()
+        var reboundItems = [EditorItem]()
+        for swap in swaps {
+            guard !swap.isKeyboardInsert, let oldId = swap.oldBlockId else { continue }
+            // Two swaps against one old id would resolve the same model twice and collide a
+            // later rebuild of the intermediate id on its row identity.
+            guard !reboundOldIds.contains(oldId) else { continue }
+            // While the old block is still present the swap event has not fully applied; a
+            // snapshot holding both ids under one row identity would contain duplicate
+            // identifiers, so leave such a swap to the fallback pipeline.
+            guard !ids.contains(oldId) else { continue }
+            // Same when a row for the new id already exists — its event batch outran the swap
+            // registration; aliasing it now would collide two rows under one identity.
+            guard modelsHolder.blocksMapping[swap.newBlockId] == nil else { continue }
+            guard let model = modelsHolder.blocksMapping[oldId] as? TextBlockViewModel,
+                  let newInfo = document.infoContainer.get(id: swap.newBlockId) else { continue }
+            // Alias before buildEditorItems runs, so a model built for the new id in this very
+            // pass — or by a later ignoreCache reset — lands on the replaced row's identity.
+            // A declined registration means the new id already belongs to another row: rebind
+            // nothing, fall back.
+            guard rowIdentityMap.alias(newBlockId: swap.newBlockId, toRowOf: oldId) else { continue }
+            model.rebind(to: newInfo)
+            cursorManager.aliasFocusSubject(oldId: oldId, newId: swap.newBlockId)
+            // The fork-time pending focus has no consumer on this path — the cell keeps first
+            // responder throughout — and left in place it would poison a later reconfigure
+            // with a stale caret write.
+            if cursorManager.blockFocus?.id == swap.newBlockId {
+                cursorManager.blockFocus = nil
+            }
+            reboundOldIds.insert(oldId)
+            reboundItems.append(.block(model))
+        }
+        if reboundOldIds.isNotEmpty {
+            // Re-key blocksMapping to the new ids before buildEditorItems consults its cache.
+            modelsHolder.updateMappings()
+            // Refresh the live cell from the rebound model: the empty diff will never
+            // reconfigure it, and its configuration still carries the replaced id (drag id,
+            // leading-view key). applyNewConfiguration skips the text-storage write while the
+            // text is identical, so the keyboard input session survives this refresh.
+            // Unanimated: this targets the focused cell mid-swap — a height change animating
+            // around the caret is exactly what the swap pipeline exists to prevent.
+            UIView.performWithoutAnimation {
+                viewInput?.reconfigure(items: reboundItems)
+            }
+        }
+        return reboundOldIds
+    }
+
+    /// Undo can restore a block an in-place rebind replaced: the live row then carries a
+    /// deleted id while its predecessor reappears in `ids`. Rebind the row back and drop the
+    /// alias so the restored block renders through its own identity again — without this the
+    /// empty diff keeps the stale row on screen and routes edits to the deleted id. Runs
+    /// regardless of the flag latch: aliases recorded earlier must stay reversible.
+    private func rebindUndoneIdentitySwaps(ids: Set<String>) {
+        let undone = rowIdentityMap.undoneAliases(presentIds: ids)
+        guard undone.isNotEmpty else { return }
+        var reboundItems = [EditorItem]()
+        for alias in undone {
+            guard let model = modelsHolder.blocksMapping[alias.newBlockId] as? TextBlockViewModel else {
+                // No live row carries the forked id — nothing to rebind back; drop the alias
+                // so the scan stops matching it.
+                rowIdentityMap.removeAlias(newBlockId: alias.newBlockId)
+                continue
+            }
+            guard modelsHolder.blocksMapping[alias.replacedBlockId] == nil,
+                  let restoredInfo = document.infoContainer.get(id: alias.replacedBlockId) else {
+                // Keep the alias: consuming it on a failed rebind would leave the live row
+                // stranded on the deleted id with no way back. The scan retries next pass.
+                continue
+            }
+            rowIdentityMap.removeAlias(newBlockId: alias.newBlockId)
+            model.rebindAfterIdentityUndo(to: restoredInfo)
+            cursorManager.removeFocusSubjectAlias(oldId: alias.replacedBlockId, newId: alias.newBlockId)
+            if cursorManager.blockFocus?.id == alias.newBlockId {
+                cursorManager.blockFocus = nil
+            }
+            reboundItems.append(.block(model))
+        }
+        guard reboundItems.isNotEmpty else { return }
+        modelsHolder.updateMappings()
+        // The restored text differs from the typed one, so this reconfigure intentionally
+        // rewrites the text storage — undo is expected to reset the typing session. The row
+        // itself never leaves the snapshot: the same cell keeps first responder throughout.
+        UIView.performWithoutAnimation {
+            viewInput?.reconfigure(items: reboundItems)
+        }
+    }
+
+    /// Fallback pipeline: under stableRowIdentityOnFork consumed fork swaps are normally
+    /// rebound in place (rebindIdentitySwaps) and never reach this path; it still serves
+    /// Enter-created rows, refused rebinds and the flag-off configuration.
+    ///
     /// The empty-block identity fork replaces the focused block's row with a fresh id. Deleting
     /// the first responder's cell in that apply briefly dismisses the keyboard, so while a focus
     /// handoff to the forked id is pending, the old row stays in the snapshot — the trailing

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockRowIdentityMap.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockRowIdentityMap.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Stable editor-row identities across in-place block id changes, scoped to one editor page.
+///
+/// The empty-block identity fork (BlockReplace) and the trailing placeholder materialization
+/// (BlockCreate) swap a visible row's block id for a middleware-generated one. Diffable item
+/// identity derives from the block id, so the id change would render as delete+insert: the
+/// focused cell and its UITextView die, the keyboard input session restarts, and autocorrect
+/// loses the just-typed word prefix. Aliasing the new id to the replaced row keeps the row's
+/// identity constant, so the swap diffs as an empty change and the live cell — with its input
+/// session — survives. See EditorPageViewModel.rebindIdentitySwaps.
+///
+/// Entries store the immediately replaced id, not the resolved root: undo restores exactly the
+/// replaced block, and detecting that requires the direct pair (see
+/// rebindUndoneIdentitySwaps). `rowId(for:)` resolves chains (virtual placeholder → created
+/// block → later fork) transitively; acyclicity holds because a new id is a fresh
+/// middleware-generated id aliased at most once.
+@MainActor
+final class BlockRowIdentityMap {
+    private var replacedIdByNewId = [String: String]()
+
+    /// False when the new id is already aliased — the caller must not rebind on top of an
+    /// existing registration: a live model's frozen `rowIdentity` would disagree with what
+    /// later rebuilds resolve.
+    func alias(newBlockId: String, toRowOf oldBlockId: String) -> Bool {
+        guard replacedIdByNewId[newBlockId] == nil else { return false }
+        replacedIdByNewId[newBlockId] = oldBlockId
+        return true
+    }
+
+    func removeAlias(newBlockId: String) {
+        replacedIdByNewId.removeValue(forKey: newBlockId)
+    }
+
+    func rowId(for blockId: String) -> String {
+        var rowId = blockId
+        while let replaced = replacedIdByNewId[rowId] {
+            rowId = replaced
+        }
+        return rowId
+    }
+
+    /// Pairs whose new id is gone while the id it replaced is present again — undo restored
+    /// the replaced block. `presentIds` is the document's current flattened id set.
+    func undoneAliases(presentIds: Set<String>) -> [(newBlockId: String, replacedBlockId: String)] {
+        replacedIdByNewId
+            .filter { !presentIds.contains($0.key) && presentIds.contains($0.value) }
+            .map { ($0.key, $0.value) }
+    }
+}

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelBuilder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/BlockViewModelBuilder.swift
@@ -13,6 +13,9 @@ final class BlockViewModelBuilder {
     private let simpleTableDependenciesBuilder: SimpleTableDependenciesBuilder
     private let infoContainer: any InfoContainerProtocol
     private let modelsHolder: EditorMainItemModelsHolder
+    // Fork/materialization aliases for this page; consulted at build time so a rebuilt model
+    // for a swapped-in id lands on the replaced row's identity. See BlockRowIdentityMap.
+    private let rowIdentityMap: BlockRowIdentityMap
     private let blockCollectionController: EditorBlockCollectionController
     private let accessoryStateManager: any AccessoryViewStateManager
     private let cursorManager: EditorCursorManager
@@ -45,6 +48,7 @@ final class BlockViewModelBuilder {
         subjectsHolder: FocusSubjectsHolder,
         infoContainer: some InfoContainerProtocol,
         modelsHolder: EditorMainItemModelsHolder,
+        rowIdentityMap: BlockRowIdentityMap,
         blockCollectionController: EditorBlockCollectionController,
         accessoryStateManager: some AccessoryViewStateManager,
         cursorManager: EditorCursorManager,
@@ -63,6 +67,7 @@ final class BlockViewModelBuilder {
         self.subjectsHolder = subjectsHolder
         self.infoContainer = infoContainer
         self.modelsHolder = modelsHolder
+        self.rowIdentityMap = rowIdentityMap
         self.blockCollectionController = blockCollectionController
         self.accessoryStateManager = accessoryStateManager
         self.cursorManager = cursorManager
@@ -231,6 +236,7 @@ final class BlockViewModelBuilder {
             blockInformationProvider: blockInformationProvider,
             actionHandler: textBlockActionHandler,
             cursorManager: cursorManager,
+            rowIdentity: rowIdentityMap.rowId(for: info.id),
             collectionController: blockCollectionController
         )
 

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/FocusSubjectsHolder.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Models/FocusSubjectsHolder.swift
@@ -14,4 +14,20 @@ final class FocusSubjectsHolder {
 
         return focusSubject
     }
+
+    /// After an in-place identity rebind the row keeps its subject: focus requests addressed
+    /// to the new block id must reach the cell that subscribed under the old one. A subject
+    /// already handed out for the new id stays — overwriting it would orphan its subscriber.
+    func alias(oldId: String, newId: String) {
+        guard blocksFocusSubjects[newId] == nil else { return }
+        blocksFocusSubjects[newId] = focusSubject(for: oldId)
+    }
+
+    /// Reverses `alias` when undo dissolved the identity rebind that created it. Removes the
+    /// entry only while it still is the old id's subject — an independently created subject
+    /// for that id keeps its subscribers.
+    func removeAlias(oldId: String, newId: String) {
+        guard blocksFocusSubjects[newId] === blocksFocusSubjects[oldId] else { return }
+        blocksFocusSubjects.removeValue(forKey: newId)
+    }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Utils/EditorСursorManager.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Utils/EditorСursorManager.swift
@@ -60,6 +60,14 @@ final class EditorCursorManager {
 
         focusSubject.send(position)
     }
+
+    func aliasFocusSubject(oldId: String, newId: String) {
+        focusSubjectHolder.alias(oldId: oldId, newId: newId)
+    }
+
+    func removeFocusSubjectAlias(oldId: String, newId: String) {
+        focusSubjectHolder.removeAlias(oldId: oldId, newId: newId)
+    }
     
     func didChangeCursorPosition(at blockId: String, position: BlockFocusPosition) {
         lastBlockFocus = BlockFocus(id: blockId, position: position)

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/VirtualTrailingBlock/VirtualTrailingBlockSession.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/VirtualTrailingBlock/VirtualTrailingBlockSession.swift
@@ -50,6 +50,12 @@ final class VirtualTrailingBlockSession: VirtualTrailingBlockSessionProtocol {
 
     private var state = State.active
     private var isInvalidated = false
+    // The editor rebound the placeholder's model to the created block in place: the cell —
+    // still first responder — continues as the real block's cell, so the focus handoff is
+    // complete and applyFocus must not re-apply a stale caret. Focus handling below stays
+    // unconditional otherwise: whenever the rebind declines, for any reason, the fallback
+    // handoff is what keeps the keyboard alive.
+    private var handoffCompletedByRebind = false
     // True while the focused placeholder cell must stay alive: removing it before the created
     // block's text view takes first responder briefly dismisses the keyboard (the accessory
     // bar visibly slides down). Cleared when the placeholder's text view resigns.
@@ -106,6 +112,14 @@ final class VirtualTrailingBlockSession: VirtualTrailingBlockSessionProtocol {
         onFinish()
     }
 
+    /// Called by the editor when it rebound the placeholder's model to the created block in
+    /// place: the still-focused cell continues as the real block's cell, so no handoff is
+    /// pending and a later applyFocus must not re-apply the materialization-time caret.
+    func focusHandoffCompletedByRebind() {
+        handoffCompletedByRebind = true
+        awaitingFocusHandoff = false
+    }
+
     func materialize(carrying content: BlockText, focusAt: BlockFocusPosition?) async throws -> VirtualTrailingBlockMaterialization {
         switch state {
         case let .materialized(info):
@@ -118,7 +132,7 @@ final class VirtualTrailingBlockSession: VirtualTrailingBlockSessionProtocol {
             do {
                 let info = try await task.value
                 state = .materialized(info)
-                if !isInvalidated {
+                if !isInvalidated, !handoffCompletedByRebind {
                     awaitingFocusHandoff = focusAt.isNotNil
                     applyFocus(focusAt, blockId: info.id)
                 }
@@ -154,7 +168,16 @@ final class VirtualTrailingBlockSession: VirtualTrailingBlockSessionProtocol {
             position: .bottom
         )
         SessionCreatedBlockIdsStorage.shared.register(blockId)
-        blockIdentitySwapStorage.register(newBlockId: blockId, replacingBlockId: nil, keyboardInsert: false)
+        // The materialization is an in-place replace of the placeholder row: carrying the
+        // virtual id lets the editor rebind the placeholder's model to the created block
+        // instead of swapping rows under the keyboard. When the rebind declines — or the
+        // stable-row-identity flag is off — the editor strips this back to nil and the
+        // session-managed fallback runs unchanged.
+        blockIdentitySwapStorage.register(
+            newBlockId: blockId,
+            replacingBlockId: virtualId,
+            keyboardInsert: false
+        )
         if let containerInfo = document.infoContainer.get(id: blockId),
            containerInfo.configurationData.parentId.isNotNil {
             return containerInfo

--- a/Anytype/Sources/ServiceLayer/Block/SessionCreatedBlocks/BlockIdentitySwapStorage.swift
+++ b/Anytype/Sources/ServiceLayer/Block/SessionCreatedBlocks/BlockIdentitySwapStorage.swift
@@ -3,8 +3,10 @@ import Factory
 
 struct BlockIdentitySwap: Equatable {
     let newBlockId: String
-    /// Id of the document block the new one replaced in place. Nil when the swapped-out row is
-    /// not a document block (virtual trailing placeholder — its row removal is session-managed).
+    /// Id of the row the new block replaced in place — a document block (empty-block fork) or
+    /// the virtual trailing placeholder's local id. Nil for the placeholder when
+    /// stableRowIdentityOnFork is off (its row removal is then session-managed) and for
+    /// Enter-created rows, which replace nothing.
     let oldBlockId: String?
     /// True for rows created by a keyboard Enter. Unlike identity swaps — which must always
     /// render unanimated — these look right with UIKit's native animated insert, except at the
@@ -26,9 +28,10 @@ protocol BlockIdentitySwapStorageProtocol: AnyObject {
 ///
 /// The collection view renders an id change as an animated delete+insert — the old row fades
 /// out below the new one — and an Enter-created row as a slow expansion over the row below.
-/// The editor consumes these ids to apply the snapshot without animation; a consumed swap's
-/// `oldBlockId` also lets the editor keep the old — still focused — row alive until the new
-/// cell takes the keyboard over.
+/// The editor consumes these ids to apply the snapshot without animation. A consumed swap's
+/// `oldBlockId` lets the editor rebind the old row to the new id in place
+/// (stableRowIdentityOnFork); in the fallback pipeline it instead keeps the old — still
+/// focused — row alive until the new cell takes the keyboard over.
 ///
 /// Ids are normally consumed on the very next update batch. `consumeSwaps` may never see one
 /// (the editor tears down before the create/replace event round-trips), so registration is

--- a/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Generated/FeatureFlags+Flags.swift
@@ -46,6 +46,10 @@ public extension FeatureFlags {
         value(for: .forkEmptyBlockOnFill)
     }
 
+    static var stableRowIdentityOnFork: Bool {
+        value(for: .stableRowIdentityOnFork)
+    }
+
     static var setKanbanView: Bool {
         value(for: .setKanbanView)
     }
@@ -142,6 +146,7 @@ public extension FeatureFlags {
         .preferredSpaceOnColdStart,
         .virtualTrailingBlock,
         .forkEmptyBlockOnFill,
+        .stableRowIdentityOnFork,
         .setKanbanView,
         .fullInlineSetImpl,
         .dndOnCollectionsAndSets,

--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -65,6 +65,12 @@ public extension FeatureDescription {
         defaultValue: true
     )
 
+    static let stableRowIdentityOnFork = FeatureDescription(
+        title: "Keep editor row identity across the empty-block fork and placeholder materialization",
+        category: .productFeature(author: "requilence@gmail.com", targetRelease: "0.50.0"),
+        defaultValue: true
+    )
+
     // MARK: - Experemental
     
     static let setKanbanView = FeatureDescription(

--- a/Modules/Services/Sources/Models/Block/Block+CommonStructures.swift
+++ b/Modules/Services/Sources/Models/Block/Block+CommonStructures.swift
@@ -21,9 +21,17 @@ public extension BlockFocusPosition {
             return .init(location: text.length, length: 0)
 
         case let .at(range):
+            guard range.location != NSNotFound else { return .init(location: 0, length: 0) }
             let textRange = NSRange(location: 0, length: text.length + 1)
-            let validSelectedRange = range.intersection(textRange)
-            return validSelectedRange ?? .init(location: 0, length: 0)
+            if let validSelectedRange = range.intersection(textRange) {
+                return validSelectedRange
+            }
+            // A position entirely past the end means the text it was computed for has not been
+            // applied yet — a paste response reaches the text view before the middleware echo
+            // carrying the pasted characters. Clamping to the end keeps the intent; answering
+            // "put the caret at offset N" with offset 0 reads as the caret jumping to the top
+            // of the block.
+            return .init(location: text.length, length: 0)
         }
     }
 }


### PR DESCRIPTION
## Summary

- The first character typed into a middleware-empty text block swapped its block id (BlockReplace fork, or BlockCreate for the trailing placeholder). Diffable identity derives from the block id, so the row was delete+inserted, the focused `UITextView` died and the keyboard input session restarted — autocorrect then computed suggestions from the word minus its first letter. The row now keeps a stable identity and its view model rebinds in place, so the swap diffs as an empty change and the same text view keeps first responder.
- Undo of a swap rebinds the row back to the restored block. All of it behind `stableRowIdentityOnFork` (default on); with the flag off the previous pipeline runs unchanged.
- `.at` focus positions past the end of the text clamp to the end instead of collapsing to 0, and paste re-applies its caret once the pasted characters arrive — previously the caret jumped to the start of the block after a paste.