### PR TITLE
Fix unified search initial token layout

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Models/UnifiedSearchModuleData.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Models/UnifiedSearchModuleData.swift
@@ -23,9 +23,6 @@ struct UnifiedSearchModuleData: Identifiable, Hashable {
     @EquatableNoop var onCreatePersonalChannel: () -> Void
     @EquatableNoop var onCreateGroupChannel: () -> Void
     @EquatableNoop var onJoinQrCode: () -> Void
-    // True when the entry control is a compact button: the bar springs open from
-    // it. The vault's entry is already bar-shaped, so it appears in place.
-    let animatesBarExpansion: Bool
     var purpose: UnifiedSearchPurpose = .navigation
     // Seeds a chat token on top of the space scope (in-chat search entry)
     var initialChatId: String? = nil

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchView.swift
@@ -12,8 +12,6 @@ struct UnifiedSearchView: View {
 
     @State private var model: UnifiedSearchViewModel
     @Namespace private var glassNamespace
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var barExpanded = false
 
     init(data: UnifiedSearchModuleData) {
         self._model = State(initialValue: UnifiedSearchViewModel(data: data))
@@ -33,15 +31,6 @@ struct UnifiedSearchView: View {
         // app switcher snapshots without a keyboard, and the underlying screen
         // must not show through the gap
         .background(Color.Background.secondary.ignoresSafeArea())
-        .onAppear {
-            guard model.animatesBarExpansion, !reduceMotion else {
-                barExpanded = true
-                return
-            }
-            withAnimation(.spring(duration: 0.35, bounce: 0.15)) {
-                barExpanded = true
-            }
-        }
         .task {
             await model.observeTypes()
         }
@@ -118,9 +107,6 @@ struct UnifiedSearchView: View {
                 .padding(.vertical, 10)
             }
         }
-        // The bar springs open from the entry button's corner
-        .scaleEffect(model.animatesBarExpansion && !barExpanded ? 0.2 : 1, anchor: .bottomLeading)
-        .opacity(model.animatesBarExpansion && !barExpanded ? 0 : 1)
         .fitIPadToReadableContentGuide()
         if #available(iOS 26.0, *) {
             block

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/UnifiedSearchViewModel.swift
@@ -156,7 +156,6 @@ final class UnifiedSearchViewModel {
     var fieldFocusRequestId = 0
 
     var isGlobal: Bool { state.spaceScopeId == nil }
-    var animatesBarExpansion: Bool { moduleData.animatesBarExpansion }
     // Create Channel is the Channels bucket's one action
     var showsCreateChannelAction: Bool { isGlobal && state.whatBucket == .channels }
 

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchBar.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchBar.swift
@@ -26,11 +26,22 @@ struct UnifiedSearchBar: View {
     let onBackspaceWhenEmpty: () -> Void
     let onSubmit: () -> Void
 
-    @State private var barWidth: CGFloat = 0
+    @State private var barWidth: CGFloat?
 
     var body: some View {
         barContent
-            .readSize { barWidth = $0.width }
+            // The overflow decision needs the assigned width. Keep the first,
+            // measuring layout invisible so oversized full labels never flash or
+            // animate across the bar before the settled layout is known.
+            .opacity(barWidth == nil ? 0 : 1)
+            .readSize { size in
+                guard size.width > 0, size.width != barWidth else { return }
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    barWidth = size.width
+                }
+            }
             .padding(.vertical, 9)
             .padding(.horizontal, 12)
             .glassCapsule
@@ -40,7 +51,7 @@ struct UnifiedSearchBar: View {
     // fit next to a usable field, every pill drops to its icon instead
     private var iconOnlyPills: Bool {
         if collapsesToIcons { return true }
-        guard barWidth > 0, tokens.isNotEmpty else { return false }
+        guard let barWidth, tokens.isNotEmpty else { return false }
         let font = UIKitFontBuilder.uiKitFont(font: .uxTitle2Medium)
         let pillsWidth = tokens.reduce(CGFloat.zero) { width, token in
             let text = (token.title as NSString).size(withAttributes: [.font: font]).width
@@ -108,7 +119,6 @@ struct UnifiedSearchBar: View {
             .fixTappableArea()
         }
         .buttonStyle(.plain)
-        .animation(.default, value: iconOnly)
         .accessibilityLabel(model.title)
         .accessibilityAction(named: Loc.remove) {
             onRemoveToken(model.token)

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChipsRowView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchChipsRowView.swift
@@ -109,7 +109,6 @@ struct UnifiedSearchChipsRowView: View {
             .padding(.horizontal, 16)
             .padding(.top, 10)
         }
-        .animation(.default, value: chips)
     }
 
     private func chipView(_ chip: UnifiedSearchChipModel) -> some View {

--- a/Anytype/Sources/PresentationLayer/Flows/ChatCoordinator/ChatCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/ChatCoordinator/ChatCoordinatorViewModel.swift
@@ -82,7 +82,6 @@ final class ChatCoordinatorViewModel: ChatModuleOutput, ObjectSettingsCoordinato
                 onCreatePersonalChannel: { },
                 onCreateGroupChannel: { },
                 onJoinQrCode: { },
-                animatesBarExpansion: false,
                 purpose: .attachToMessage,
                 excludedObjectIds: data.excludedObjectIds,
                 onSelectDetails: { [weak self] details in

--- a/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/DiscussionCoordinator/DiscussionCoordinatorViewModel.swift
@@ -81,7 +81,6 @@ final class DiscussionCoordinatorViewModel: DiscussionModuleOutput {
                 onCreatePersonalChannel: { },
                 onCreateGroupChannel: { },
                 onJoinQrCode: { },
-                animatesBarExpansion: false,
                 purpose: .attachToMessage,
                 excludedObjectIds: data.excludedObjectIds,
                 onSelectDetails: { [weak self] details in

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -331,12 +331,11 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
             onClose: { [weak self] in
                 self?.searchOverlayData = nil
                 self?.searchOverlayOriginItem = nil
-            },
-            animatesBarExpansion: false
+            }
         )
     }
 
-    private func searchModuleData(currentSpaceId: String?, initialChatId: String? = nil, onClose: (() -> Void)?, animatesBarExpansion: Bool) -> UnifiedSearchModuleData {
+    private func searchModuleData(currentSpaceId: String?, initialChatId: String? = nil, onClose: (() -> Void)?) -> UnifiedSearchModuleData {
         UnifiedSearchModuleData(
             currentSpaceId: currentSpaceId,
             onSelect: { [weak self] screenData in
@@ -373,7 +372,6 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
             onJoinQrCode: { [weak self] in
                 self?.onSelectQrCodeJoin()
             },
-            animatesBarExpansion: animatesBarExpansion,
             initialChatId: initialChatId
         )
     }
@@ -900,8 +898,7 @@ extension SpaceHubCoordinatorViewModel: HomeBottomNavigationPanelModuleOutput {
                 onClose: { [weak self] in
                     self?.searchOverlayData = nil
                     self?.searchOverlayOriginItem = nil
-                },
-                animatesBarExpansion: true
+                }
             )
         } else {
             showGlobalSearchData = GlobalSearchModuleData(
@@ -924,8 +921,7 @@ extension SpaceHubCoordinatorViewModel: HomeBottomNavigationPanelModuleOutput {
             onClose: { [weak self] in
                 self?.searchOverlayData = nil
                 self?.searchOverlayOriginItem = nil
-            },
-            animatesBarExpansion: true
+            }
         )
     }
 


### PR DESCRIPTION
---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/open/blob/main/templates/CLA.md)

---

### Description

Removes the unified-search entry expansion and implicit token animations so the search sheet opens with chips in their final positions. The search bar now resolves its available width invisibly and applies the fitting pill layout without animation, preventing initial overlap and reducing unnecessary GPU work.

### What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix
- [x] 🔥 Performance Improvements

### Related Tickets & Documents

N/A

### Mobile & Desktop Screenshots/Recordings

N/A — removes the transient opening animation and overlap.

### Added tests?

- [x] 🙅 no, because they aren't needed

Verified with Xcode Beta on the iPhone 17 Pro simulator running iOS 27.0.

### Added to documentation?

- [x] 🙅 no documentation needed

### Are there any post-deployment tasks we need to perform?

No.