### PR TITLE
IOS-5760 Retry chat search after a failed request

### DIFF
--- a/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/Chat/ChatViewModel.swift
@@ -305,7 +305,8 @@ final class ChatViewModel: MessageModuleOutput, ChatActionProviderHandler {
             // A newer search owns the state
         } catch {
             guard query == searchQuery else { return }
-            lastSearchQuery = query
+            // Not cached, so the failed query (or a revert to the previous one) retries on the next task run
+            lastSearchQuery = nil
             searchResults = []
             searchSelectedIndex = nil
             searchInProgress = false


### PR DESCRIPTION
## Summary
- Review follow-up for #5088: a failed `chatSearch` request cached the failing query in `lastSearchQuery`, so the dedup guard blocked any retry of that query (or a revert to the previous successful one) until search was closed and reopened
- The catch branch now resets `lastSearchQuery` to nil instead, so the next `.task(id:)` run re-issues the request