### PR TITLE
Retry iOS platform download in release build

### DIFF
--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -38,7 +38,7 @@ jobs:
           xcode-version: '26.1'
 
       - name: Install iOS Platform
-        run: xcodebuild -downloadPlatform iOS
+        uses: ./.github/actions/install-ios-platform
 
       - name: Download Middleware
         run: make setup-middle-ci


### PR DESCRIPTION
## Summary

- Port of #5106 to `release` so the 0.49.0 production build stops dying on a transient `xcodebuild -downloadPlatform iOS` failure ("Unable to connect to simulator", exit 70 — hit on run 33522600391).
- Uses `./.github/actions/install-ios-platform`, which retries 3× with a 30s gap.
