### PR TITLE
Retry iOS platform download in release build

### DIFF
--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -38,7 +38,7 @@ jobs:
           xcode-version: '26.1'
 
       - name: Install iOS Platform
-        run: xcodebuild -downloadPlatform iOS
+        uses: ./.github/actions/install-ios-platform
 
       - name: Download Middleware
         run: make setup-middle-ci


### PR DESCRIPTION
## Summary

- `release_build.yaml` called `xcodebuild -downloadPlatform iOS` directly, so a single "Unable to connect to simulator" (exit 70) killed the whole production release build — this just happened on run 33522600391.
- Switch it to `./.github/actions/install-ios-platform`, the composite action written for this exact flake (3 attempts, 30s apart), already used by `dev_build.yaml`, `pr_tests.yml`, `update_middleware.yaml` and `update_cache.yaml`.
- `license-checks.yml`, `branch_build.yaml`, `ipa.yaml` and `test_fastlane_build.yaml` still call it raw and could get the same treatment separately.
