### PR TITLE
Improve unified search filter suggestions

### DIFF
--- a/AnyTypeTests/PresentationLayer/UnifiedSearch/UnifiedSearchChipModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/UnifiedSearch/UnifiedSearchChipModelTests.swift
@@ -1,0 +1,23 @@
+import Testing
+@testable import Anytype
+
+struct UnifiedSearchChipModelTests {
+
+    @Test
+    func channelScopePackageAppendsPickerToIndividualChannels() {
+        let individualChips = [
+            UnifiedSearchChipModel(token: .space(spaceId: "space-1"), title: "One"),
+            UnifiedSearchChipModel(token: .space(spaceId: "space-2"), title: "Two")
+        ]
+
+        let package = UnifiedSearchChipModel.channelScopePackage(individualChips: individualChips)
+
+        #expect(package.dropLast() == individualChips[...])
+        #expect(package.last?.action == .openChannelsPicker)
+    }
+
+    @Test
+    func channelScopePackageIsEmptyWithoutIndividualChannels() {
+        #expect(UnifiedSearchChipModel.channelScopePackage(individualChips: []).isEmpty)
+    }
+}

--- a/AnyTypeTests/PresentationLayer/UnifiedSearch/UnifiedSearchTypeSorterTests.swift
+++ b/AnyTypeTests/PresentationLayer/UnifiedSearch/UnifiedSearchTypeSorterTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+import AnytypeCore
+import Services
+@testable import Anytype
+
+struct UnifiedSearchTypeSorterTests {
+
+    @Test func sorted_ordersByLastUsedDateDescendingThenNameAscending() {
+        let sameDate = Date(timeIntervalSince1970: 200)
+        let types = [
+            makeType(id: "unused", uniqueKey: "unused", name: "Unused", lastUsedDate: nil),
+            makeType(id: "task", uniqueKey: "task", name: "Task", lastUsedDate: sameDate),
+            makeType(id: "alpha", uniqueKey: "alpha", name: "Alpha", lastUsedDate: sameDate),
+            makeType(id: "latest", uniqueKey: "latest", name: "Latest", lastUsedDate: Date(timeIntervalSince1970: 300))
+        ]
+
+        let result = UnifiedSearchTypeSorter.sorted(types, deduplicateByUniqueKey: false)
+
+        #expect(result.map(\.id) == ["latest", "alpha", "task", "unused"])
+    }
+
+    @Test func sorted_deduplicatesByUniqueKeyKeepingMostRecentlyUsedInstance() {
+        let types = [
+            makeType(id: "page-old", uniqueKey: "page", name: "Page", lastUsedDate: Date(timeIntervalSince1970: 100)),
+            makeType(id: "page-new", uniqueKey: "page", name: "Page", lastUsedDate: Date(timeIntervalSince1970: 300)),
+            makeType(id: "task", uniqueKey: "task", name: "Task", lastUsedDate: Date(timeIntervalSince1970: 200))
+        ]
+
+        let result = UnifiedSearchTypeSorter.sorted(types, deduplicateByUniqueKey: true)
+
+        #expect(result.map(\.id) == ["page-new", "task"])
+    }
+
+    private func makeType(
+        id: String,
+        uniqueKey: String,
+        name: String,
+        lastUsedDate: Date?
+    ) -> ObjectDetails {
+        var values = [
+            BundledPropertyKey.name.rawValue: name.protobufValue,
+            BundledPropertyKey.uniqueKey.rawValue: uniqueKey.protobufValue
+        ]
+        if let lastUsedDate {
+            values[BundledPropertyKey.lastUsedDate.rawValue] = lastUsedDate.protobufValue
+        }
+        return ObjectDetails(id: id, values: values)
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Models/UnifiedSearchTypeSorter.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Models/UnifiedSearchTypeSorter.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Services
+
+enum UnifiedSearchTypeSorter {
+
+    static func sorted<S: Sequence>(
+        _ types: S,
+        deduplicateByUniqueKey: Bool
+    ) -> [ObjectDetails] where S.Element == ObjectDetails {
+        let types = Array(types)
+        let candidates: [ObjectDetails]
+
+        if deduplicateByUniqueKey {
+            candidates = Dictionary(grouping: types, by: \.uniqueKey)
+                .values
+                .compactMap { $0.sorted(by: isOrderedBefore).first }
+        } else {
+            candidates = types
+        }
+
+        return candidates.sorted(by: isOrderedBefore)
+    }
+
+    private static func isOrderedBefore(_ lhs: ObjectDetails, _ rhs: ObjectDetails) -> Bool {
+        switch (lhs.lastUsedDate, rhs.lastUsedDate) {
+        case let (lhsDate?, rhsDate?) where lhsDate != rhsDate:
+            return lhsDate > rhsDate
+        case (_?, nil):
+            return true
+        case (nil, _?):
+            return false
+        default:
+            break
+        }
+
+        let titleComparison = lhs.title.localizedCaseInsensitiveCompare(rhs.title)
+        if titleComparison != .orderedSame {
+            return titleComparison == .orderedAscending
+        }
+
+        let uniqueKeyComparison = lhs.uniqueKey.localizedCaseInsensitiveCompare(rhs.uniqueKey)
+        if uniqueKeyComparison != .orderedSame {
+            return uniqueKeyComparison == .orderedAscending
+        }
+
+        return lhs.id < rhs.id
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchView.swift
@@ -3,6 +3,13 @@ import SwiftUI
 
 struct UnifiedSearchView: View {
 
+    private enum FilterResultsOnboardingTarget: Hashable {
+        case focus(String)
+        case channel(String)
+        case person(String)
+        case type(String)
+    }
+
     @State private var model: UnifiedSearchViewModel
     @Namespace private var glassNamespace
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -61,6 +68,12 @@ struct UnifiedSearchView: View {
             if model.showOnboarding {
                 onboardingOverlay
             }
+        }
+        .sheet(isPresented: $model.showChannelsPicker) {
+            UnifiedSearchPickerView(rows: model.channelsPickerRows) {
+                model.onSelectChannelScope($0)
+            }
+            .presentationDetents([.medium, .large])
         }
         .sheet(isPresented: $model.showPeoplePicker) {
             UnifiedSearchPickerView(rows: model.peoplePickerRows) {
@@ -159,8 +172,13 @@ struct UnifiedSearchView: View {
                         title: row.title,
                         caption: row.caption,
                         badged: row.kind != .typeInstance,
+                        showsFilterResultsOnboarding: filterResultsOnboardingTarget == .focus(row.id),
                         onTap: { model.onSelectFocusRow(row) },
-                        onDrill: { model.onSelectFocusRow(row) }
+                        onDrill: {
+                            model.onFilterResultsTap {
+                                model.onSelectFocusRow(row)
+                            }
+                        }
                     )
                 }
             }
@@ -171,8 +189,13 @@ struct UnifiedSearchView: View {
                 ForEach(model.channelRows) { row in
                     UnifiedSearchChannelRowView(
                         row: row,
+                        showsFilterResultsOnboarding: filterResultsOnboardingTarget == .channel(row.id),
                         onTap: { model.onSelectChannel(row) },
-                        onDrill: { model.onScopeToSpace(row.spaceId, source: .row) }
+                        onDrill: {
+                            model.onFilterResultsTap {
+                                model.onScopeToSpace(row.spaceId, source: .row)
+                            }
+                        }
                     )
                 }
             }
@@ -190,8 +213,13 @@ struct UnifiedSearchView: View {
                         title: row.title,
                         caption: row.caption,
                         badged: true,
+                        showsFilterResultsOnboarding: filterResultsOnboardingTarget == .person(row.id),
                         onTap: { model.onSelectPersonRow(row) },
-                        onDrill: { model.onDrillPersonRow(row) }
+                        onDrill: {
+                            model.onFilterResultsTap {
+                                model.onDrillPersonRow(row)
+                            }
+                        }
                     )
                 }
             }
@@ -204,8 +232,13 @@ struct UnifiedSearchView: View {
                         icon: row.icon,
                         title: row.title,
                         caption: row.subtitle,
+                        showsFilterResultsOnboarding: filterResultsOnboardingTarget == .type(row.id),
                         onTap: { model.onSelectTypeRow(row) },
-                        onDrill: { model.onDrillTypeRow(row) }
+                        onDrill: {
+                            model.onFilterResultsTap {
+                                model.onDrillTypeRow(row)
+                            }
+                        }
                     )
                 }
             }
@@ -251,6 +284,23 @@ struct UnifiedSearchView: View {
         }
         .scrollIndicators(.never)
         .scrollDismissesKeyboard(.immediately)
+    }
+
+    private var filterResultsOnboardingTarget: FilterResultsOnboardingTarget? {
+        guard model.showFilterResultsOnboarding, !model.showOnboarding else { return nil }
+        if let focus = model.focusRows.first {
+            return .focus(focus.id)
+        }
+        if let channel = model.channelRows.first {
+            return .channel(channel.id)
+        }
+        if let person = model.personRows.first {
+            return .person(person.id)
+        }
+        if let type = model.typeRows.first {
+            return .type(type.id)
+        }
+        return nil
     }
 
     // The empty browse titles itself with day groups; a text search shows one

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchViewModel.swift
@@ -96,14 +96,19 @@ final class UnifiedSearchViewModel {
     var rowSections = [ListSectionData<String?, SearchWithMetaModel>]()
     var messageRows = [UnifiedSearchMessageRow]()
     var selectedTokenId: String?
+    var showChannelsPicker = false
     var showPeoplePicker = false
     var showTypesPicker = false
     var showOnboarding = false
+    var showFilterResultsOnboarding = false
     var isInitial = true
 
     @ObservationIgnored
     @UserDefault("UserData.UnifiedSearchOnboardingSeen", defaultValue: false)
     private var onboardingSeen: Bool
+    @ObservationIgnored
+    @UserDefault("UserData.UnifiedSearchFilterResultsOnboardingSeen", defaultValue: false)
+    private var filterResultsOnboardingSeen: Bool
 
     private var participantCanEdit = false
     @ObservationIgnored
@@ -115,6 +120,8 @@ final class UnifiedSearchViewModel {
     private var typeCountByUniqueKey = [String: Int]()
     @ObservationIgnored
     private var sortedGlobalTypes = [ObjectDetails]()
+    @ObservationIgnored
+    private var sortedGlobalPickerTypes = [ObjectDetails]()
     @ObservationIgnored
     private var allParticipants = [Participant]()
     @ObservationIgnored
@@ -203,6 +210,7 @@ final class UnifiedSearchViewModel {
         self.updateTokenModels()
         self.rebuildChips()
         self.showOnboarding = data.purpose == .navigation && !onboardingSeen
+        self.showFilterResultsOnboarding = data.purpose == .navigation && !filterResultsOnboardingSeen
     }
 
     // Any tap or keypress counts as seen
@@ -210,6 +218,14 @@ final class UnifiedSearchViewModel {
         guard showOnboarding else { return }
         onboardingSeen = true
         showOnboarding = false
+    }
+
+    func onFilterResultsTap(_ action: () -> Void) {
+        if showFilterResultsOnboarding {
+            filterResultsOnboardingSeen = true
+            showFilterResultsOnboarding = false
+        }
+        action()
     }
 
     // The vault-wide types/participants/chats subscriptions live for the account
@@ -258,6 +274,11 @@ final class UnifiedSearchViewModel {
             .map { ($0.title, $0) }
             .sorted { $0.0.localizedCaseInsensitiveCompare($1.0) == .orderedAscending }
             .map(\.1)
+
+        sortedGlobalPickerTypes = UnifiedSearchTypeSorter.sorted(
+            typesById.values.filter { !$0.isHidden && !Constants.excludedTypeChipKeys.contains($0.uniqueKeyValue) },
+            deduplicateByUniqueKey: true
+        )
     }
 
     func observeMembers() async {
@@ -469,11 +490,27 @@ final class UnifiedSearchViewModel {
             state.addToken(token)
             updateTokenModels()
             rebuildChips()
+        case .openChannelsPicker:
+            showChannelsPicker = true
         case .openPeoplePicker:
             showPeoplePicker = true
         case .openTypesPicker:
             showTypesPicker = true
         }
+    }
+
+    var channelsPickerRows: [UnifiedSearchPickerRow] {
+        orderedSpaceViews.map { spaceView in
+            UnifiedSearchPickerRow(
+                id: spaceView.targetSpaceId,
+                title: spaceView.title,
+                icon: spaceView.objectIconImage
+            )
+        }
+    }
+
+    func onSelectChannelScope(_ channel: UnifiedSearchPickerRow) {
+        onScopeToSpace(channel.id, source: .chip)
     }
 
     var peoplePickerRows: [UnifiedSearchPickerRow] {
@@ -488,7 +525,17 @@ final class UnifiedSearchViewModel {
 
     var typesPickerRows: [UnifiedSearchPickerRow] {
         let scopeId = state.spaceScopeId
-        return typesBrowseList(scopeSpaceId: scopeId).map { type in
+        let types = if let scopeId {
+            UnifiedSearchTypeSorter.sorted(
+                typesById.values.filter {
+                    $0.spaceId == scopeId && !$0.isHidden && !Constants.excludedTypeChipKeys.contains($0.uniqueKeyValue)
+                },
+                deduplicateByUniqueKey: false
+            )
+        } else {
+            sortedGlobalPickerTypes
+        }
+        return types.map { type in
             UnifiedSearchPickerRow(
                 id: type.uniqueKey,
                 title: type.title,
@@ -898,8 +945,8 @@ final class UnifiedSearchViewModel {
 
     // MARK: - Channels & People
 
-    // Channel and person rows lead only a plain global text query: any filter
-    // token means the query is already about something narrower
+    // Channel, person and type rows lead only a plain global text query: any
+    // filter token means the query is already about something narrower.
     private var showsLeadRows: Bool {
         isGlobal
             && state.searchText.trimmed.isNotEmpty
@@ -1324,13 +1371,23 @@ final class UnifiedSearchViewModel {
         let scopeId = state.spaceScopeId
         let whatFilled = state.tokens.contains { $0.group == .what }
 
-        // Scope suggestion (global mode only): re-add the entry space.
-        // Hidden under the Channels bucket - scoping cannot answer there.
-        if scopeId == nil,
-           let currentSpaceId = moduleData.currentSpaceId,
-           state.whatBucket != .channels,
-           spaceViewsStorage.spaceView(spaceId: currentSpaceId) != nil {
-            result.append(UnifiedSearchChipModel(token: .space(spaceId: currentSpaceId), title: Loc.UnifiedSearch.Chip.inThisChannel))
+        if scopeId == nil, state.whatBucket != .channels {
+            // Scope suggestion (global mode only): re-add the entry space.
+            var channelChips = [UnifiedSearchChipModel]()
+            if let currentSpaceId = moduleData.currentSpaceId,
+               spaceViewsStorage.spaceView(spaceId: currentSpaceId) != nil {
+                channelChips.append(UnifiedSearchChipModel(
+                    token: .space(spaceId: currentSpaceId),
+                    title: Loc.UnifiedSearch.Chip.inThisChannel
+                ))
+            }
+
+            if supportsChannelScopeSuggestions {
+                channelChips.append(contentsOf: channelScopeChips(excluding: moduleData.currentSpaceId))
+                result.append(contentsOf: UnifiedSearchChipModel.channelScopePackage(individualChips: channelChips))
+            } else {
+                result.append(contentsOf: channelChips)
+            }
         }
 
         if scopeId == nil, !whatFilled {
@@ -1372,6 +1429,31 @@ final class UnifiedSearchViewModel {
         result.append(contentsOf: personChips(scopeSpaceId: scopeId, byMeOnly: false))
 
         chips = result
+    }
+
+    private func channelScopeChips(excluding excludedSpaceId: String?) -> [UnifiedSearchChipModel] {
+        orderedSpaceViews
+            .filter { $0.targetSpaceId != excludedSpaceId }
+            .map { spaceView in
+                UnifiedSearchChipModel(
+                    token: .space(spaceId: spaceView.targetSpaceId),
+                    title: spaceView.title,
+                    icon: spaceView.objectIconImage
+                )
+            }
+    }
+
+    private var supportsChannelScopeSuggestions: Bool {
+        state.tokens.contains { token in
+            switch token {
+            case .kind(let bucket):
+                bucket != .channels
+            case .type:
+                true
+            default:
+                false
+            }
+        }
     }
 
     private func typeChips(spaceId: String) -> [UnifiedSearchChipModel] {

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChannelRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChannelRowView.swift
@@ -13,6 +13,7 @@ struct UnifiedSearchChannelRowView: View {
 
     let row: UnifiedSearchChannelRow
     // Primary tap opens the space; the drill affordance scopes the search to it instead
+    var showsFilterResultsOnboarding = false
     let onTap: () -> Void
     let onDrill: () -> Void
 
@@ -34,12 +35,14 @@ struct UnifiedSearchChannelRowView: View {
                 Button {
                     onDrill()
                 } label: {
-                    Image(asset: .X18.search)
-                        .foregroundStyle(Color.Control.secondary)
-                        .fixTappableArea()
+                    UnifiedSearchFilterResultsButtonLabel(
+                        showsOnboarding: showsFilterResultsOnboarding
+                    )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(Loc.search)
+                .accessibilityLabel(
+                    showsFilterResultsOnboarding ? Loc.UnifiedSearch.Onboarding.useAsFilter : Loc.search
+                )
             }
             .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
             .fixTappableArea()

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChipsRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChipsRowView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct UnifiedSearchChipModel: Identifiable, Hashable {
     enum Action: Hashable {
         case addToken(UnifiedSearchToken)
+        case openChannelsPicker
         case openPeoplePicker
         case openTypesPicker
     }
@@ -25,11 +26,18 @@ struct UnifiedSearchChipModel: Identifiable, Hashable {
         switch action {
         case .addToken(let token):
             token.id
+        case .openChannelsPicker:
+            "channels-picker"
         case .openPeoplePicker:
             "people-picker"
         case .openTypesPicker:
             "types-picker"
         }
+    }
+
+    static func channelScopePackage(individualChips: [Self]) -> [Self] {
+        guard individualChips.isNotEmpty else { return [] }
+        return individualChips + [Self(action: .openChannelsPicker, title: UnifiedSearchKindBucket.channels.title)]
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchFilterResultsButtonLabel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchFilterResultsButtonLabel.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct UnifiedSearchFilterResultsButtonLabel: View {
+
+    let showsOnboarding: Bool
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 6) {
+            if showsOnboarding {
+                AnytypeText(Loc.UnifiedSearch.Onboarding.useAsFilter, style: .uxCalloutMedium)
+                    .foregroundStyle(foregroundColor)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .offset(y: -2)
+            }
+
+            Image(asset: .X18.search)
+        }
+        .foregroundStyle(foregroundColor)
+        .frame(minWidth: 44, minHeight: 44, alignment: .trailing)
+        .fixTappableArea()
+    }
+
+    private var foregroundColor: Color {
+        showsOnboarding ? Color.Control.accent80 : Color.Control.primary
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchLeadRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchLeadRowView.swift
@@ -10,6 +10,7 @@ struct UnifiedSearchLeadRowView: View {
     let title: String
     let caption: String?
     var badged = false
+    var showsFilterResultsOnboarding = false
     let onTap: () -> Void
     let onDrill: () -> Void
 
@@ -36,12 +37,14 @@ struct UnifiedSearchLeadRowView: View {
                 Button {
                     onDrill()
                 } label: {
-                    Image(asset: .X18.search)
-                        .foregroundStyle(Color.Control.secondary)
-                        .fixTappableArea()
+                    UnifiedSearchFilterResultsButtonLabel(
+                        showsOnboarding: showsFilterResultsOnboarding
+                    )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(Loc.search)
+                .accessibilityLabel(
+                    showsFilterResultsOnboarding ? Loc.UnifiedSearch.Onboarding.useAsFilter : Loc.search
+                )
             }
             .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
             .fixTappableArea()

--- a/Anytype/Sources/ServiceLayer/CrossSpaceTypes/CrossSpaceTypesSubscriptionBuilder.swift
+++ b/Anytype/Sources/ServiceLayer/CrossSpaceTypes/CrossSpaceTypesSubscriptionBuilder.swift
@@ -36,7 +36,8 @@ final class CrossSpaceTypesSubscriptionBuilder: CrossSpaceTypesSubscriptionBuild
             // color - the icon builder needs both
             BundledPropertyKey.iconOption.rawValue,
             BundledPropertyKey.isHidden.rawValue,
-            BundledPropertyKey.isDeleted.rawValue
+            BundledPropertyKey.isDeleted.rawValue,
+            BundledPropertyKey.lastUsedDate.rawValue
         ]
 
         return .crossSpaceSearch(

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -1366,6 +1366,7 @@ public enum Loc {
     public enum Onboarding {
       public static let subtitle = Loc.tr("UI", "UnifiedSearch.Onboarding.subtitle", fallback: "Narrow results by type, person or Channel with the chips above the search field - or search everything at once.")
       public static let title = Loc.tr("UI", "UnifiedSearch.Onboarding.title", fallback: "Meet the new search")
+      public static let useAsFilter = Loc.tr("UI", "UnifiedSearch.Onboarding.useAsFilter", fallback: "Use as filter")
     }
     public enum Person {
       public static let createOneToOne = Loc.tr("UI", "UnifiedSearch.Person.createOneToOne", fallback: "Create 1-1 Channel")

--- a/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
@@ -105323,6 +105323,17 @@
         }
       }
     },
+    "UnifiedSearch.Onboarding.useAsFilter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use as filter"
+          }
+        }
+      }
+    },
     "UnifiedSearch.Onboarding.subtitle" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)

---

### Description

Improves unified search filtering and discovery:

- Suggests channel tokens when Messages or a type token is selected.
- Keeps individual channel suggestions and the Channels selector token together as a package.
- Adds the Channels selector sheet for choosing any channel scope.
- Sorts type-selector entries by the freshest last-used date across spaces, then by name.
- Improves the result-row filter affordance alignment, contrast, and touch target.
- Adds one-time inline Use as filter onboarding on the first filterable result.

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

N/A

### Mobile & Desktop Screenshots/Recordings

The result-row filter affordance and channel suggestion flow were verified in the iPhone 17 Pro simulator.

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they are not needed
- [ ] 🙋 no, because I need help

Four focused tests covering channel-token packaging and type sorting pass with Xcode 27 beta on the iPhone 17 Pro / iOS 27.0 simulator.

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

None.