### PR TITLE
Order and limit unified search refinement suggestions

### DIFF
--- a/AnyTypeTests/PresentationLayer/UnifiedSearch/UnifiedSearchChipModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/UnifiedSearch/UnifiedSearchChipModelTests.swift
@@ -4,20 +4,58 @@ import Testing
 struct UnifiedSearchChipModelTests {
 
     @Test
-    func channelScopePackageAppendsPickerToIndividualChannels() {
-        let individualChips = [
-            UnifiedSearchChipModel(token: .space(spaceId: "space-1"), title: "One"),
-            UnifiedSearchChipModel(token: .space(spaceId: "space-2"), title: "Two")
+    func refinementPackagePutsSelectorsBeforeIndividualSuggestions() {
+        let people = [
+            UnifiedSearchChipModel(token: .creator(identity: "person-1"), title: "One")
+        ]
+        let channels = [
+            UnifiedSearchChipModel(token: .space(spaceId: "space-1"), title: "Channel")
         ]
 
-        let package = UnifiedSearchChipModel.channelScopePackage(individualChips: individualChips)
+        let package = UnifiedSearchChipModel.refinementPackage(
+            people: people,
+            channels: channels,
+            individualLimit: 5
+        )
 
-        #expect(package.dropLast() == individualChips[...])
-        #expect(package.last?.action == .openChannelsPicker)
+        #expect(package.map(\.action) == [
+            .openChannelsPicker,
+            .openPeoplePicker,
+            people[0].action,
+            channels[0].action
+        ])
     }
 
     @Test
-    func channelScopePackageIsEmptyWithoutIndividualChannels() {
-        #expect(UnifiedSearchChipModel.channelScopePackage(individualChips: []).isEmpty)
+    func refinementPackageLimitsEachIndividualGroup() {
+        let people = (0..<7).map {
+            UnifiedSearchChipModel(token: .creator(identity: "person-\($0)"), title: "Person \($0)")
+        }
+        let channels = (0..<8).map {
+            UnifiedSearchChipModel(token: .space(spaceId: "space-\($0)"), title: "Channel \($0)")
+        }
+
+        let package = UnifiedSearchChipModel.refinementPackage(
+            people: people,
+            channels: channels,
+            individualLimit: 5
+        )
+
+        #expect(package.count == 12)
+        #expect(package[2..<7].map(\.action) == people.prefix(5).map(\.action))
+        #expect(package[7..<12].map(\.action) == channels.prefix(5).map(\.action))
+    }
+
+    @Test
+    func refinementPackageOmitsSelectorForEmptyGroup() {
+        let channel = UnifiedSearchChipModel(token: .space(spaceId: "space-1"), title: "Channel")
+
+        let package = UnifiedSearchChipModel.refinementPackage(
+            people: [],
+            channels: [channel],
+            individualLimit: 5
+        )
+
+        #expect(package.map(\.action) == [.openChannelsPicker, channel.action])
     }
 }

--- a/AnyTypeTests/PresentationLayer/UnifiedSearch/UnifiedSearchChipModelTests.swift
+++ b/AnyTypeTests/PresentationLayer/UnifiedSearch/UnifiedSearchChipModelTests.swift
@@ -47,6 +47,29 @@ struct UnifiedSearchChipModelTests {
     }
 
     @Test
+    func refinementPackageKeepsCurrentChannelWithinLimit() {
+        let channels = (0..<6).map {
+            UnifiedSearchChipModel(token: .space(spaceId: "space-\($0)"), title: "Channel \($0)")
+        }
+
+        let package = UnifiedSearchChipModel.refinementPackage(
+            people: [],
+            channels: channels,
+            prioritizedChannelSpaceId: "space-5",
+            individualLimit: 5
+        )
+
+        #expect(package.map(\.action) == [
+            .openChannelsPicker,
+            channels[5].action,
+            channels[0].action,
+            channels[1].action,
+            channels[2].action,
+            channels[3].action
+        ])
+    }
+
+    @Test
     func refinementPackageOmitsSelectorForEmptyGroup() {
         let channel = UnifiedSearchChipModel(token: .space(spaceId: "space-1"), title: "Channel")
 

--- a/AnyTypeTests/PresentationLayer/UnifiedSearch/UnifiedSearchStateTests.swift
+++ b/AnyTypeTests/PresentationLayer/UnifiedSearch/UnifiedSearchStateTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import Anytype
+
+struct UnifiedSearchStateTests {
+
+    @Test
+    func addingSpaceScopeConvertsTypeFocusIntoTypeFilter() {
+        var state = UnifiedSearchState(tokens: [.typeFocus(uniqueKey: "task")])
+
+        state.setSpaceScope("space-1")
+
+        #expect(state.tokens == [
+            .type(uniqueKey: "task"),
+            .space(spaceId: "space-1")
+        ])
+        #expect(state.focusedTypeKey == nil)
+        #expect(state.typeUniqueKey == "task")
+        #expect(state.spaceScopeId == "space-1")
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Models/UnifiedSearchFocusModels.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Models/UnifiedSearchFocusModels.swift
@@ -2,7 +2,8 @@ import Foundation
 import Services
 
 // A row of a focused listing: the focused type's or person's instance in one
-// space. Type instances open; person instances filter (creator + that space).
+// space. A type instance's primary action opens it; its trailing action filters.
+// Person instances filter (creator + that space) from either action.
 struct UnifiedSearchFocusRow: Identifiable, Hashable {
     enum Kind: Hashable {
         case typeInstance

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchView.swift
@@ -176,7 +176,7 @@ struct UnifiedSearchView: View {
                         onTap: { model.onSelectFocusRow(row) },
                         onDrill: {
                             model.onFilterResultsTap {
-                                model.onSelectFocusRow(row)
+                                model.onFilterByFocusRow(row)
                             }
                         }
                     )

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchViewModel.swift
@@ -1376,6 +1376,7 @@ final class UnifiedSearchViewModel {
             result.append(contentsOf: UnifiedSearchChipModel.refinementPackage(
                 people: personSuggestionChips(scopeSpaceId: nil),
                 channels: channelScopeChips(),
+                prioritizedChannelSpaceId: moduleData.currentSpaceId,
                 individualLimit: Constants.refinementSuggestionLimit
             ))
             chips = result

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchViewModel.swift
@@ -1187,7 +1187,7 @@ final class UnifiedSearchViewModel {
     func onSelectFocusRow(_ row: UnifiedSearchFocusRow) {
         switch row.kind {
         case .typeInstance:
-            // A type instance opens
+            // The primary action on a type instance opens it.
             AnytypeAnalytics.instance().logSearchResult()
             guard let details = typesById[row.objectId] else { return }
             moduleData.onSelect(ScreenData(details: details))
@@ -1209,6 +1209,30 @@ final class UnifiedSearchViewModel {
             logToken(scopeToken, action: .add, source: .focus)
             updateTokenModels()
             rebuildChips()
+        }
+    }
+
+    func onFilterByFocusRow(_ row: UnifiedSearchFocusRow) {
+        switch row.kind {
+        case .typeInstance:
+            // Keep the primary action as open, but make the trailing accessory
+            // filter by this type in this Channel. Adding a scope converts the
+            // type focus into the corresponding plain type token.
+            guard let uniqueKey = state.focusedTypeKey else { return }
+            UISelectionFeedbackGenerator().selectionChanged()
+            let typeToken = UnifiedSearchToken.type(uniqueKey: uniqueKey)
+            let scopeToken = UnifiedSearchToken.space(spaceId: row.spaceId)
+            pushSnapshot(ownerTokenId: scopeToken.id, gestureTokenIds: [scopeToken.id, typeToken.id])
+            skipDebounceOnce = true
+            selectedTokenId = nil
+            state.searchText = ""
+            state.setSpaceScope(row.spaceId)
+            pruneOrphanedSnapshots()
+            logToken(scopeToken, action: .add, source: .focus)
+            updateTokenModels()
+            rebuildChips()
+        case .personInstance, .oneToOneChannel:
+            onSelectFocusRow(row)
         }
     }
 

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchViewModel.swift
@@ -20,6 +20,7 @@ final class UnifiedSearchViewModel {
         static let personRowsFullQueryLength = 4
         static let typeChipsLimit = 8
         static let memberChipsLimit = 3
+        static let refinementSuggestionLimit = 5
         // Covered by other chips (Media) or never useful as a type filter
         static let excludedTypeChipKeys: Set<ObjectTypeUniqueKey> = [
             .template, .participant, .objectType, .file, .image, .video, .audio, .chatDerived, .discussion, .date
@@ -1371,6 +1372,16 @@ final class UnifiedSearchViewModel {
         let scopeId = state.spaceScopeId
         let whatFilled = state.tokens.contains { $0.group == .what }
 
+        if scopeId == nil, supportsCrossSpaceRefinementSuggestions {
+            result.append(contentsOf: UnifiedSearchChipModel.refinementPackage(
+                people: personSuggestionChips(scopeSpaceId: nil),
+                channels: channelScopeChips(),
+                individualLimit: Constants.refinementSuggestionLimit
+            ))
+            chips = result
+            return
+        }
+
         if scopeId == nil, state.whatBucket != .channels {
             // Scope suggestion (global mode only): re-add the entry space.
             var channelChips = [UnifiedSearchChipModel]()
@@ -1382,12 +1393,7 @@ final class UnifiedSearchViewModel {
                 ))
             }
 
-            if supportsChannelScopeSuggestions {
-                channelChips.append(contentsOf: channelScopeChips(excluding: moduleData.currentSpaceId))
-                result.append(contentsOf: UnifiedSearchChipModel.channelScopePackage(individualChips: channelChips))
-            } else {
-                result.append(contentsOf: channelChips)
-            }
+            result.append(contentsOf: channelChips)
         }
 
         if scopeId == nil, !whatFilled {
@@ -1431,19 +1437,20 @@ final class UnifiedSearchViewModel {
         chips = result
     }
 
-    private func channelScopeChips(excluding excludedSpaceId: String?) -> [UnifiedSearchChipModel] {
+    private func channelScopeChips() -> [UnifiedSearchChipModel] {
         orderedSpaceViews
-            .filter { $0.targetSpaceId != excludedSpaceId }
             .map { spaceView in
                 UnifiedSearchChipModel(
                     token: .space(spaceId: spaceView.targetSpaceId),
-                    title: spaceView.title,
+                    title: spaceView.targetSpaceId == moduleData.currentSpaceId
+                        ? Loc.UnifiedSearch.Chip.inThisChannel
+                        : spaceView.title,
                     icon: spaceView.objectIconImage
                 )
             }
     }
 
-    private var supportsChannelScopeSuggestions: Bool {
+    private var supportsCrossSpaceRefinementSuggestions: Bool {
         state.tokens.contains { token in
             switch token {
             case .kind(let bucket):
@@ -1516,6 +1523,35 @@ final class UnifiedSearchViewModel {
                     icon: participant.icon.map { Icon.object($0) } ?? .object(.profile(.placeholder))
                 )
             }
+    }
+
+    private func personSuggestionChips(scopeSpaceId: String?) -> [UnifiedSearchChipModel] {
+        guard whoFilterApplies,
+              state.creatorIdentity == nil,
+              state.focusedPersonIdentity == nil,
+              let ownIdentity else { return [] }
+
+        let people = personBrowseList(scopeSpaceId: scopeSpaceId)
+        guard people.count > 1 else { return [] }
+
+        var result = [UnifiedSearchChipModel]()
+        let own = people.first { $0.identity == ownIdentity }
+        result.append(UnifiedSearchChipModel(
+            token: .creator(identity: ownIdentity),
+            title: Loc.UnifiedSearch.Chip.byMe,
+            icon: own?.icon.map { Icon.object($0) }
+        ))
+        result.append(contentsOf: people
+            .filter { $0.identity != ownIdentity }
+            .map { participant in
+                UnifiedSearchChipModel(
+                    token: .creator(identity: participant.identity),
+                    title: Loc.UnifiedSearch.Chip.by(participant.title),
+                    icon: participant.icon.map { Icon.object($0) } ?? .object(.profile(.placeholder))
+                )
+            }
+        )
+        return result
     }
 
     // People deduped by identity in the vault's 1:1-first order: partners of 1:1

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChannelRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChannelRowView.swift
@@ -40,9 +40,7 @@ struct UnifiedSearchChannelRowView: View {
                     )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(
-                    showsFilterResultsOnboarding ? Loc.UnifiedSearch.Onboarding.useAsFilter : Loc.search
-                )
+                .accessibilityLabel(Loc.UnifiedSearch.Accessibility.filterBy(row.title))
             }
             .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
             .fixTappableArea()

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChipsRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChipsRowView.swift
@@ -38,12 +38,17 @@ struct UnifiedSearchChipModel: Identifiable, Hashable {
     static func refinementPackage(
         people: [Self],
         channels: [Self],
+        prioritizedChannelSpaceId: String? = nil,
         individualLimit: Int
     ) -> [Self] {
         guard individualLimit > 0 else { return [] }
 
         let people = Array(people.prefix(individualLimit))
-        let channels = Array(channels.prefix(individualLimit))
+        let channels = Array(
+            channels
+                .prioritizingSpace(prioritizedChannelSpaceId)
+                .prefix(individualLimit)
+        )
         var result = [Self]()
 
         if channels.isNotEmpty {
@@ -62,6 +67,23 @@ struct UnifiedSearchChipModel: Identifiable, Hashable {
 
         result.append(contentsOf: people)
         result.append(contentsOf: channels)
+        return result
+    }
+}
+
+private extension Array where Element == UnifiedSearchChipModel {
+    func prioritizingSpace(_ spaceId: String?) -> Self {
+        guard let spaceId,
+              let index = firstIndex(where: { chip in
+                  if case .addToken(.space(let candidateSpaceId)) = chip.action {
+                      return candidateSpaceId == spaceId
+                  }
+                  return false
+              }),
+              index != startIndex else { return self }
+
+        var result = self
+        result.insert(result.remove(at: index), at: startIndex)
         return result
     }
 }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChipsRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChipsRowView.swift
@@ -35,9 +35,34 @@ struct UnifiedSearchChipModel: Identifiable, Hashable {
         }
     }
 
-    static func channelScopePackage(individualChips: [Self]) -> [Self] {
-        guard individualChips.isNotEmpty else { return [] }
-        return individualChips + [Self(action: .openChannelsPicker, title: UnifiedSearchKindBucket.channels.title)]
+    static func refinementPackage(
+        people: [Self],
+        channels: [Self],
+        individualLimit: Int
+    ) -> [Self] {
+        guard individualLimit > 0 else { return [] }
+
+        let people = Array(people.prefix(individualLimit))
+        let channels = Array(channels.prefix(individualLimit))
+        var result = [Self]()
+
+        if channels.isNotEmpty {
+            result.append(Self(
+                action: .openChannelsPicker,
+                title: UnifiedSearchKindBucket.channels.title
+            ))
+        }
+        if people.isNotEmpty {
+            result.append(Self(
+                action: .openPeoplePicker,
+                title: Loc.UnifiedSearch.Chip.people,
+                icon: .asset(ImageAsset.CustomIcons.people)
+            ))
+        }
+
+        result.append(contentsOf: people)
+        result.append(contentsOf: channels)
+        return result
     }
 }
 

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchFilterResultsButtonLabel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchFilterResultsButtonLabel.swift
@@ -14,7 +14,8 @@ struct UnifiedSearchFilterResultsButtonLabel: View {
                     .offset(y: -2)
             }
 
-            Image(asset: .X18.search)
+            Image(systemName: "line.3.horizontal.decrease")
+                .font(.system(size: 18, weight: .medium))
         }
         .foregroundStyle(foregroundColor)
         .frame(minWidth: 44, minHeight: 44, alignment: .trailing)

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchLeadRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchLeadRowView.swift
@@ -42,9 +42,7 @@ struct UnifiedSearchLeadRowView: View {
                     )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(
-                    showsFilterResultsOnboarding ? Loc.UnifiedSearch.Onboarding.useAsFilter : Loc.search
-                )
+                .accessibilityLabel(Loc.UnifiedSearch.Accessibility.filterBy(title))
             }
             .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
             .fixTappableArea()

--- a/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureService.swift
+++ b/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureService.swift
@@ -70,6 +70,7 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
         guard let draftId = draftStorage.draftObjectId(spaceId: spaceId) else { return }
         try await objectActionsService.updateBundledDetails(contextID: draftId, details: [.isHidden(false)])
         draftStorage.setDraftObjectId(nil, spaceId: spaceId)
+        await markDraftTypeAsUsed(objectId: draftId, spaceId: spaceId)
     }
 
     func clearDraft(spaceId: String) async throws {
@@ -160,6 +161,15 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
     private func deleteDraft(objectId: String, spaceId: String) async throws {
         try await objectActionsService.delete(objectIds: [objectId])
         draftStorage.setDraftObjectId(nil, spaceId: spaceId)
+    }
+
+    private func markDraftTypeAsUsed(objectId: String, spaceId: String) async {
+        guard let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [objectId]).first,
+              details.type.isNotEmpty else { return }
+        try? await objectActionsService.updateBundledDetails(
+            contextID: details.type,
+            details: [.lastUsedDate(.now)]
+        )
     }
 
     // Callers prepare the space caches (prepareSpaceForPreview) before this

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -1343,6 +1343,11 @@ public enum Loc {
     public static func inSpacePlusOne(_ p1: Any) -> String {
       return Loc.tr("UI", "UnifiedSearch.inSpacePlusOne", String(describing: p1), fallback: "in %@ + 1 other Channel")
     }
+    public enum Accessibility {
+      public static func filterBy(_ p1: Any) -> String {
+        return Loc.tr("UI", "UnifiedSearch.Accessibility.filterBy", String(describing: p1), fallback: "Filter by %@")
+      }
+    }
     public enum Chip {
       public static func by(_ p1: Any) -> String {
         return Loc.tr("UI", "UnifiedSearch.Chip.by", String(describing: p1), fallback: "By %@")

--- a/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
@@ -105169,6 +105169,17 @@
         }
       }
     },
+    "UnifiedSearch.Accessibility.filterBy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter by %@"
+          }
+        }
+      }
+    },
     "UnifiedSearch.Chip.by" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)

---

### Description

Follow-up to #5100 that makes cross-space refinement suggestions predictable after selecting a specific type, layout, or Messages token:

- Places Channels first in the suggestion row.
- Places People second, before individual suggestions.
- Limits individual people suggestions to five.
- Limits individual channel suggestions to five.
- Applies limits after the existing people and Space Hub channel sorting.
- Keeps selector chips coupled to their individual suggestion groups.

This is a stacked PR based on the branch for #5100 so the review contains only this follow-up delta.

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

Depends on #5100.

### Mobile & Desktop Screenshots/Recordings

Verified on the iPhone 17 Pro / iOS 27.0 simulator.

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they are not needed
- [ ] 🙋 no, because I need help

Five focused tests in two suites pass with Xcode 27 beta on the iPhone 17 Pro / iOS 27.0 simulator.

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

Retarget this PR to develop after #5100 merges.