### PR TITLE
IOS-6617 Enable quick capture in release builds

### DIFF
--- a/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
+++ b/Modules/AnytypeCore/AnytypeCore/Utils/FeatureFlags/FeatureDescription+Flags.swift
@@ -67,9 +67,8 @@ public extension FeatureDescription {
 
     static let quickCapture = FeatureDescription(
         title: "Quick Capture from Space Hub - IOS-6617",
-        category: .productFeature(author: "requilence@gmail.com", targetRelease: "?"),
-        defaultValue: false,
-        debugValue: true
+        category: .productFeature(author: "requilence@gmail.com", targetRelease: "0.49.0"),
+        defaultValue: true
     )
 
     static let quickCaptureTypeSuggestions = FeatureDescription(


### PR DESCRIPTION
## Summary

- Turn on `quickCapture` for the `releaseAnytype` target so Quick Capture ships in 0.49.0 — it was `defaultValue: false` / `debugValue: true`, i.e. visible only in dev nightlies and dark in production builds.
- Record the now-known `targetRelease` as `0.49.0` instead of the `?` placeholder.
- `quickCaptureTypeSuggestions` (on-device FoundationModels type suggestion) stays off in release; flip separately if it should ship too.
