### PR TITLE
Quick Capture draft improvements, stable Space Hub order, search entry glimmer

### DIFF
--- a/AnyTypeTests/Markdown/Mocks/UserDefaultsStorageMock.swift
+++ b/AnyTypeTests/Markdown/Mocks/UserDefaultsStorageMock.swift
@@ -18,6 +18,7 @@ final class UserDefaultsStorageMock: UserDefaultsStorageProtocol {
     var userInterfaceStyle: UIUserInterfaceStyle { get { fatalError() } set { fatalError() } }
     var autoDownloadSizeLimitRawValue: Int { get { fatalError() } set { fatalError() } }
     var autoDownloadUseCellular: Bool { get { fatalError() } set { fatalError() } }
+    var spaceHubLastMessageDates: [String: Date] = [:]
     
     func wallpapersPublisher() -> AnyPublisher<[String : Anytype.SpaceWallpaperType], Never> {
         fatalError()

--- a/AnyTypeTests/Markdown/Mocks/UserDefaultsStorageMock.swift
+++ b/AnyTypeTests/Markdown/Mocks/UserDefaultsStorageMock.swift
@@ -19,6 +19,7 @@ final class UserDefaultsStorageMock: UserDefaultsStorageProtocol {
     var autoDownloadSizeLimitRawValue: Int { get { fatalError() } set { fatalError() } }
     var autoDownloadUseCellular: Bool { get { fatalError() } set { fatalError() } }
     var spaceHubLastMessageDates: [String: Date] = [:]
+    var unifiedSearchDiscovered: Bool = false
     
     func wallpapersPublisher() -> AnyPublisher<[String : Anytype.SpaceWallpaperType], Never> {
         fatalError()

--- a/AnyTypeTests/PresentationLayer/SpaceHub/SpaceHubRememberedLastMessageDatesTests.swift
+++ b/AnyTypeTests/PresentationLayer/SpaceHub/SpaceHubRememberedLastMessageDatesTests.swift
@@ -1,0 +1,201 @@
+import Testing
+import Foundation
+@testable import Anytype
+import Services
+import SwiftProtobuf
+
+// Chat previews stream in after launch. Until a space's previews arrive the hub keeps it at the
+// message date it showed last time; once they arrive they are the truth, even with no message.
+struct SpaceHubRememberedLastMessageDatesTests {
+
+    private let day: TimeInterval = 86_400
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    // MARK: - Fallback while previews are loading
+
+    @Test func spaceWithoutPreviewUsesRememberedDate() {
+        let remembered = now - 1 * day
+
+        let result = build(spaces: [makeSpace(id: "space-1")], remembered: ["space-1": remembered])
+
+        #expect(result.spaces.map(\.lastMessageDate) == [remembered])
+        #expect(result.arrivedLastMessageDates.isEmpty)
+    }
+
+    @Test func arrivedPreviewWinsOverRememberedDate() {
+        let messageDate = now - 1 * day
+
+        let result = build(
+            spaces: [makeSpace(id: "space-1")],
+            previews: [makePreview(spaceId: "space-1", chatId: "chat-1", messageDate: messageDate)],
+            chatDetails: [makeChat(id: "chat-1")],
+            remembered: ["space-1": now - 5 * day]
+        )
+
+        #expect(result.spaces.map(\.lastMessageDate) == [messageDate])
+        #expect(result.arrivedLastMessageDates == ["space-1": messageDate])
+    }
+
+    @Test func arrivedPreviewWithoutMessageDropsRememberedDate() {
+        // The chat's state arrived but it holds no message: emptied, or never had one.
+        let remembered = ["space-1": now - 1 * day]
+
+        let result = build(
+            spaces: [makeSpace(id: "space-1")],
+            previews: [ChatMessagePreview(spaceId: "space-1", chatId: "chat-1")],
+            chatDetails: [makeChat(id: "chat-1")],
+            remembered: remembered
+        )
+        let updated = SpaceHubSpacesStorage.rememberedLastMessageDates(remembered, updatedWith: result.arrivedLastMessageDates)
+
+        #expect(result.spaces.map(\.lastMessageDate) == [nil])
+        #expect(result.arrivedLastMessageDates.keys.contains("space-1"))
+        #expect(updated.isEmpty)
+    }
+
+    @Test func archivedChatCountsAsArrivedWithoutMessage() {
+        let remembered = ["space-1": now - 1 * day]
+
+        let result = build(
+            spaces: [makeSpace(id: "space-1")],
+            previews: [makePreview(spaceId: "space-1", chatId: "chat-1", messageDate: now - 1 * day)],
+            chatDetails: [makeChat(id: "chat-1", isArchived: true)],
+            remembered: remembered
+        )
+        let updated = SpaceHubSpacesStorage.rememberedLastMessageDates(remembered, updatedWith: result.arrivedLastMessageDates)
+
+        #expect(result.spaces.map(\.lastMessageDate) == [nil])
+        #expect(updated.isEmpty)
+    }
+
+    @Test func spaceNeverSeenBeforeHasNoDate() {
+        let result = build(spaces: [makeSpace(id: "space-1")], remembered: [:])
+
+        #expect(result.spaces.map(\.lastMessageDate) == [nil])
+    }
+
+    // MARK: - Remembering dates for the next launch
+
+    @Test func partialPreviewSetKeepsDatesOfSpacesStillLoading() {
+        let remembered = ["loading": now - 3 * day, "arrived": now - 4 * day]
+        let arrivedMessageDate = now - 1 * day
+
+        let result = build(
+            spaces: [makeSpace(id: "loading"), makeSpace(id: "arrived")],
+            previews: [makePreview(spaceId: "arrived", chatId: "chat-1", messageDate: arrivedMessageDate)],
+            chatDetails: [makeChat(id: "chat-1")],
+            remembered: remembered
+        )
+        let updated = SpaceHubSpacesStorage.rememberedLastMessageDates(remembered, updatedWith: result.arrivedLastMessageDates)
+
+        #expect(updated == ["loading": now - 3 * day, "arrived": arrivedMessageDate])
+    }
+
+    @Test func newSpaceWithPreviewIsRemembered() {
+        let messageDate = now - 1 * day
+
+        let result = build(
+            spaces: [makeSpace(id: "space-1")],
+            previews: [makePreview(spaceId: "space-1", chatId: "chat-1", messageDate: messageDate)],
+            chatDetails: [makeChat(id: "chat-1")],
+            remembered: [:]
+        )
+        let updated = SpaceHubSpacesStorage.rememberedLastMessageDates([:], updatedWith: result.arrivedLastMessageDates)
+
+        #expect(updated == ["space-1": messageDate])
+    }
+
+    // MARK: - Sorting
+
+    @Test func rememberedDateOrdersSpaceAheadOfNewerJoinDate() {
+        // "loading" joined long ago but its last message was yesterday; "joined" has no
+        // messages and joined three days ago. Without the remembered date "loading" would
+        // sort below "joined" and jump above it once its preview arrived.
+        let loading = build(
+            spaces: [makeSpace(id: "loading", joinDate: now - 30 * day)],
+            remembered: ["loading": now - 1 * day]
+        ).spaces
+        let joined = build(
+            spaces: [makeSpace(id: "joined", joinDate: now - 3 * day)],
+            remembered: [:]
+        ).spaces
+
+        let sorted = (joined + loading).sortedForSpaceHub()
+
+        #expect(sorted.map(\.spaceView.targetSpaceId) == ["loading", "joined"])
+    }
+
+    // MARK: - Fixtures
+
+    private func build(
+        spaces: [ParticipantSpaceViewData],
+        previews: [ChatMessagePreview] = [],
+        chatDetails: [ObjectDetails] = [],
+        remembered: [String: Date]
+    ) -> SpaceHubSpacesStorage.BuildResult {
+        SpaceHubSpacesStorage.build(
+            spaces: spaces,
+            previews: previews,
+            chatDetails: chatDetails,
+            discussionUnreadBySpace: [:],
+            rememberedLastMessageDates: remembered
+        )
+    }
+
+    // The space view id and the target space id differ in production; keep them distinct so a
+    // read/write key mismatch would fail here.
+    private func makeSpace(id: String, joinDate: Date? = nil) -> ParticipantSpaceViewData {
+        let spaceView = SpaceView(
+            id: "view-\(id)",
+            name: id,
+            description: "",
+            objectIconImage: .object(.space(.mock)),
+            targetSpaceId: id,
+            createdDate: nil,
+            joinDate: joinDate,
+            accountStatus: .spaceActive,
+            localStatus: .ok,
+            spaceAccessType: .private,
+            readersLimit: nil,
+            writersLimit: nil,
+            chatId: "",
+            spaceOrder: "",
+            spaceType: .regular,
+            pushNotificationEncryptionKey: "",
+            pushNotificationMode: .all,
+            forceAllIds: [],
+            forceMuteIds: [],
+            forceMentionIds: [],
+            oneToOneIdentity: "",
+            homepage: .empty
+        )
+        return ParticipantSpaceViewData(
+            spaceView: spaceView,
+            participant: nil,
+            permissions: SpacePermissions(spaceView: spaceView, participant: nil, isLocalMode: false)
+        )
+    }
+
+    private func makeChat(id: String, isArchived: Bool = false) -> ObjectDetails {
+        var values: [String: Google_Protobuf_Value] = [:]
+        if isArchived {
+            values[BundledPropertyKey.isArchived.rawValue] = Google_Protobuf_Value(boolValue: true)
+        }
+        return ObjectDetails(id: id, values: values)
+    }
+
+    private func makePreview(spaceId: String, chatId: String, messageDate: Date) -> ChatMessagePreview {
+        var preview = ChatMessagePreview(spaceId: spaceId, chatId: chatId)
+        preview.lastMessage = LastMessagePreview(
+            id: "message-\(chatId)",
+            creator: nil,
+            text: "Hello",
+            createdAt: messageDate,
+            modifiedAt: nil,
+            attachments: [],
+            attachmentCount: 0,
+            orderId: "order-1"
+        )
+        return preview
+    }
+}

--- a/AnyTypeTests/Services/QuickCaptureDraftTests.swift
+++ b/AnyTypeTests/Services/QuickCaptureDraftTests.swift
@@ -39,12 +39,26 @@ struct QuickCaptureDraftTests {
         #expect(QuickCaptureDraft.isDraft(hiddenDraft().updated(by: [QuickCaptureDraft.relationKey: .init()]), participantId: nil))
     }
 
-    @Test func legacyMigrationIncludesNullButNotExplicitFlags() {
-        #expect(QuickCaptureDraft.needsMigration(hiddenDraft()))
-        #expect(QuickCaptureDraft.needsMigration(hiddenDraft().updated(by: [QuickCaptureDraft.relationKey: .with { $0.nullValue = .nullValue }])))
+    @Test func draftFlagRequiresExplicitValue() {
+        #expect(!QuickCaptureDraft.hasDraftFlag(hiddenDraft()))
+        #expect(!QuickCaptureDraft.hasDraftFlag(hiddenDraft().updated(by: [QuickCaptureDraft.relationKey: .with { $0.nullValue = .nullValue }])))
         for flag in [true, false] {
-            #expect(!QuickCaptureDraft.needsMigration(hiddenDraft().updated(by: [QuickCaptureDraft.relationKey: flag.protobufValue])))
+            #expect(QuickCaptureDraft.hasDraftFlag(hiddenDraft().updated(by: [QuickCaptureDraft.relationKey: flag.protobufValue])))
         }
+    }
+
+    @Test func onlyDraftsWithIndexedContentMarkTheirSpace() {
+        let empty = hiddenDraft()
+        let titled = hiddenDraft().updated(by: [
+            BundledPropertyKey.spaceId.rawValue: "space-b".protobufValue, BundledPropertyKey.name.rawValue: "Idea".protobufValue
+        ])
+        let bodyOnly = hiddenDraft().updated(by: [
+            BundledPropertyKey.spaceId.rawValue: "space-c".protobufValue, BundledPropertyKey.snippet.rawValue: "Some text".protobufValue
+        ])
+        let discovery = QuickCaptureDraftDiscovery(drafts: [empty, titled, bodyOnly], isComplete: true)
+
+        #expect(discovery.spaceIdsWithContent == ["space-b", "space-c"])
+        #expect(discovery.newestDraft(spaceId: "space-a")?.id == empty.id)
     }
 
     @Test func knownForeignCreatorIsRejectedButUnknownParticipantDoesNotHideDraft() {

--- a/AnyTypeTests/Services/QuickCaptureDraftTests.swift
+++ b/AnyTypeTests/Services/QuickCaptureDraftTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+import Services
+import AnytypeCore
+@testable import Anytype
+
+struct QuickCaptureDraftTests {
+    @Test func untouchedRestoredDraftNavigatesWithoutPrompt() {
+        for targetHasContent in [false, true] {
+            #expect(QuickCaptureSpaceSwitch.action(
+                hasContent: true, hasLocalEdits: false, targetHasContent: targetHasContent
+            ) == .openTarget)
+        }
+    }
+
+    @Test func clearedDraftNavigatesEvenAfterEditing() {
+        #expect(QuickCaptureSpaceSwitch.action(
+            hasContent: false, hasLocalEdits: true, targetHasContent: true
+        ) == .openTarget)
+    }
+
+    @Test func editedTextMovesUnlessDestinationHoldsContent() {
+        #expect(QuickCaptureSpaceSwitch.action(
+            hasContent: true, hasLocalEdits: true, targetHasContent: false
+        ) == .move)
+        #expect(QuickCaptureSpaceSwitch.action(
+            hasContent: true, hasLocalEdits: true, targetHasContent: true
+        ) == .confirm)
+    }
+
+    @Test func explicitPublishedFlagWinsOverHidden() {
+        let details = hiddenDraft().updated(by: [QuickCaptureDraft.relationKey: false.protobufValue])
+        #expect(!QuickCaptureDraft.isDraft(details, participantId: "me"))
+    }
+
+    @Test func legacyHiddenDraftSurvivesMissingFlagAndCreator() {
+        #expect(QuickCaptureDraft.isDraft(hiddenDraft(), participantId: "me"))
+        #expect(QuickCaptureDraft.isDraft(hiddenDraft(), participantId: nil))
+        #expect(QuickCaptureDraft.isDraft(hiddenDraft().updated(by: [QuickCaptureDraft.relationKey: .init()]), participantId: nil))
+    }
+
+    @Test func legacyMigrationIncludesNullButNotExplicitFlags() {
+        #expect(QuickCaptureDraft.needsMigration(hiddenDraft()))
+        #expect(QuickCaptureDraft.needsMigration(hiddenDraft().updated(by: [QuickCaptureDraft.relationKey: .with { $0.nullValue = .nullValue }])))
+        for flag in [true, false] {
+            #expect(!QuickCaptureDraft.needsMigration(hiddenDraft().updated(by: [QuickCaptureDraft.relationKey: flag.protobufValue])))
+        }
+    }
+
+    @Test func knownForeignCreatorIsRejectedButUnknownParticipantDoesNotHideDraft() {
+        let details = hiddenDraft().updated(by: [BundledPropertyKey.creator.rawValue: "someone-else".protobufValue])
+        #expect(!QuickCaptureDraft.isDraft(details, participantId: "me"))
+        #expect(QuickCaptureDraft.isDraft(details, participantId: nil))
+    }
+
+    @Test func deletedAndArchivedObjectsAreNeverDrafts() {
+        for key in [BundledPropertyKey.isDeleted, .isArchived] {
+            let details = hiddenDraft().updated(by: [key.rawValue: true.protobufValue, QuickCaptureDraft.relationKey: true.protobufValue])
+            #expect(!QuickCaptureDraft.isDraft(details, participantId: nil))
+        }
+    }
+
+    @Test func discoveryRequestsEveryConsumedFieldAndEveryParticipant() throws {
+        let request = QuickCaptureDraft.discoveryRequest(participantIds: ["me-space-a", "me-space-b"], localDraftIds: ["legacy"])
+        let union = try #require(request.filters.first)
+        #expect(union.operator == .or)
+        let owned = try #require(union.nestedFilters.first)
+        #expect(owned.operator == .and)
+        let creators = try #require(owned.nestedFilters.first { $0.relationKey == BundledPropertyKey.creator.rawValue })
+        #expect(creators.condition == .in)
+        #expect(creators.value.listValue.values.map(\.stringValue) == ["me-space-a", "me-space-b"])
+        #expect(union.nestedFilters.last?.relationKey == BundledPropertyKey.id.rawValue)
+        for key in ["id", "spaceId", "name", "description", "snippet", "creator", "createdDate", "isDraft", "isHidden", "isDeleted", "isArchived"] {
+            #expect(request.keys.contains(key))
+        }
+        #expect(request.sorts.first?.relationKey == "createdDate")
+        #expect(request.sorts.first?.type == .desc)
+    }
+
+    @Test func partialDiscoveryRetainsKnownDraftsWithoutClaimingAbsence() {
+        let discovery = QuickCaptureDraftDiscovery(drafts: [hiddenDraft()], isComplete: false)
+        #expect(discovery.newestDraft(spaceId: "space-a")?.id == "draft")
+        #expect(discovery.newestDraft(spaceId: "space-b") == nil)
+        #expect(!discovery.isComplete)
+    }
+
+    @Test func bodyOnlyAndAttachmentOnlyDraftsAreNotEmpty() {
+        #expect(content([text("body", "Unsent text")]).hasContent)
+        #expect(content([image("image")]).hasContent)
+        #expect(!content([text("empty", "")]).hasContent)
+    }
+
+    @Test func fullyEmptyDraftCanBeCleanedUpWithOrWithoutPlaceholderBlocks() {
+        #expect(!content([]).hasContent)
+        #expect(!content([
+            .empty(id: "title", content: .text(.plain("", contentType: .title))),
+            text("empty-one", ""), text("empty-two", "")
+        ]).hasContent)
+    }
+
+    @Test func titleOrDescriptionAlonePreventsEmptyDraftCleanup() {
+        for key in [BundledPropertyKey.name, .description] {
+            let details = hiddenDraft().updated(by: [key.rawValue: "Unsent text".protobufValue])
+            #expect(QuickCaptureDraftContent(details: details, blocks: [text("empty", "")]).hasContent)
+        }
+    }
+
+    @Test func headerTextSurvivesEvenWhenDetailsHaveNotCaughtUp() {
+        for style in [BlockText.Style.title, .description] {
+            #expect(content([.empty(id: "header", content: .text(.plain("Unsent text", contentType: style)))]).hasContent)
+        }
+    }
+
+    @Test func nestedAndUnsupportedBlocksPreventCleanup() {
+        #expect(content([
+            .empty(id: "layout", content: .layout(.init(style: .header))),
+            text("nested", "Unsent text")
+        ]).hasContent)
+        #expect(content([.empty(id: "unknown", content: .unsupported)]).hasContent)
+    }
+
+    @Test func whitespaceIsPreservedInsteadOfBeingTreatedAsFullyEmpty() {
+        #expect(content([text("body", " \n")]).hasContent)
+        let details = hiddenDraft().updated(by: [BundledPropertyKey.name.rawValue: " ".protobufValue])
+        #expect(QuickCaptureDraftContent(details: details, blocks: []).hasContent)
+    }
+
+    @Test func textLandingDoesNotProveAttachmentWasCopied() {
+        let source = content([text("body", "A note"), image("image")])
+        #expect(!content([text("copied-body", "A note")]).contains(source))
+        #expect(content([text("copied-body", "A note"), image("copied-image")]).contains(source))
+    }
+
+    @Test func copyVerificationChecksAllTextAndRepeatedAttachments() {
+        let source = content([text("body", "A note"), text("cell", "Table content"), image("one"), image("two")])
+        #expect(!content([text("copy", "A note"), image("image")]).contains(source))
+        #expect(!content([text("copy", "A note"), text("cell-copy", "Table content"), image("one")]).contains(source))
+    }
+
+    private func hiddenDraft() -> ObjectDetails {
+        ObjectDetails(id: "draft", values: [
+            BundledPropertyKey.isHidden.rawValue: true.protobufValue,
+            BundledPropertyKey.spaceId.rawValue: "space-a".protobufValue
+        ])
+    }
+
+    private func content(_ blocks: [BlockInformation]) -> QuickCaptureDraftContent {
+        QuickCaptureDraftContent(details: hiddenDraft(), blocks: blocks)
+    }
+
+    private func text(_ id: String, _ value: String) -> BlockInformation {
+        .empty(id: id, content: .text(.plain(value, contentType: .text)))
+    }
+
+    private func image(_ id: String) -> BlockInformation {
+        .empty(id: id, content: .file(.empty(contentType: .image)))
+    }
+}

--- a/AnyTypeTests/Services/QuickCaptureInputObserverTests.swift
+++ b/AnyTypeTests/Services/QuickCaptureInputObserverTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import UIKit
+@testable import Anytype
+
+@MainActor
+struct QuickCaptureInputObserverTests {
+    @Test(arguments: ["a", "\n", ""])
+    func inputIsObservedEvenWhenEditorInterceptsIt(_ replacement: String) throws {
+        let textView = UITextView()
+        let delegate = InputDelegate()
+        textView.delegate = delegate
+        let observer = QuickCaptureInputObserver()
+        var inputCount = 0
+        observer.observe(textView) { inputCount += 1 }
+
+        let accepted = textView.delegate?.textView?(textView, shouldChangeTextIn: NSRange(location: 0, length: 0), replacementText: replacement)
+
+        #expect(accepted == false)
+        #expect(inputCount == 1)
+        #expect(delegate.replacements == [replacement])
+        #expect(textView.delegate === delegate)
+    }
+
+    @Test func installingAndRemovingObserverDoesNotCountAsInput() {
+        let textView = UITextView()
+        let delegate = InputDelegate()
+        textView.delegate = delegate
+        let observer = QuickCaptureInputObserver()
+        var inputCount = 0
+        observer.observe(textView) { inputCount += 1 }
+        observer.stopObserving()
+        #expect(inputCount == 0)
+        #expect(textView.delegate === delegate)
+    }
+
+    @Test func otherDelegateCallbacksAreForwarded() {
+        let textView = UITextView()
+        let delegate = InputDelegate()
+        textView.delegate = delegate
+        let observer = QuickCaptureInputObserver()
+        observer.observe(textView) { }
+        #expect(observer.responds(to: #selector(UITextViewDelegate.textViewDidEndEditing(_:))))
+        textView.delegate?.textViewDidEndEditing?(textView)
+        #expect(delegate.didEndEditing)
+        observer.stopObserving()
+    }
+
+    @Test func movingObserverRestoresPreviousTextViewWithoutOverwritingReplacementDelegate() {
+        let first = UITextView()
+        let second = UITextView()
+        let original = InputDelegate()
+        let replacement = InputDelegate()
+        first.delegate = original
+        let observer = QuickCaptureInputObserver()
+        observer.observe(first) { }
+        observer.observe(second) { }
+        #expect(first.delegate === original)
+        second.delegate = replacement
+        observer.stopObserving()
+        #expect(second.delegate === replacement)
+    }
+}
+
+@MainActor
+private final class InputDelegate: NSObject, UITextViewDelegate {
+    var replacements = [String]()
+    var didEndEditing = false
+
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        replacements.append(text)
+        return false
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        didEndEditing = true
+    }
+}

--- a/AnyTypeTests/Services/QuickCaptureLifecycleTests.swift
+++ b/AnyTypeTests/Services/QuickCaptureLifecycleTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+import Services
+@testable import Anytype
+
+@MainActor
+@Suite(.serialized)
+final class QuickCaptureLifecycleTests {
+    private let service: CaptureLifecycleServiceStub
+    private let model: QuickCaptureCoordinatorViewModel
+
+    init() {
+        let service = CaptureLifecycleServiceStub()
+        self.service = service
+        Container.shared.quickCaptureService.register { service }
+        Container.shared.openedDocumentProvider.register { CaptureDocumentsStub() }
+        model = QuickCaptureCoordinatorViewModel { _ in }
+    }
+
+    deinit {
+        Container.shared.quickCaptureService.reset()
+        Container.shared.openedDocumentProvider.reset()
+    }
+
+    @Test func dismissingUntouchedEmptyDraftRunsCleanup() async {
+        await model.openDraft(spaceId: "source")
+        await model.onDismiss()
+        #expect(service.deletedIds == ["draft-source"])
+    }
+
+    @Test func dismissingEditedButApparentlyEmptyDraftDoesNotRacePendingText() async {
+        await model.openDraft(spaceId: "source")
+        model.onUserInput()
+        #expect(!model.isNotEmpty)
+        await model.onDismiss()
+        #expect(service.deletedIds.isEmpty)
+    }
+
+    @Test func dismissingDuringSendOrAnotherOperationDoesNotCleanUp() async {
+        await model.openDraft(spaceId: "source")
+        model.isProcessing = true
+        await model.onDismiss()
+        #expect(service.deletedIds.isEmpty)
+    }
+
+    @Test func switchingAwayFromEditedEmptyDraftPreservesIt() async {
+        await model.openDraft(spaceId: "source")
+        model.onUserInput()
+        await model.openDraft(spaceId: "target")
+        await model.onDismiss()
+        #expect(service.deletedIds == ["draft-target"])
+    }
+
+    @Test func keepBothNeverAutoDeletesTheSourceEvenIfItBecameEmpty() async {
+        await model.openDraft(spaceId: "source")
+        await model.onKeepBothDrafts(.mock(id: "target", accountStatus: .spaceActive, localStatus: .ok))
+        await model.onDismiss()
+        #expect(service.deletedIds == ["draft-target"])
+    }
+
+    @Test func switchingDoesNotWaitForOldDraftCleanupButDismissalDoes() async {
+        let gate = CaptureCleanupGate()
+        service.deleteGate = gate
+        await model.openDraft(spaceId: "source")
+        await model.openDraft(spaceId: "target")
+        #expect(model.editorData?.objectId == "draft-target")
+        await gate.waitUntilEntered()
+        await gate.release()
+        await model.onDismiss()
+        #expect(Set(service.deletedIds) == ["draft-source", "draft-target"])
+    }
+
+    @Test func cleanupSurvivesCancellationOfPresentationTask() async {
+        await model.openDraft(spaceId: "source")
+        let dismissal = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            await model.onDismiss()
+        }
+        await dismissal.value
+        #expect(service.deletedIds == ["draft-source"])
+        #expect(!service.cleanupWasCancelled)
+    }
+}
+
+@MainActor
+private final class CaptureLifecycleServiceStub: QuickCaptureServiceProtocol {
+    var deletedIds = [String]()
+    var cleanupWasCancelled = false
+    var deleteGate: CaptureCleanupGate?
+
+    nonisolated func lastCaptureSpaceId() -> String? { "source" }
+    func discoverDrafts() async throws -> QuickCaptureDraftDiscovery { .init(drafts: [], isComplete: true) }
+    func obtainDraft(spaceId: String) async throws -> ObjectDetails {
+        ObjectDetails(id: "draft-\(spaceId)", values: ["spaceId": spaceId.protobufValue])
+    }
+    func hasDraftWithContent(spaceId: String) async throws -> Bool { false }
+    func commitDraft(objectId: String, spaceId: String) async throws { }
+    func clearDraft(objectId: String, spaceId: String) async throws { deletedIds.append(objectId) }
+    func deleteDraftIfEmpty(objectId: String, spaceId: String) async throws -> Bool {
+        cleanupWasCancelled = Task.isCancelled
+        if let deleteGate { await deleteGate.enter() }
+        deletedIds.append(objectId)
+        return true
+    }
+    func moveDraft(objectId: String, from sourceSpaceId: String, to targetSpaceId: String) async throws -> ObjectDetails {
+        try await obtainDraft(spaceId: targetSpaceId)
+    }
+}
+
+private struct CaptureDocumentsStub: OpenedDocumentsProviderProtocol {
+    func document(objectId: String, spaceId: String, mode: DocumentMode) -> any BaseDocumentProtocol {
+        let document = MockBaseDocument(objectId: objectId)
+        document.mockSpaceId = spaceId
+        return document
+    }
+    func setDocument(objectId: String, spaceId: String, mode: DocumentMode) -> any SetDocumentProtocol {
+        fatalError("Quick Capture must not open a set document")
+    }
+}
+
+private actor CaptureCleanupGate {
+    private var entered = false
+    private var released = false
+    private var entryWaiter: CheckedContinuation<Void, Never>?
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+
+    func enter() async {
+        entered = true
+        entryWaiter?.resume()
+        entryWaiter = nil
+        if !released { await withCheckedContinuation { releaseWaiter = $0 } }
+    }
+
+    func waitUntilEntered() async {
+        if !entered { await withCheckedContinuation { entryWaiter = $0 } }
+    }
+
+    func release() {
+        released = true
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+}

--- a/AnyTypeTests/Services/QuickCaptureServiceTests.swift
+++ b/AnyTypeTests/Services/QuickCaptureServiceTests.swift
@@ -151,7 +151,9 @@ final class QuickCaptureServiceTests {
     }
 
     @Test(arguments: [true, false])
-    func legacyDraftIsMigratedBeforeReplacingPointer(preferLocalHint: Bool) async throws {
+    func legacyDraftIsResolvedWithoutWritingDraftFlag(preferLocalHint: Bool) async throws {
+        // Object.SetDetails rejects isDraft in a space where no object was created with it,
+        // so opening never stamps a legacy draft.
         let legacy = ObjectDetails(id: "draft", values: [
             "isHidden": true.protobufValue, "spaceId": "space".protobufValue,
             "creator": "me".protobufValue, "createdDate": 1.protobufValue,
@@ -164,25 +166,61 @@ final class QuickCaptureServiceTests {
         let resolved = try await service.storedDraft(spaceId: "space", preferLocalHint: preferLocalHint)
 
         #expect(resolved?.id == "newer")
-        #expect(await middleware.migratedIds == ["draft"])
+        #expect(await middleware.detailWrites.isEmpty)
         #expect(storage.draftObjectId(spaceId: "space") == "newer")
-        let discovery = try await service.discoverDrafts()
-        #expect(discovery.drafts.contains { $0.id == "draft" })
     }
 
-    @Test(arguments: [true, false])
-    func failedMigrationKeepsLegacyPointer(preferLocalHint: Bool) async throws {
+    @Test func clearedDraftIsNotResurrectedByStaleSearch() async throws {
+        // The stub keeps deleted records in search results, like the space index does for a
+        // moment after Object.ListDelete.
+        await middleware.setSearchRecords([draft()])
+
+        try await service.clearDraft(objectId: "draft", spaceId: "space")
+
+        #expect(await middleware.deletedIds == ["draft"])
+        #expect(storage.draftObjectId(spaceId: "space") == nil)
+        #expect(try await service.storedDraft(spaceId: "space") == nil)
+        #expect(try await service.discoverDrafts().drafts.isEmpty)
+    }
+
+    @Test func publishingLegacyDraftWritesOnlyHiddenFlag() async throws {
         let legacy = ObjectDetails(id: "draft", values: [
-            "isHidden": true.protobufValue, "spaceId": "space".protobufValue,
-            "creator": "me".protobufValue, "createdDate": 1.protobufValue
+            "isHidden": true.protobufValue, "spaceId": "space".protobufValue, "creator": "me".protobufValue
         ])
-        await middleware.setSearchRecords([legacy, draft(id: "newer").updated(by: ["createdDate": 2.protobufValue])])
-        _ = try await service.discoverDrafts()
-        await middleware.failMigration()
-        await #expect(throws: CaptureTestError.self) {
-            try await service.storedDraft(spaceId: "space", preferLocalHint: preferLocalHint)
+        await middleware.setSearchRecords([legacy])
+
+        try await service.commitDraft(objectId: "draft", spaceId: "space")
+
+        let writes = await middleware.detailWrites
+        #expect(writes.count == 1)
+        #expect(writes.first?.contextID == "draft")
+        let flags = writtenFlags(writes.first?.details)
+        #expect(flags.isHidden == false)
+        #expect(flags.isDraft == nil)
+    }
+
+    @Test func publishingFlaggedDraftClearsBothFlagsInOneWrite() async throws {
+        await middleware.setSearchRecords([draft()])
+
+        try await service.commitDraft(objectId: "draft", spaceId: "space")
+
+        let writes = await middleware.detailWrites
+        #expect(writes.count == 1)
+        let flags = writtenFlags(writes.first?.details)
+        #expect(flags.isDraft == false)
+        #expect(flags.isHidden == false)
+    }
+
+    private func writtenFlags(_ details: [BundledDetails]?) -> (isDraft: Bool?, isHidden: Bool?) {
+        var flags: (isDraft: Bool?, isHidden: Bool?) = (nil, nil)
+        for detail in details ?? [] {
+            switch detail {
+            case .isDraft(let value): flags.isDraft = value
+            case .isHidden(let value): flags.isHidden = value
+            default: break
+            }
         }
-        #expect(storage.draftObjectId(spaceId: "space") == "draft")
+        return flags
     }
 
     private func draft(id: String = "draft") -> ObjectDetails {
@@ -228,15 +266,13 @@ private actor CaptureMiddlewareStub: ObjectLifecycleServiceProtocol, ObjectActio
     private var snapshot: ObjectViewModel?
     private var records = [ObjectDetails]()
     private var deleteFails = false
-    private var migrationFails = false
     private(set) var deletedIds = [String]()
-    private(set) var migratedIds = [String]()
+    private(set) var detailWrites = [(contextID: String, details: [BundledDetails])]()
     private(set) var archiveCalls = 0
 
     func setView(_ view: ObjectViewModel) { snapshot = view }
     func setSearchRecords(_ records: [ObjectDetails]) { self.records = records }
     func failDelete() { deleteFails = true }
-    func failMigration() { migrationFails = true }
 
     func openForPreview(contextId: String, spaceId: String) async throws -> ObjectViewModel {
         guard let snapshot else { throw CaptureTestError.unavailable }
@@ -251,13 +287,7 @@ private actor CaptureMiddlewareStub: ObjectLifecycleServiceProtocol, ObjectActio
     }
 
     func updateBundledDetails(contextID: String, details: [BundledDetails]) async throws {
-        if migrationFails { throw CaptureTestError.unavailable }
-        for detail in details {
-            if case .isDraft(true) = detail {
-                migratedIds.append(contextID)
-                records = records.map { $0.id == contextID ? $0.updated(by: ["isDraft": true.protobufValue]) : $0 }
-            }
-        }
+        detailWrites.append((contextID, details))
     }
 
     func search(data: SearchRequest) async throws -> [ObjectDetails] {

--- a/AnyTypeTests/Services/QuickCaptureServiceTests.swift
+++ b/AnyTypeTests/Services/QuickCaptureServiceTests.swift
@@ -1,0 +1,295 @@
+import Foundation
+import Testing
+import Services
+import AnytypeCore
+import AsyncTools
+import ProtobufMessages
+@testable import Anytype
+
+@Suite(.serialized)
+final class QuickCaptureServiceTests {
+    private let storage: CaptureDraftStorageStub
+    private let middleware: CaptureMiddlewareStub
+    private let service: QuickCaptureService
+
+    init() {
+        let storage = CaptureDraftStorageStub()
+        let middleware = CaptureMiddlewareStub()
+        self.storage = storage
+        self.middleware = middleware
+        Container.shared.quickCaptureDraftStorage.register { storage }
+        Container.shared.objectLifecycleService.register { middleware }
+        Container.shared.objectActionsService.register { middleware }
+        Container.shared.searchMiddleService.register { middleware }
+        Container.shared.crossSpaceSearchMiddleService.register { middleware }
+        Container.shared.participantsStorage.register { CaptureParticipantsStub() }
+        service = QuickCaptureService()
+    }
+
+    deinit {
+        Container.shared.quickCaptureDraftStorage.reset()
+        Container.shared.objectLifecycleService.reset()
+        Container.shared.objectActionsService.reset()
+        Container.shared.searchMiddleService.reset()
+        Container.shared.crossSpaceSearchMiddleService.reset()
+        Container.shared.participantsStorage.reset()
+    }
+
+    @Test func emptyDraftIsPermanentlyDeletedBeforePointerIsCleared() async throws {
+        await middleware.setView(view())
+        #expect(try await service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space"))
+        #expect(await middleware.deletedIds == ["draft"])
+        #expect(storage.draftObjectId(spaceId: "space") == nil)
+        #expect(await middleware.archiveCalls == 0)
+    }
+
+    @Test func failedDeletePreservesPointer() async {
+        await middleware.setView(view())
+        await middleware.failDelete()
+        await #expect(throws: CaptureTestError.self) {
+            try await service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space")
+        }
+        #expect(storage.draftObjectId(spaceId: "space") == "draft")
+    }
+
+    @Test func missingSnapshotRootOrDetailsNeverAuthorizesDeletion() async {
+        var noRoot = view()
+        noRoot.blocks = []
+        var noDetails = view()
+        noDetails.details = []
+        for snapshot in [noRoot, noDetails] {
+            await middleware.setView(snapshot)
+            await #expect(throws: QuickCaptureError.self) {
+                try await service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space")
+            }
+        }
+        #expect(await middleware.deletedIds.isEmpty)
+        #expect(storage.draftObjectId(spaceId: "space") == "draft")
+    }
+
+    @Test func failedReadNeverDeletesOrClearsPointer() async {
+        await #expect(throws: CaptureTestError.self) {
+            try await service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space")
+        }
+        #expect(await middleware.deletedIds.isEmpty)
+        #expect(storage.draftObjectId(spaceId: "space") == "draft")
+    }
+
+    @Test func cancellationBeforeDeleteKeepsTheDraftAndPointer() async {
+        await middleware.setView(view())
+        let service = service
+        let cleanup = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space")
+        }
+        await #expect(throws: CancellationError.self) { try await cleanup.value }
+        #expect(await middleware.deletedIds.isEmpty)
+        #expect(storage.draftObjectId(spaceId: "space") == "draft")
+    }
+
+    @Test func visibleDraftIsNotAutoDeleted() async throws {
+        await middleware.setView(view(details: draft().updated(by: ["isHidden": false.protobufValue])))
+        #expect(try await !service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space"))
+        #expect(await middleware.deletedIds.isEmpty)
+    }
+
+    @Test func publishedArchivedDeletedAndForeignObjectsAreProtected() async {
+        let variants = [
+            draft().updated(by: ["isDraft": false.protobufValue]),
+            draft().updated(by: ["isArchived": true.protobufValue]),
+            draft().updated(by: ["isDeleted": true.protobufValue]),
+            draft().updated(by: ["creator": "someone-else".protobufValue])
+        ]
+        for details in variants {
+            await middleware.setView(view(details: details))
+            await #expect(throws: QuickCaptureError.self) {
+                try await service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space")
+            }
+        }
+        #expect(await middleware.deletedIds.isEmpty)
+        #expect(storage.draftObjectId(spaceId: "space") == "draft")
+    }
+
+    @Test func descriptionAndNestedBodyTextAreProtected() async throws {
+        for style in [BlockText.Style.description, .text] {
+            var snapshot = view()
+            snapshot.blocks.append(try #require(BlockInformationConverter.convert(information:
+                .empty(id: "nested", content: .text(.plain("Unsent", contentType: style)))
+            )))
+            await middleware.setView(snapshot)
+            #expect(try await !service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space"))
+        }
+        #expect(await middleware.deletedIds.isEmpty)
+    }
+
+    @Test func attachmentOnlyDraftIsProtected() async throws {
+        var snapshot = view()
+        snapshot.blocks.append(try #require(BlockInformationConverter.convert(information:
+            .empty(id: "image", content: .file(.empty(contentType: .image)))
+        )))
+        await middleware.setView(snapshot)
+        #expect(try await !service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space"))
+        #expect(await middleware.deletedIds.isEmpty)
+    }
+
+    @Test func unconvertibleBlockPreventsCleanup() async {
+        var snapshot = view()
+        snapshot.blocks.append(.with { $0.id = "unknown" })
+        await middleware.setView(snapshot)
+        await #expect(throws: QuickCaptureError.self) {
+            try await service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space")
+        }
+        #expect(await middleware.deletedIds.isEmpty)
+        #expect(storage.draftObjectId(spaceId: "space") == "draft")
+    }
+
+    @Test func cleanupDoesNotClearReplacementPointer() async throws {
+        await middleware.setView(view())
+        storage.setDraftObjectId("replacement", spaceId: "space")
+        #expect(try await service.deleteDraftIfEmpty(objectId: "draft", spaceId: "space"))
+        #expect(storage.draftObjectId(spaceId: "space") == "replacement")
+    }
+
+    @Test(arguments: [true, false])
+    func legacyDraftIsMigratedBeforeReplacingPointer(preferLocalHint: Bool) async throws {
+        let legacy = ObjectDetails(id: "draft", values: [
+            "isHidden": true.protobufValue, "spaceId": "space".protobufValue,
+            "creator": "me".protobufValue, "createdDate": 1.protobufValue,
+            "name": "Unsent legacy draft".protobufValue, "isDraft": .with { $0.nullValue = .nullValue }
+        ])
+        let newer = draft(id: "newer").updated(by: ["createdDate": 2.protobufValue])
+        await middleware.setSearchRecords([legacy, newer])
+        _ = try await service.discoverDrafts()
+
+        let resolved = try await service.storedDraft(spaceId: "space", preferLocalHint: preferLocalHint)
+
+        #expect(resolved?.id == "newer")
+        #expect(await middleware.migratedIds == ["draft"])
+        #expect(storage.draftObjectId(spaceId: "space") == "newer")
+        let discovery = try await service.discoverDrafts()
+        #expect(discovery.drafts.contains { $0.id == "draft" })
+    }
+
+    @Test(arguments: [true, false])
+    func failedMigrationKeepsLegacyPointer(preferLocalHint: Bool) async throws {
+        let legacy = ObjectDetails(id: "draft", values: [
+            "isHidden": true.protobufValue, "spaceId": "space".protobufValue,
+            "creator": "me".protobufValue, "createdDate": 1.protobufValue
+        ])
+        await middleware.setSearchRecords([legacy, draft(id: "newer").updated(by: ["createdDate": 2.protobufValue])])
+        _ = try await service.discoverDrafts()
+        await middleware.failMigration()
+        await #expect(throws: CaptureTestError.self) {
+            try await service.storedDraft(spaceId: "space", preferLocalHint: preferLocalHint)
+        }
+        #expect(storage.draftObjectId(spaceId: "space") == "draft")
+    }
+
+    private func draft(id: String = "draft") -> ObjectDetails {
+        ObjectDetails(id: id, values: [
+            "isHidden": true.protobufValue, "isDraft": true.protobufValue,
+            "spaceId": "space".protobufValue, "creator": "me".protobufValue
+        ])
+    }
+
+    private func view(details: ObjectDetails? = nil) -> ObjectViewModel {
+        let details = details ?? draft()
+        return .with {
+            $0.rootID = details.id
+            $0.blocks = [.with { $0.id = details.id; $0.smartblock = .init() }]
+            $0.details = [.with { $0.id = details.id; $0.details.fields = details.values }]
+        }
+    }
+}
+
+private enum CaptureTestError: Error { case unavailable }
+
+private final class CaptureDraftStorageStub: QuickCaptureDraftStorageProtocol, Sendable {
+    private let ids = AtomicStorage(["space": "draft"])
+    func draftObjectId(spaceId: String) -> String? { ids.value[spaceId] }
+    func draftObjectIds() -> [String] { Array(ids.value.values) }
+    func setDraftObjectId(_ objectId: String?, spaceId: String) { ids.access { $0[spaceId] = objectId } }
+    func lastCaptureSpaceId() -> String? { "space" }
+    func setLastCaptureSpaceId(_ spaceId: String) { }
+}
+
+private final class CaptureParticipantsStub: ParticipantsStorageProtocol, Sendable {
+    let participants = [Participant(
+        id: "me", localName: "", globalName: "", icon: nil, status: .active, permission: .owner,
+        identity: "", identityProfileLink: "", spaceId: "space", type: ""
+    )]
+    private let stream = AsyncToManyStream<[Participant]>()
+    var participantsSequence: AnyAsyncSequence<[Participant]> { stream.eraseToAnyAsyncSequence() }
+    func startSubscription() async { }
+    func stopSubscription() async { }
+}
+
+private actor CaptureMiddlewareStub: ObjectLifecycleServiceProtocol, ObjectActionsServiceProtocol, SearchMiddleServiceProtocol, CrossSpaceSearchMiddleServiceProtocol {
+    private var snapshot: ObjectViewModel?
+    private var records = [ObjectDetails]()
+    private var deleteFails = false
+    private var migrationFails = false
+    private(set) var deletedIds = [String]()
+    private(set) var migratedIds = [String]()
+    private(set) var archiveCalls = 0
+
+    func setView(_ view: ObjectViewModel) { snapshot = view }
+    func setSearchRecords(_ records: [ObjectDetails]) { self.records = records }
+    func failDelete() { deleteFails = true }
+    func failMigration() { migrationFails = true }
+
+    func openForPreview(contextId: String, spaceId: String) async throws -> ObjectViewModel {
+        guard let snapshot else { throw CaptureTestError.unavailable }
+        return snapshot
+    }
+    func open(contextId: String, spaceId: String) async throws -> ObjectViewModel { throw CaptureTestError.unavailable }
+    func close(contextId: String, spaceId: String) async throws { }
+
+    func delete(objectIds: [String]) async throws {
+        if deleteFails { throw CaptureTestError.unavailable }
+        deletedIds.append(contentsOf: objectIds)
+    }
+
+    func updateBundledDetails(contextID: String, details: [BundledDetails]) async throws {
+        if migrationFails { throw CaptureTestError.unavailable }
+        for detail in details {
+            if case .isDraft(true) = detail {
+                migratedIds.append(contextID)
+                records = records.map { $0.id == contextID ? $0.updated(by: ["isDraft": true.protobufValue]) : $0 }
+            }
+        }
+    }
+
+    func search(data: SearchRequest) async throws -> [ObjectDetails] {
+        if let ids = data.filters.first(where: { $0.relationKey == "id" })?.value.listValue.values.map(\.stringValue) {
+            return records.filter { ids.contains($0.id) }
+        }
+        return records.filter { $0.values["isDraft"]?.boolValue == true }
+            .sorted { ($0.createdDate ?? .distantPast) > ($1.createdDate ?? .distantPast) }
+    }
+
+    func search(data: CrossSpaceSearchRequest) async throws -> CrossSpaceSearchResult {
+        let localIds = data.filters.first?.nestedFilters.first(where: { $0.relationKey == "id" })?.value.listValue.values.map(\.stringValue) ?? []
+        return CrossSpaceSearchResult(records: records.filter { $0.values["isDraft"]?.boolValue == true || localIds.contains($0.id) }
+            .sorted { ($0.createdDate ?? .distantPast) > ($1.createdDate ?? .distantPast) }, allStoresLoaded: true)
+    }
+
+    func setArchive(objectIds: [String], _ isArchived: Bool) async throws { archiveCalls += 1 }
+    func createObject(name: String, typeUniqueKey: ObjectTypeUniqueKey, shouldDeleteEmptyObject: Bool, shouldSelectType: Bool, shouldSelectTemplate: Bool, spaceId: String, origin: ObjectOrigin, templateId: String?, createdInContext: String, createdInContextRef: String, additionalDetails: [BundledDetails]) async throws -> ObjectDetails { throw CaptureTestError.unavailable }
+    func setPin(objectIds: [String], _ isPinned: Bool) async throws { throw CaptureTestError.unavailable }
+    func setLocked(_ isLocked: Bool, objectId: String) async throws { throw CaptureTestError.unavailable }
+    func updateLayout(contextID: String, value: Int) async throws { throw CaptureTestError.unavailable }
+    func duplicate(objectId: String) async throws -> String { throw CaptureTestError.unavailable }
+    func applyTemplate(objectId: String, templateId: String) async throws { throw CaptureTestError.unavailable }
+    func updateDetails(contextId: String, relationKey: String, value: DataviewGroupValue) async throws { throw CaptureTestError.unavailable }
+    func setInternalFlags(contextId: String, internalFlags: [Int]) async throws { throw CaptureTestError.unavailable }
+    func addObjectsToCollection(contextId: String, objectIds: [String]) async throws { throw CaptureTestError.unavailable }
+    func setObjectType(objectId: String, typeUniqueKey: ObjectTypeUniqueKey) async throws { throw CaptureTestError.unavailable }
+    func setObjectSetType(objectId: String) async throws { throw CaptureTestError.unavailable }
+    func setObjectCollectionType(objectId: String) async throws { throw CaptureTestError.unavailable }
+    func setSource(objectId: String, source: [String]) async throws { throw CaptureTestError.unavailable }
+    func undo(objectId: String) async throws { throw CaptureTestError.unavailable }
+    func redo(objectId: String) async throws { throw CaptureTestError.unavailable }
+    func move(dashboadId: String, blockId: String, dropPositionblockId: String, position: Anytype_Model_Block.Position) async throws { throw CaptureTestError.unavailable }
+    func createSet(name: String, iconEmoji: Emoji?, setOfObjectType: String, spaceId: String) async throws -> ObjectDetails { throw CaptureTestError.unavailable }
+}

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchBar.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchBar.swift
@@ -73,7 +73,7 @@ struct UnifiedSearchBar: View {
             }
 
             UnifiedSearchTextField(
-                placeholder: Loc.search,
+                placeholder: Loc.UnifiedSearch.placeholder,
                 focusRequestId: focusRequestId,
                 text: $text,
                 onBackspaceWhenEmpty: onBackspaceWhenEmpty,

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchBar.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/Search/UnifiedSearch/Views/UnifiedSearchBar.swift
@@ -73,7 +73,7 @@ struct UnifiedSearchBar: View {
             }
 
             UnifiedSearchTextField(
-                placeholder: Loc.UnifiedSearch.placeholder,
+                placeholder: Loc.search,
                 focusRequestId: focusRequestId,
                 text: $text,
                 onBackspaceWhenEmpty: onBackspaceWhenEmpty,

--- a/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureCoordinatorView.swift
@@ -46,7 +46,7 @@ struct QuickCaptureCoordinatorView: View {
             }
             .sheet(isPresented: $model.showSpacePicker) {
                 QuickCaptureSpacePickerView(
-                    spaces: model.sortedEditableSpaces,
+                    spaces: model.pickerSpaces,
                     selectedSpaceId: model.spaceView?.targetSpaceId,
                     draftSpaceIds: model.draftSpaceIds,
                     isProcessing: model.isInteractionLocked,

--- a/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureCoordinatorView.swift
@@ -9,8 +9,8 @@ struct QuickCaptureCoordinatorView: View {
 
     @State private var topInset: CGFloat = 0
 
-    init(onCreated: @escaping (QuickCaptureCreatedBanner) -> Void) {
-        _model = State(initialValue: QuickCaptureCoordinatorViewModel(onCreated: onCreated))
+    init(model: QuickCaptureCoordinatorViewModel) {
+        _model = State(initialValue: model)
     }
 
     var body: some View {
@@ -22,6 +22,10 @@ struct QuickCaptureCoordinatorView: View {
             .task {
                 await model.onAppear()
             }
+            .task {
+                await model.discoverDrafts()
+            }
+            .interactiveDismissDisabled(model.isProcessing)
             .task(id: model.editorData?.objectId) {
                 await model.subscribeOnDraft()
             }
@@ -44,6 +48,8 @@ struct QuickCaptureCoordinatorView: View {
                 QuickCaptureSpacePickerView(
                     spaces: model.sortedEditableSpaces,
                     selectedSpaceId: model.spaceView?.targetSpaceId,
+                    draftSpaceIds: model.draftSpaceIds,
+                    isProcessing: model.isInteractionLocked,
                     onSelect: { model.onSelectSpace($0) }
                 )
             }
@@ -55,11 +61,25 @@ struct QuickCaptureCoordinatorView: View {
         if let editorData = model.editorData {
             EditorPageCoordinatorView(data: editorData, showHeader: false)
                 .id(editorData.objectId)
+                .onReceive(NotificationCenter.default.publisher(for: UITextView.textDidBeginEditingNotification)) {
+                    model.onTextEditingBegan($0)
+                }
+                .onReceive(NotificationCenter.default.publisher(for: UITextView.textDidChangeNotification)) {
+                    model.onTextChanged($0)
+                }
+                .disabled(model.isInteractionLocked)
+                .allowsHitTesting(!model.isInteractionLocked)
         } else {
             VStack {
                 Spacer()
-                CircleLoadingView()
-                    .frame(width: 24, height: 24)
+                if model.draftLoadFailed {
+                    Button(Loc.tryAgain) {
+                        Task { await model.onAppear() }
+                    }
+                } else {
+                    CircleLoadingView()
+                        .frame(width: 24, height: 24)
+                }
                 Spacer()
             }
             .frame(maxWidth: .infinity)
@@ -103,25 +123,29 @@ struct QuickCaptureCoordinatorView: View {
             }
         }
         .confirmationDialog(
-            Loc.QuickCapture.replaceDraftTitle(model.pendingSpaceSwitch?.title ?? ""),
-            isPresented: replaceDraftConfirmation,
-            titleVisibility: .visible
-        ) {
-            Button(Loc.QuickCapture.replaceDraft, role: .destructive) {
-                model.onConfirmReplaceDraft()
+            Loc.QuickCapture.switchDraftTitle(model.pendingSpaceSwitch?.title ?? ""),
+            isPresented: spaceSwitchConfirmation,
+            titleVisibility: .visible,
+            presenting: model.pendingSpaceSwitch
+        ) { selected in
+            Button(Loc.QuickCapture.keepBoth) {
+                Task { await model.onKeepBothDrafts(selected) }
+            }
+            Button(Loc.QuickCapture.discardMyDraft, role: .destructive) {
+                Task { await model.onDiscardCurrentDraft(selected) }
             }
             Button(Loc.cancel, role: .cancel) {
-                model.onCancelReplaceDraft()
+                model.onCancelSpaceSwitch()
             }
-        } message: {
-            Text(Loc.QuickCapture.replaceDraftMessage)
+        } message: { _ in
+            Text(Loc.QuickCapture.switchDraftMessage)
         }
     }
 
-    private var replaceDraftConfirmation: Binding<Bool> {
+    private var spaceSwitchConfirmation: Binding<Bool> {
         Binding(
             get: { model.pendingSpaceSwitch != nil },
-            set: { if !$0 { model.onCancelReplaceDraft() } }
+            set: { if !$0 { model.onCancelSpaceSwitch() } }
         )
     }
 
@@ -135,13 +159,20 @@ struct QuickCaptureCoordinatorView: View {
                 AnytypeText(model.spaceView?.title ?? "", style: .uxCalloutMedium)
                     .foregroundStyle(Color.Text.primary)
                     .lineLimit(1)
-                Image(asset: .X18.Disclosure.down)
-                    .foregroundStyle(Color.Control.secondary)
+                HStack(spacing: 4) {
+                    if model.hasDraftsInOtherSpaces {
+                        QuickCaptureDraftDot()
+                    }
+                    Image(asset: .X18.Disclosure.down)
+                        .foregroundStyle(Color.Control.secondary)
+                }
+                .padding(.leading, model.hasDraftsInOtherSpaces ? 4 : 0)
             }
             .padding(.horizontal, 12)
             .frame(height: 44)
         }
-        .disabled(model.isProcessing)
+        .disabled(model.isInteractionLocked)
+        .accessibilityValue(model.hasDraftsInOtherSpaces ? Loc.QuickCapture.draftsInOtherSpaces : "")
         .glassEffectInteractiveIOS26(in: Capsule())
     }
 
@@ -158,6 +189,7 @@ struct QuickCaptureCoordinatorView: View {
         }
         .frame(width: 44, height: 44)
         .glassEffectInteractiveIOS26(in: Circle())
+        .disabled(model.isInteractionLocked)
     }
 
     private func settingsMenu(_ editorData: EditorPageObject) -> some View {
@@ -173,6 +205,7 @@ struct QuickCaptureCoordinatorView: View {
                 .frame(width: 44, height: 44)
         }
         .glassEffectInteractiveIOS26(in: Circle())
+        .disabled(model.isInteractionLocked)
     }
 
     private var trashButton: some View {
@@ -184,7 +217,7 @@ struct QuickCaptureCoordinatorView: View {
                 .foregroundStyle(Color.Control.primary)
         }
         .frame(width: 44, height: 44)
-        .disabled(model.isProcessing)
+        .disabled(model.isInteractionLocked)
         .glassEffectInteractiveIOS26(in: Circle())
     }
 
@@ -207,7 +240,7 @@ struct QuickCaptureCoordinatorView: View {
             .clipShape(Circle())
             .opacity(model.isNotEmpty ? 1 : 0.4)
         }
-        .disabled(!model.isNotEmpty || model.isProcessing)
+        .disabled(!model.isNotEmpty || model.isInteractionLocked)
     }
 
 }

--- a/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureCoordinatorViewModel.swift
@@ -39,6 +39,9 @@ final class QuickCaptureCoordinatorViewModel {
     var editorData: EditorPageObject?
     var isNotEmpty = false
     var isProcessing = false
+    var draftLoadFailed = false
+    private(set) var hasPublished = false
+    private(set) var draftSpaceIds = Set<String>()
     var showSpacePicker = false
     var showClearDraftConfirmation = false
     var pendingSpaceSwitch: SpaceView?
@@ -53,6 +56,12 @@ final class QuickCaptureCoordinatorViewModel {
     private let onCreated: (QuickCaptureCreatedBanner) -> Void
     @ObservationIgnored
     private var document: (any BaseDocumentProtocol)?
+    @ObservationIgnored
+    private var hasTypedThisSession = false
+    @ObservationIgnored
+    private let inputObserver = QuickCaptureInputObserver()
+    @ObservationIgnored
+    private var cleanupTasks = [String: Task<Void, Never>]()
     // Only the newest draft operation may write state - a slower predecessor must
     // never land on top of the draft the user is looking at now
     @ObservationIgnored
@@ -72,6 +81,14 @@ final class QuickCaptureCoordinatorViewModel {
 
     init(onCreated: @escaping (QuickCaptureCreatedBanner) -> Void) {
         self.onCreated = onCreated
+    }
+
+    var isInteractionLocked: Bool {
+        isProcessing || hasPublished || pendingSpaceSwitch != nil || editorData == nil
+    }
+
+    var hasDraftsInOtherSpaces: Bool {
+        draftSpaceIds.contains { $0 != spaceView?.targetSpaceId }
     }
 
     var sortedEditableSpaces: [SpaceView] {
@@ -103,7 +120,10 @@ final class QuickCaptureCoordinatorViewModel {
     // MARK: - Lifecycle
 
     func onAppear() async {
-        guard editorData.isNil else { return }
+        guard editorData.isNil, !isProcessing else { return }
+        isProcessing = true
+        draftLoadFailed = false
+        defer { isProcessing = false }
         typeSuggestionService.prewarm()
         let spaces = sortedEditableSpaces
         guard let targetSpace = lastCaptureSpace(in: spaces) ?? spaces.first else {
@@ -113,11 +133,40 @@ final class QuickCaptureCoordinatorViewModel {
         await openDraft(spaceId: targetSpace.targetSpaceId)
     }
 
+    func discoverDrafts() async {
+        // This task never selects the opening space or delays the local-pointer lookup.
+        while !Task.isCancelled {
+            do {
+                let discovery = try await quickCaptureService.discoverDrafts()
+                guard !Task.isCancelled else { return }
+                if discovery.isComplete {
+                    draftSpaceIds = discovery.spaceIds
+                } else {
+                    draftSpaceIds.formUnion(discovery.spaceIds)
+                }
+                updateCurrentDraftIndicator()
+            } catch is CancellationError {
+                return
+            } catch {
+                // Existing indicators survive unavailable stores; absence isn't evidence.
+            }
+            do { try await Task.sleep(for: .seconds(3)) } catch { return }
+        }
+    }
+
     func subscribeOnDraft() async {
         guard let document else { return }
         async let contentSub: () = subscribeOnContent(document: document)
         async let syncSub: () = subscribeOnSyncStatus(document: document)
         _ = await (contentSub, syncSub)
+    }
+
+    func onDismiss() async {
+        inputObserver.stopObserving()
+        if !hasPublished, !isProcessing, !hasTypedThisSession, let document {
+            scheduleEmptyDraftCleanup(document: document)
+        }
+        for task in cleanupTasks.values { await task.value }
     }
 
     func onTapSyncStatus() {
@@ -127,22 +176,56 @@ final class QuickCaptureCoordinatorViewModel {
 
     // MARK: - Actions
 
+    func onTextEditingBegan(_ notification: Notification) {
+        guard !hasTypedThisSession, let textView = currentEditorTextView(notification) else { return }
+        inputObserver.observe(textView) { [weak self] in
+            self?.onUserInput()
+        }
+    }
+
+    func onTextChanged(_ notification: Notification) {
+        guard !hasTypedThisSession, currentEditorTextView(notification) != nil else { return }
+        onUserInput()
+        inputObserver.stopObserving()
+    }
+
+    func onUserInput() {
+        hasTypedThisSession = true
+    }
+
+    private func currentEditorTextView(_ notification: Notification) -> UITextView? {
+        guard let editorData, let textView = notification.object as? UITextView,
+              textView.isFirstResponder else { return nil }
+        var responder: UIResponder? = textView
+        while let current = responder {
+            if let editor = current as? EditorPageController {
+                guard editor.viewModel?.document.objectId == editorData.objectId,
+                      editor.viewModel?.document.spaceId == editorData.spaceId else { return nil }
+                return textView
+            }
+            responder = current.next
+        }
+        return nil
+    }
+
     func onTapSend() {
-        guard !isProcessing, isNotEmpty, let spaceView, let document else { return }
+        guard !isInteractionLocked, isNotEmpty, let spaceView, let document else { return }
+        isProcessing = true
+        finishEditing()
         let spaceId = spaceView.targetSpaceId
         let objectId = document.objectId
         let analyticsType = document.details?.analyticsType ?? .custom
         let spaceName = spaceView.title
         let typeName = document.details?.objectType.displayName ?? Loc.PasteMenu.object
         Task {
-            isProcessing = true
-            defer { isProcessing = false }
             do {
-                try await quickCaptureService.commitDraft(spaceId: spaceId)
+                try await quickCaptureService.commitDraft(objectId: objectId, spaceId: spaceId)
             } catch {
+                isProcessing = false
                 toastBarData = ToastBarData(error.localizedDescription, type: .failure)
                 return
             }
+            hasPublished = true
             spaceRecencyStorage.markInteraction(spaceId: spaceId)
             AnytypeAnalytics.instance().logCreateObject(
                 objectType: analyticsType,
@@ -161,61 +244,86 @@ final class QuickCaptureCoordinatorViewModel {
     }
 
     func onTapClearDraft() {
-        guard !isProcessing else { return }
+        guard !isInteractionLocked else { return }
         showClearDraftConfirmation = true
     }
 
     func onConfirmClearDraft() {
-        guard !isProcessing, let spaceId = spaceView?.targetSpaceId else { return }
+        guard !isInteractionLocked, let spaceId = spaceView?.targetSpaceId, let document else { return }
+        isProcessing = true
+        finishEditing()
         Task {
-            isProcessing = true
             defer { isProcessing = false }
             do {
-                try await quickCaptureService.clearDraft(spaceId: spaceId)
+                try await quickCaptureService.clearDraft(objectId: document.objectId, spaceId: spaceId)
             } catch {
                 // The draft survived - keep showing it instead of pretending it is gone
                 toastBarData = ToastBarData(Loc.QuickCapture.clearDraftFailed, type: .failure)
                 return
             }
+            resetDraftState()
             await openDraft(spaceId: spaceId)
         }
     }
 
     func onTapSpaceChip() {
-        guard !isProcessing else { return }
+        guard !isInteractionLocked else { return }
         showSpacePicker = true
     }
 
     func onSelectSpace(_ selected: SpaceView) {
+        guard !isInteractionLocked else { return }
         showSpacePicker = false
-        guard !isProcessing else { return }
         guard let currentSpaceId = spaceView?.targetSpaceId, selected.targetSpaceId != currentSpaceId else { return }
-
-        // Nothing typed yet - the user just wants that space's own draft
-        guard isNotEmpty else {
-            Task { await openDraft(spaceId: selected.targetSpaceId) }
-            return
-        }
-
+        isProcessing = true
+        finishEditing()
         Task {
-            isProcessing = true
-            let targetHoldsDraft = await quickCaptureService.hasDraftWithContent(spaceId: selected.targetSpaceId)
-            isProcessing = false
-            if targetHoldsDraft {
-                pendingSpaceSwitch = selected
-            } else {
-                await moveDraft(to: selected)
+            defer { isProcessing = false }
+            do {
+                if QuickCaptureSpaceSwitch.action(hasContent: isNotEmpty, hasLocalEdits: hasTypedThisSession, targetHasContent: false) == .openTarget {
+                    await openDraft(spaceId: selected.targetSpaceId)
+                    return
+                }
+                let targetHoldsDraft = try await quickCaptureService.hasDraftWithContent(spaceId: selected.targetSpaceId)
+                switch QuickCaptureSpaceSwitch.action(hasContent: isNotEmpty, hasLocalEdits: hasTypedThisSession, targetHasContent: targetHoldsDraft) {
+                case .openTarget: await openDraft(spaceId: selected.targetSpaceId)
+                case .move: await moveDraft(to: selected)
+                case .confirm: pendingSpaceSwitch = selected
+                }
+            } catch {
+                toastBarData = ToastBarData(Loc.QuickCapture.operationFailed, type: .failure)
             }
         }
     }
 
-    func onConfirmReplaceDraft() {
-        guard let selected = pendingSpaceSwitch else { return }
-        pendingSpaceSwitch = nil
-        Task { await moveDraft(to: selected) }
+    func onKeepBothDrafts(_ selected: SpaceView) async {
+        await resolveSpaceConflict(selected: selected, discardCurrent: false)
     }
 
-    func onCancelReplaceDraft() {
+    func onDiscardCurrentDraft(_ selected: SpaceView) async {
+        await resolveSpaceConflict(selected: selected, discardCurrent: true)
+    }
+
+    private func resolveSpaceConflict(selected: SpaceView, discardCurrent: Bool) async {
+        guard !isProcessing, !hasPublished, let document else { return }
+        pendingSpaceSwitch = nil
+        isProcessing = true
+        finishEditing()
+        defer { isProcessing = false }
+        do {
+            // Resolve the destination before giving up anything in the current space.
+            await cleanupTasks[selected.targetSpaceId]?.value
+            let target = try await quickCaptureService.obtainDraft(spaceId: selected.targetSpaceId)
+            if discardCurrent {
+                try await quickCaptureService.clearDraft(objectId: document.objectId, spaceId: document.spaceId)
+            }
+            setupDraft(details: target, spaceId: selected.targetSpaceId)
+        } catch {
+            toastBarData = ToastBarData(Loc.QuickCapture.operationFailed, type: .failure)
+        }
+    }
+
+    func onCancelSpaceSwitch() {
         pendingSpaceSwitch = nil
     }
 
@@ -229,21 +337,19 @@ final class QuickCaptureCoordinatorViewModel {
     }
 
     private func moveDraft(to selected: SpaceView) async {
-        guard !isProcessing, let currentSpaceId = spaceView?.targetSpaceId, let document else { return }
-        let blocks = copyableBlocks(document: document)
-        let name = document.details?.name ?? ""
+        guard !hasPublished, let currentSpaceId = spaceView?.targetSpaceId, let document else { return }
         let generation = beginDraftOperation()
-        isProcessing = true
-        defer { isProcessing = false }
         do {
+            await cleanupTasks[selected.targetSpaceId]?.value
             let details = try await quickCaptureService.moveDraft(
+                objectId: document.objectId,
                 from: currentSpaceId,
-                to: selected.targetSpaceId,
-                blocks: blocks,
-                name: name
+                to: selected.targetSpaceId
             )
             guard isCurrentDraftOperation(generation) else { return }
             setupDraft(details: details, spaceId: selected.targetSpaceId)
+        } catch QuickCaptureError.targetHasContent {
+            pendingSpaceSwitch = selected
         } catch {
             guard isCurrentDraftOperation(generation) else { return }
             // The source draft is untouched on failure - the user stays on their text
@@ -303,12 +409,14 @@ final class QuickCaptureCoordinatorViewModel {
     // flag: that flag is one-way and any details write clears it
     private func subscribeOnContent(document: any BaseDocumentProtocol) async {
         for await _ in document.syncPublisher.values {
+            guard self.document?.objectId == document.objectId, !Task.isCancelled else { return }
             isNotEmpty = hasContent(document: document)
+            updateCurrentDraftIndicator()
         }
     }
 
     private func hasContent(document: any BaseDocumentProtocol) -> Bool {
-        if document.details?.name.isNotEmpty == true { return true }
+        if document.details?.name.isNotEmpty == true || document.details?.description.isNotEmpty == true { return true }
         return copyableBlocks(document: document).contains { info in
             if case let .text(text) = info.content { return text.text.isNotEmpty }
             return true
@@ -317,6 +425,7 @@ final class QuickCaptureCoordinatorViewModel {
 
     private func subscribeOnSyncStatus(document: any BaseDocumentProtocol) async {
         for await _ in document.subscibeFor(update: [.syncStatus]).values {
+            guard self.document?.objectId == document.objectId, !Task.isCancelled else { return }
             guard let status = document.syncStatus else { continue }
             syncStatusData = SyncStatusData(
                 status: status,
@@ -326,28 +435,35 @@ final class QuickCaptureCoordinatorViewModel {
         }
     }
 
-    private func openDraft(spaceId: String) async {
+    func openDraft(spaceId: String) async {
         let generation = beginDraftOperation()
-        resetDraftState()
         // Name the destination while it loads instead of showing an empty chip
-        spaceView = findSpaceView(spaceId: spaceId)
+        if editorData == nil { spaceView = findSpaceView(spaceId: spaceId) }
         do {
+            await cleanupTasks[spaceId]?.value
             let details = try await quickCaptureService.obtainDraft(spaceId: spaceId)
             guard isCurrentDraftOperation(generation) else { return }
+            let previousDocument = document
+            let canCleanUpPrevious = !hasTypedThisSession
             setupDraft(details: details, spaceId: spaceId)
+            if canCleanUpPrevious, let previousDocument, previousDocument.objectId != details.id {
+                scheduleEmptyDraftCleanup(document: previousDocument)
+            }
         } catch {
             guard isCurrentDraftOperation(generation) else { return }
             toastBarData = ToastBarData(error.localizedDescription, type: .failure)
-            dismiss?()
+            draftLoadFailed = editorData == nil
         }
     }
 
     private func setupDraft(details: ObjectDetails, spaceId: String) {
+        resetDraftState()
         spaceView = findSpaceView(spaceId: spaceId)
         document = openDocumentProvider.document(objectId: details.id, spaceId: spaceId)
         // First guess from the search details; the content subscription refines it
         // once the document is open
         isNotEmpty = details.name.isNotEmpty || details.snippet.isNotEmpty
+        updateCurrentDraftIndicator()
         // EditorPageObject directly, without EditorCoordinatorView/SpaceLoadingContainerView:
         // activating the space here would make SpaceHubCoordinator navigate under the sheet
         editorData = EditorPageObject(
@@ -363,16 +479,47 @@ final class QuickCaptureCoordinatorViewModel {
         )
     }
 
+    private func scheduleEmptyDraftCleanup(document: any BaseDocumentProtocol) {
+        cleanupTasks[document.spaceId] = Task {
+            await deleteDraftIfEmpty(document: document)
+        }
+    }
+
+    private func deleteDraftIfEmpty(document: any BaseDocumentProtocol) async {
+        guard !hasContent(document: document) else { return }
+        do {
+            if try await quickCaptureService.deleteDraftIfEmpty(objectId: document.objectId, spaceId: document.spaceId) {
+                draftSpaceIds.remove(document.spaceId)
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            anytypeAssertionFailure("Unable to clean up an empty quick capture draft", info: ["error": error.localizedDescription])
+        }
+    }
+
     private func findSpaceView(spaceId: String) -> SpaceView? {
         participantSpacesStorage.activeParticipantSpaces
             .first { $0.spaceView.targetSpaceId == spaceId }?.spaceView
     }
 
     private func resetDraftState() {
+        inputObserver.stopObserving()
+        hasTypedThisSession = false
         editorData = nil
         document = nil
         isNotEmpty = false
         syncStatusData = nil
+    }
+
+    private func finishEditing() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        if let document { isNotEmpty = hasContent(document: document) }
+    }
+
+    private func updateCurrentDraftIndicator() {
+        guard let spaceId = spaceView?.targetSpaceId else { return }
+        if isNotEmpty && !hasPublished { draftSpaceIds.insert(spaceId) }
     }
 
     private func handleOpenObject(data: ScreenData) {

--- a/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureCoordinatorViewModel.swift
@@ -91,6 +91,15 @@ final class QuickCaptureCoordinatorViewModel {
         draftSpaceIds.contains { $0 != spaceView?.targetSpaceId }
     }
 
+    // Picker order only. Spaces holding unsent text come first so the dot is never buried;
+    // the opening space is still chosen from `sortedEditableSpaces`, because discovery must
+    // never decide where the sheet opens.
+    var pickerSpaces: [SpaceView] {
+        let spaces = sortedEditableSpaces
+        let withDrafts = spaces.filter { draftSpaceIds.contains($0.targetSpaceId) }
+        return withDrafts + spaces.filter { !draftSpaceIds.contains($0.targetSpaceId) }
+    }
+
     var sortedEditableSpaces: [SpaceView] {
         let recency = spaceRecencyStorage.lastInteractionDates()
         return participantSpacesStorage.activeParticipantSpaces
@@ -140,9 +149,9 @@ final class QuickCaptureCoordinatorViewModel {
                 let discovery = try await quickCaptureService.discoverDrafts()
                 guard !Task.isCancelled else { return }
                 if discovery.isComplete {
-                    draftSpaceIds = discovery.spaceIds
+                    draftSpaceIds = discovery.spaceIdsWithContent
                 } else {
-                    draftSpaceIds.formUnion(discovery.spaceIds)
+                    draftSpaceIds.formUnion(discovery.spaceIdsWithContent)
                 }
                 updateCurrentDraftIndicator()
             } catch is CancellationError {
@@ -176,14 +185,14 @@ final class QuickCaptureCoordinatorViewModel {
 
     // MARK: - Actions
 
-    func onTextEditingBegan(_ notification: Notification) {
+    func onTextEditingBegan(_ notification: Foundation.Notification) {
         guard !hasTypedThisSession, let textView = currentEditorTextView(notification) else { return }
         inputObserver.observe(textView) { [weak self] in
             self?.onUserInput()
         }
     }
 
-    func onTextChanged(_ notification: Notification) {
+    func onTextChanged(_ notification: Foundation.Notification) {
         guard !hasTypedThisSession, currentEditorTextView(notification) != nil else { return }
         onUserInput()
         inputObserver.stopObserving()
@@ -193,7 +202,7 @@ final class QuickCaptureCoordinatorViewModel {
         hasTypedThisSession = true
     }
 
-    private func currentEditorTextView(_ notification: Notification) -> UITextView? {
+    private func currentEditorTextView(_ notification: Foundation.Notification) -> UITextView? {
         guard let editorData, let textView = notification.object as? UITextView,
               textView.isFirstResponder else { return nil }
         var responder: UIResponder? = textView

--- a/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureInputObserver.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureInputObserver.swift
@@ -1,0 +1,42 @@
+import UIKit
+
+@MainActor
+final class QuickCaptureInputObserver: NSObject, UITextViewDelegate {
+    private weak var textView: UITextView?
+    private weak var originalDelegate: (any UITextViewDelegate)?
+    private var onInput: (() -> Void)?
+
+    func observe(_ textView: UITextView, onInput: @escaping () -> Void) {
+        stopObserving()
+        self.textView = textView
+        originalDelegate = textView.delegate
+        self.onInput = onInput
+        textView.delegate = self
+    }
+
+    func stopObserving() {
+        if textView?.delegate === self { textView?.delegate = originalDelegate }
+        textView = nil
+        originalDelegate = nil
+        onInput = nil
+    }
+
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let delegate = originalDelegate
+        onInput?()
+        stopObserving()
+        return delegate?.textView?(textView, shouldChangeTextIn: range, replacementText: text) ?? true
+    }
+
+    override func responds(to selector: Selector!) -> Bool {
+        if super.responds(to: selector) { return true }
+        return MainActor.assumeIsolated { originalDelegate?.responds(to: selector) == true }
+    }
+
+    override func forwardingTarget(for selector: Selector!) -> Any? {
+        if let delegate = MainActor.assumeIsolated({ originalDelegate }), delegate.responds(to: selector) {
+            return delegate
+        }
+        return super.forwardingTarget(for: selector)
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureSpacePickerView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureSpacePickerView.swift
@@ -48,8 +48,10 @@ struct QuickCaptureSpacePickerView: View {
             HStack(spacing: 12) {
                 IconView(icon: space.objectIconImage)
                     .frame(width: 48, height: 48)
-                QuickCaptureDraftDot()
-                    .opacity(draftSpaceIds.contains(space.targetSpaceId) ? 1 : 0)
+                // Drafts are grouped at the top, so the dot's gutter is only reserved where it shows
+                if draftSpaceIds.contains(space.targetSpaceId) {
+                    QuickCaptureDraftDot()
+                }
                 AnytypeText(space.title, style: .uxTitle2Regular)
                     .foregroundStyle(Color.Text.primary)
                     .lineLimit(1)

--- a/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureSpacePickerView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/QuickCapture/QuickCaptureSpacePickerView.swift
@@ -6,6 +6,8 @@ struct QuickCaptureSpacePickerView: View {
 
     let spaces: [SpaceView]
     let selectedSpaceId: String?
+    let draftSpaceIds: Set<String>
+    let isProcessing: Bool
     let onSelect: (SpaceView) -> Void
 
     @State private var searchText = ""
@@ -46,6 +48,8 @@ struct QuickCaptureSpacePickerView: View {
             HStack(spacing: 12) {
                 IconView(icon: space.objectIconImage)
                     .frame(width: 48, height: 48)
+                QuickCaptureDraftDot()
+                    .opacity(draftSpaceIds.contains(space.targetSpaceId) ? 1 : 0)
                 AnytypeText(space.title, style: .uxTitle2Regular)
                     .foregroundStyle(Color.Text.primary)
                     .lineLimit(1)
@@ -57,5 +61,16 @@ struct QuickCaptureSpacePickerView: View {
             }
             .frame(height: 64)
         }
+        .disabled(isProcessing)
+        .accessibilityValue(draftSpaceIds.contains(space.targetSpaceId) ? Loc.QuickCapture.unsentDraft : "")
+    }
+}
+
+struct QuickCaptureDraftDot: View {
+    var body: some View {
+        Circle()
+            .fill(Color.Pure.orange)
+            .frame(width: 6, height: 6)
+            .accessibilityHidden(true)
     }
 }

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorView.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorView.swift
@@ -92,8 +92,10 @@ struct SpaceHubCoordinatorView: View {
                 SettingsCoordinatorView()
                     .pageNavigation(model.pageNavigation)
             }
-            .sheet(isPresented: $model.showQuickCapture) {
-                QuickCaptureCoordinatorView(onCreated: { model.quickCaptureDidCreate($0) })
+            .sheet(isPresented: $model.showQuickCapture, onDismiss: { model.quickCaptureDidDismiss() }) {
+                if let captureModel = model.quickCaptureModel {
+                    QuickCaptureCoordinatorView(model: captureModel)
+                }
             }
             .overlay(alignment: .bottom) {
                 if let banner = model.quickCaptureCreated {

--- a/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Flows/SpaceHub/SpaceHubCoordinatorViewModel.swift
@@ -44,7 +44,10 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     var shouldScanQrCode = false
     var showAppSettings = false
     var showQuickCapture = false
+    private(set) var quickCaptureModel: QuickCaptureCoordinatorViewModel?
     var quickCaptureCreated: QuickCaptureCreatedBanner?
+    @ObservationIgnored
+    private var quickCaptureCleanupTask: Task<Void, Never>?
     
     var photosItems: [PhotosPickerItem] = []
     var showPhotosPicker = false
@@ -389,7 +392,20 @@ final class SpaceHubCoordinatorViewModel: SpaceHubModuleOutput {
     }
 
     func onSelectQuickCapture() {
-        showQuickCapture = true
+        Task {
+            await quickCaptureCleanupTask?.value
+            guard !showQuickCapture, quickCaptureModel == nil else { return }
+            quickCaptureModel = QuickCaptureCoordinatorViewModel { [weak self] in
+                self?.quickCaptureDidCreate($0)
+            }
+            showQuickCapture = true
+        }
+    }
+
+    func quickCaptureDidDismiss() {
+        guard let captureModel = quickCaptureModel else { return }
+        quickCaptureModel = nil
+        quickCaptureCleanupTask = Task { await captureModel.onDismiss() }
     }
 
     func quickCaptureDidCreate(_ banner: QuickCaptureCreatedBanner) {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/ParticipantSpaceViewDataWithPreview+Sorting.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/ParticipantSpaceViewDataWithPreview+Sorting.swift
@@ -18,8 +18,8 @@ extension Array where Element == ParticipantSpaceViewDataWithPreview {
         case (false, true):
             return false
         case (false, false):
-            let lhsMessageDate = lhs.latestPreview.lastMessage?.createdAt
-            let rhsMessageDate = rhs.latestPreview.lastMessage?.createdAt
+            let lhsMessageDate = lhs.lastMessageDate
+            let rhsMessageDate = rhs.lastMessageDate
             let lhsJoinDate = lhs.spaceView.joinDate
             let rhsJoinDate = rhs.spaceView.joinDate
 

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/ParticipantSpaceViewDataWithPreview.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/ParticipantSpaceViewDataWithPreview.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Services
 import StoredHashMacro
 
@@ -5,6 +6,9 @@ import StoredHashMacro
 struct ParticipantSpaceViewDataWithPreview: Equatable, Identifiable, Hashable {
     let space: ParticipantSpaceViewData
     let latestPreview: ChatMessagePreview
+    /// Sort key: the latest message's date or, while this space's chat previews are still
+    /// loading, the date remembered from the previous launch. See `SpaceHubSpacesStorage`.
+    let lastMessageDate: Date?
     let totalUnreadCounter: Int
     let totalMentionCounter: Int
     let hasUnreadReactions: Bool
@@ -19,21 +23,4 @@ struct ParticipantSpaceViewDataWithPreview: Equatable, Identifiable, Hashable {
     var spaceView: SpaceView { space.spaceView }
 
     var hasCounters: Bool { totalUnreadCounter > 0 || totalMentionCounter > 0 || hasUnreadReactions }
-}
-
-extension ParticipantSpaceViewDataWithPreview {
-    init(space: ParticipantSpaceViewData) {
-        self.init(
-            space: space,
-            latestPreview: ChatMessagePreview(spaceId: space.id, chatId: space.spaceView.chatId),
-            totalUnreadCounter: 0,
-            totalMentionCounter: 0,
-            hasUnreadReactions: false,
-            unreadCounterStyle: .highlighted,
-            mentionCounterStyle: .highlighted,
-            reactionStyle: .highlighted,
-            unreadPreviews: [],
-            unreadDiscussionParents: []
-        )
-    }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpaceHubSpacesStorage.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Helpers/SpaceHubSpacesStorage.swift
@@ -4,13 +4,27 @@ import AsyncTools
 import AsyncAlgorithms
 @preconcurrency import Combine
 import AnytypeCore
+import Services
 
 
 protocol SpaceHubSpacesStorageProtocol: Sendable {
     var spacesStream: AnyAsyncSequence<[ParticipantSpaceViewDataWithPreview]> { get async }
 }
 
+// Chat previews are the hub's sort key and arrive late: the middleware subscribes to every chat
+// in every space on login, and chats of spaces that finish loading afterwards are pushed as
+// events. A space with no preview yet sorts by the message date remembered from the previous
+// launch, so the hub paints in the order the user last saw and rows don't jump as previews
+// trickle in. Once a space's previews have arrived they are the truth even without a message
+// (deleted, archived or empty chat); otherwise a stale date would float that space forever.
 actor SpaceHubSpacesStorage: SpaceHubSpacesStorageProtocol {
+
+    struct BuildResult {
+        let spaces: [ParticipantSpaceViewDataWithPreview]
+        /// spaceId -> latest message date of every space whose previews have arrived; the value
+        /// is nil when those previews carry no message. Spaces still loading are absent.
+        let arrivedLastMessageDates: [String: Date?]
+    }
 
     @Injected(\.participantSpacesStorage)
     private var participantSpacesStorage: any ParticipantSpacesStorageProtocol
@@ -24,8 +38,12 @@ actor SpaceHubSpacesStorage: SpaceHubSpacesStorageProtocol {
     @Injected(\.objectsWithUnreadDiscussionsSubscription)
     private var objectsWithUnreadDiscussionsSubscription: any ObjectsWithUnreadDiscussionsSubscriptionProtocol
 
+    @Injected(\.userDefaultsStorage)
+    private var userDefaults: any UserDefaultsStorageProtocol
+
     var spacesStream: AnyAsyncSequence<[ParticipantSpaceViewDataWithPreview]> {
         get async {
+            let userDefaults = self.userDefaults
             let chatTriple = combineLatest(
                 participantSpacesStorage.activeOrLoadingParticipantSpacesPublisher.values,
                 await chatMessagesPreviewsStorage.previewsSequence,
@@ -38,68 +56,118 @@ actor SpaceHubSpacesStorage: SpaceHubSpacesStorageProtocol {
 
             return combineStream.map { (triple, discussionUnreadBySpace) in
                 let (spaces, previews, chatDetails) = triple
-                return spaces.map { space in
-                    let spacePreviews = previews.filter { $0.spaceId == space.spaceView.targetSpaceId }
-
-                    let nonArchivedPreviews = spacePreviews.filter { preview in
-                        guard let chatDetail = chatDetails.first(where: { $0.id == preview.chatId }) else { return false }
-                        return !chatDetail.isArchivedOrDeleted
-                    }
-
-                    let discussionUnread = discussionUnreadBySpace[space.spaceView.targetSpaceId]
-                    let counterData = SpacePreviewCountersBuilder.build(
-                        spaceView: space.spaceView,
-                        previews: nonArchivedPreviews,
-                        discussionUnread: discussionUnread
-                    )
-
-                    let latestPreview = nonArchivedPreviews.max(by: { preview1, preview2 in
-                        guard let date1 = preview1.lastMessage?.createdAt,
-                              let date2 = preview2.lastMessage?.createdAt else {
-                            return preview1.lastMessage == nil
-                        }
-                        return date1 < date2
-                    }) ?? ChatMessagePreview(spaceId: space.id, chatId: space.spaceView.chatId)
-
-                    let unreadPreviews = nonArchivedPreviews
-                        .filter { preview in
-                            guard preview.hasCounters else { return false }
-                            if FeatureFlags.muteAndHide && space.spaceView.spaceType.supportsMultiChats {
-                                let mode = space.spaceView.effectiveNotificationMode(for: preview.chatId)
-                                if mode == .nothing {
-                                    return preview.mentionCounter > 0 || preview.hasUnreadReactions
-                                }
-                            }
-                            return true
-                        }
-                        .sorted { preview1, preview2 in
-                            let date1 = preview1.lastMessage?.createdAt ?? .distantPast
-                            let date2 = preview2.lastMessage?.createdAt ?? .distantPast
-                            return date1 > date2
-                        }
-
-                    let visibleDiscussionParents = SpaceHubSpacesStorage.filterVisibleDiscussionParents(
-                        discussionUnread?.parents ?? [],
-                        spaceView: space.spaceView
-                    )
-
-                    return ParticipantSpaceViewDataWithPreview(
-                        space: space,
-                        latestPreview: latestPreview,
-                        totalUnreadCounter: counterData.totalUnread,
-                        totalMentionCounter: counterData.totalMentions,
-                        hasUnreadReactions: counterData.hasUnreadReactions,
-                        unreadCounterStyle: counterData.unreadStyle,
-                        mentionCounterStyle: counterData.mentionStyle,
-                        reactionStyle: counterData.reactionStyle,
-                        unreadPreviews: unreadPreviews,
-                        unreadDiscussionParents: visibleDiscussionParents
-                    )
-                }
+                // Built off the actor so the stream's subscribers don't serialize on it; only the
+                // read-merge-write of the remembered dates is isolated.
+                let result = Self.build(
+                    spaces: spaces,
+                    previews: previews,
+                    chatDetails: chatDetails,
+                    discussionUnreadBySpace: discussionUnreadBySpace,
+                    rememberedLastMessageDates: userDefaults.spaceHubLastMessageDates
+                )
+                await self.remember(result.arrivedLastMessageDates)
+                return result.spaces
             }
             .removeDuplicates()
             .eraseToAnyAsyncSequence()
         }
+    }
+
+    static func build(
+        spaces: [ParticipantSpaceViewData],
+        previews: [ChatMessagePreview],
+        chatDetails: [ObjectDetails],
+        discussionUnreadBySpace: [String: SpaceDiscussionsUnreadInfo],
+        rememberedLastMessageDates: [String: Date]
+    ) -> BuildResult {
+        var arrivedLastMessageDates: [String: Date?] = [:]
+
+        let result = spaces.map { space -> ParticipantSpaceViewDataWithPreview in
+            let spaceId = space.spaceView.targetSpaceId
+            let spacePreviews = previews.filter { $0.spaceId == spaceId }
+
+            let nonArchivedPreviews = spacePreviews.filter { preview in
+                guard let chatDetail = chatDetails.first(where: { $0.id == preview.chatId }) else { return false }
+                return !chatDetail.isArchivedOrDeleted
+            }
+
+            let discussionUnread = discussionUnreadBySpace[spaceId]
+            let counterData = SpacePreviewCountersBuilder.build(
+                spaceView: space.spaceView,
+                previews: nonArchivedPreviews,
+                discussionUnread: discussionUnread
+            )
+
+            let latestPreview = nonArchivedPreviews.max(by: { preview1, preview2 in
+                guard let date1 = preview1.lastMessage?.createdAt,
+                      let date2 = preview2.lastMessage?.createdAt else {
+                    return preview1.lastMessage == nil
+                }
+                return date1 < date2
+            }) ?? ChatMessagePreview(spaceId: space.id, chatId: space.spaceView.chatId)
+
+            let messageDate = latestPreview.lastMessage?.createdAt
+            let lastMessageDate: Date?
+            if spacePreviews.isNotEmpty {
+                // updateValue keeps a nil date as an explicit "arrived, no message" entry.
+                arrivedLastMessageDates.updateValue(messageDate, forKey: spaceId)
+                lastMessageDate = messageDate
+            } else {
+                lastMessageDate = rememberedLastMessageDates[spaceId]
+            }
+
+            let unreadPreviews = nonArchivedPreviews
+                .filter { preview in
+                    guard preview.hasCounters else { return false }
+                    if FeatureFlags.muteAndHide && space.spaceView.spaceType.supportsMultiChats {
+                        let mode = space.spaceView.effectiveNotificationMode(for: preview.chatId)
+                        if mode == .nothing {
+                            return preview.mentionCounter > 0 || preview.hasUnreadReactions
+                        }
+                    }
+                    return true
+                }
+                .sorted { preview1, preview2 in
+                    let date1 = preview1.lastMessage?.createdAt ?? .distantPast
+                    let date2 = preview2.lastMessage?.createdAt ?? .distantPast
+                    return date1 > date2
+                }
+
+            let visibleDiscussionParents = filterVisibleDiscussionParents(
+                discussionUnread?.parents ?? [],
+                spaceView: space.spaceView
+            )
+
+            return ParticipantSpaceViewDataWithPreview(
+                space: space,
+                latestPreview: latestPreview,
+                lastMessageDate: lastMessageDate,
+                totalUnreadCounter: counterData.totalUnread,
+                totalMentionCounter: counterData.totalMentions,
+                hasUnreadReactions: counterData.hasUnreadReactions,
+                unreadCounterStyle: counterData.unreadStyle,
+                mentionCounterStyle: counterData.mentionStyle,
+                reactionStyle: counterData.reactionStyle,
+                unreadPreviews: unreadPreviews,
+                unreadDiscussionParents: visibleDiscussionParents
+            )
+        }
+
+        return BuildResult(spaces: result, arrivedLastMessageDates: arrivedLastMessageDates)
+    }
+
+    /// Stores the date of every space whose previews arrived and drops the entry when they carry
+    /// no message. Spaces still loading keep their remembered date, so a partial preview set never
+    /// erases the order the next launch needs.
+    static func rememberedLastMessageDates(
+        _ remembered: [String: Date],
+        updatedWith arrivedLastMessageDates: [String: Date?]
+    ) -> [String: Date] {
+        var dates = remembered
+        for (spaceId, date) in arrivedLastMessageDates {
+            dates[spaceId] = date
+        }
+        return dates
     }
 
     static func filterVisibleDiscussionParents(
@@ -114,6 +182,16 @@ actor SpaceHubSpacesStorage: SpaceHubSpacesStorageProtocol {
             // Aggregator admits any subscribed parent; drop fully-caught-up rows
             // so the multichat preview never shows a name with no badge.
             return parent.unreadMessageCount > 0 || parent.hasUnreadMention
+        }
+    }
+
+    // MARK: - Private
+
+    private func remember(_ arrivedLastMessageDates: [String: Date?]) {
+        let remembered = userDefaults.spaceHubLastMessageDates
+        let updated = Self.rememberedLastMessageDates(remembered, updatedWith: arrivedLastMessageDates)
+        if updated != remembered {
+            userDefaults.spaceHubLastMessageDates = updated
         }
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubView.swift
@@ -60,6 +60,7 @@ struct SpaceHubView: View {
                     view.safeAreaBarIOS26(edge: .bottom, spacing: 0) {
                         VaultSearchBottomBar(
                             quickCaptureEnabled: FeatureFlags.quickCapture,
+                            highlightSearch: model.highlightSearchEntry,
                             onTapSearch: { model.onSearchTap() },
                             onTapQuickCapture: { model.onTapQuickCapture() },
                             onTapCreatePersonalChannel: { model.onTapCreatePersonalChannel() },

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubViewModel.swift
@@ -21,6 +21,8 @@ final class SpaceHubViewModel {
     private var allSpaceCardModels: [SpaceCardModel] = []
 
     var notificationsNotDetermined = false
+    // Existing users see the search entry glimmer until their first tap; fresh installs never do
+    var highlightSearchEntry = false
     var spaceMuteData: SpaceMuteData?
     var profileIcon: Icon?
     var spaceToDelete: StringIdentifiable?
@@ -48,6 +50,7 @@ final class SpaceHubViewModel {
 
     init(output: (any SpaceHubModuleOutput)?) {
         self.output = output
+        highlightSearchEntry = !userDefaults.unifiedSearchDiscovered
     }
     
     func onTapSettings() {
@@ -59,6 +62,10 @@ final class SpaceHubViewModel {
     }
 
     func onSearchTap() {
+        if highlightSearchEntry {
+            highlightSearchEntry = false
+            userDefaults.unifiedSearchDiscovered = true
+        }
         output?.onSelectSearch()
     }
 

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/VaultSearchBarButton.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/VaultSearchBarButton.swift
@@ -10,11 +10,16 @@ struct VaultSearchBottomBar: View {
     // Quick capture takes the trailing slot here; creating a channel moves up
     // to the profile row, since capture is the far more frequent action
     let quickCaptureEnabled: Bool
+    // Attention effect on the search entry until the user taps it once
+    let highlightSearch: Bool
     let onTapSearch: () -> Void
     let onTapQuickCapture: () -> Void
     let onTapCreatePersonalChannel: () -> Void
     let onTapCreateGroupChannel: () -> Void
     let onTapJoinViaQrCode: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var glimmerStart = Date()
 
     var body: some View {
         GlassEffectContainerIOS26(spacing: 6) {
@@ -51,19 +56,44 @@ struct VaultSearchBottomBar: View {
         } label: {
             HStack(spacing: 8) {
                 Image(asset: .X18.search)
-                    .foregroundStyle(Color.Control.secondary)
-                AnytypeText(Loc.search, style: .uxBodyRegular)
+                    // Reduce Motion gets a still cue in place of the glimmer
+                    .foregroundStyle(highlightSearch && reduceMotion ? Color.Control.accent100 : Color.Control.secondary)
+                // Call to action for the unified search entry: it now covers every channel, objects and messages
+                AnytypeText(Loc.UnifiedSearch.placeholder, style: .uxBodyRegular)
                     .foregroundStyle(Color.Text.secondary)
                 Spacer()
             }
             .padding(.vertical, 11)
             .padding(.horizontal, 12)
+            // Part of the glass content, applied before the glass: anything layered after
+            // glassEffect sits outside the glass element and makes the bar's scroll-edge
+            // effect fall back to a hard dark band under the toolbar
+            .overlay {
+                if highlightSearch, !reduceMotion {
+                    searchGlimmer
+                }
+            }
             .barBackground
             .fixTappableArea()
         }
         .buttonStyle(.plain)
     }
 
+    // A light band sweeps the capsule every few seconds until the first tap. It is drawn as
+    // glass content, so the material itself stays at rest (Apple: let glass rest, limit effects).
+    // The periodic timeline hands each sweep a fresh band, which keeps the sweep Core
+    // Animation-driven between ticks and restarts it after the app was in the background.
+    private var searchGlimmer: some View {
+        GeometryReader { geometry in
+            TimelineView(.periodic(from: glimmerStart, by: SearchGlimmerBand.period)) { context in
+                SearchGlimmerBand(travel: geometry.size.width, height: geometry.size.height)
+                    .id(context.date)
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height, alignment: .leading)
+        }
+        .clipShape(Capsule())
+        .allowsHitTesting(false)
+    }
     @available(iOS 26.0, *)
     private var createMenu: some View {
         Menu {
@@ -91,5 +121,33 @@ private extension View {
                 .background(Color.Background.highlightedMedium)
                 .clipShape(.capsule)
         }
+    }
+}
+
+private struct SearchGlimmerBand: View {
+    static let period: TimeInterval = 6
+
+    let travel: CGFloat
+    let height: CGFloat
+
+    @State private var phase: CGFloat = -1
+
+    var body: some View {
+        Rectangle()
+            // Normal blending on purpose: a blend mode inside a GlassEffectContainer forces an
+            // offscreen compositing group, and the glass backdrop then renders as a flat card
+            .fill(LinearGradient(
+                colors: [.clear, .white.opacity(0.28), .clear],
+                startPoint: .leading,
+                endPoint: .trailing
+            ))
+            .frame(width: travel * 0.3, height: height * 3)
+            .rotationEffect(.degrees(18))
+            .offset(x: phase * travel)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 1.4)) {
+                    phase = 1
+                }
+            }
     }
 }

--- a/Anytype/Sources/ServiceLayer/AppVersionTracker/AppVersionTracker.swift
+++ b/Anytype/Sources/ServiceLayer/AppVersionTracker/AppVersionTracker.swift
@@ -82,6 +82,8 @@ final class AppVersionTracker: AppVersionTrackerProtocol {
         // Do not show tip for new users
         if isFirstAppLaunch {
             ChatCreationTip().invalidate(reason: .displayCountExceeded)
+            // Fresh installs meet unified search as the baseline; only upgraders get the glimmer
+            userDefaults.unifiedSearchDiscovered = true
         }
     }
 }

--- a/Anytype/Sources/ServiceLayer/Auth/LoginStateService.swift
+++ b/Anytype/Sources/ServiceLayer/Auth/LoginStateService.swift
@@ -76,13 +76,14 @@ final class LoginStateService: LoginStateServiceProtocol, Sendable {
     }
     
     func cleanStateAfterLogout() async {
-        userDefaults.cleanStateAfterLogout()
         basicUserInfoStorage.cleanUserIdAfterLogout()
         expandedService.clearData()
         middlewareConfigurationProvider.removeCachedConfiguration()
         pushNotificationsPermissionService.unregisterForRemoteNotifications()
         spaceFileUploadService.cancelAllUploads()
         await stopSubscriptions()
+        // After the subscriptions stop nothing can write the old account's state back.
+        userDefaults.cleanStateAfterLogout()
     }
     
     func setupStateBeforeLoginOrAuth() async {

--- a/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureDraft.swift
+++ b/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureDraft.swift
@@ -26,10 +26,13 @@ enum QuickCaptureDraft {
         return details.isHidden
     }
 
-    static func needsMigration(_ details: ObjectDetails) -> Bool {
-        guard let kind = details.values[relationKey]?.kind else { return true }
-        if case .nullValue = kind { return true }
-        return false
+    /// Whether the object carries isDraft, which only objects created with it in
+    /// `additionalDetails` do. Object.SetDetails rejects the key otherwise, because the
+    /// relation is installed into a space only when an object is created with it.
+    static func hasDraftFlag(_ details: ObjectDetails) -> Bool {
+        guard let kind = details.values[relationKey]?.kind else { return false }
+        if case .nullValue = kind { return false }
+        return true
     }
 
     static func discoveryRequest(participantIds: [String], localDraftIds: [String] = [], offset: Int = 0) -> CrossSpaceSearchRequest {
@@ -65,7 +68,19 @@ struct QuickCaptureDraftDiscovery: Sendable {
         drafts.first { $0.spaceId == spaceId }
     }
 
-    var spaceIds: Set<String> { Set(drafts.map(\.spaceId)) }
+    /// Spaces whose draft holds something to come back to. The dot means "unsent text lives
+    /// here", so an abandoned empty draft, which stays in the store because a keystroke may
+    /// still be in flight when the sheet closes, must not mark its space. Emptiness is read
+    /// from the indexed details; an attachment-only draft has no text and is not marked.
+    var spaceIdsWithContent: Set<String> {
+        Set(drafts.filter(QuickCaptureDraft.hasIndexedContent).map(\.spaceId))
+    }
+}
+
+extension QuickCaptureDraft {
+    static func hasIndexedContent(_ details: ObjectDetails) -> Bool {
+        details.name.isNotEmpty || details.description.isNotEmpty || details.snippet.isNotEmpty
+    }
 }
 
 enum QuickCaptureSpaceSwitch: Equatable {

--- a/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureDraft.swift
+++ b/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureDraft.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Services
+import AnytypeCore
+
+enum QuickCaptureDraft {
+    // GO-7499; not yet present in the bundled middleware's generated property keys.
+    static let relationKey = "isDraft"
+
+    static let keys = (BundledPropertyKey.objectListKeys + [
+        .id, .spaceId, .name, .description, .snippet, .creator, .createdDate,
+        .isHidden, .isDeleted, .isArchived, .internalFlags, .coverId, .coverType
+    ]).uniqued().map(\.rawValue) + [relationKey]
+
+    static func isDraft(_ details: ObjectDetails, participantId: String?) -> Bool {
+        guard !details.isDeleted, !details.isArchived else { return false }
+        if let participantId, participantId.isNotEmpty, details.creator.isNotEmpty,
+           details.creator != participantId { return false }
+        // Explicit false always wins, including a published object still marked hidden.
+        if let kind = details.values[relationKey]?.kind {
+            switch kind {
+            case .boolValue(let value): return value
+            case .nullValue: return details.isHidden
+            default: return false
+            }
+        }
+        return details.isHidden
+    }
+
+    static func needsMigration(_ details: ObjectDetails) -> Bool {
+        guard let kind = details.values[relationKey]?.kind else { return true }
+        if case .nullValue = kind { return true }
+        return false
+    }
+
+    static func discoveryRequest(participantIds: [String], localDraftIds: [String] = [], offset: Int = 0) -> CrossSpaceSearchRequest {
+        var draftFilter = DataviewFilter()
+        draftFilter.relationKey = relationKey
+        draftFilter.condition = .equal
+        draftFilter.value = true
+        var ownedDrafts = DataviewFilter()
+        ownedDrafts.operator = .and
+        ownedDrafts.nestedFilters = [draftFilter, SearchHelper.creatorsFilter(participantIds)]
+        var discoverable = DataviewFilter()
+        discoverable.operator = .or
+        // Legacy local pointers may have no creator; validate ownership on the result.
+        discoverable.nestedFilters = [ownedDrafts]
+        if localDraftIds.isNotEmpty { discoverable.nestedFilters.append(SearchHelper.includeIdsFilter(localDraftIds)) }
+        return CrossSpaceSearchRequest(
+            filters: [discoverable,
+                      SearchHelper.isDeletedFilter(isDeleted: false), SearchHelper.isArchivedFilter(isArchived: false)],
+            sorts: [SearchHelper.sort(relation: .createdDate, type: .desc)],
+            fullText: "",
+            keys: keys,
+            offset: offset,
+            limit: 100
+        )
+    }
+}
+
+struct QuickCaptureDraftDiscovery: Sendable {
+    let drafts: [ObjectDetails]
+    let isComplete: Bool
+
+    func newestDraft(spaceId: String) -> ObjectDetails? {
+        drafts.first { $0.spaceId == spaceId }
+    }
+
+    var spaceIds: Set<String> { Set(drafts.map(\.spaceId)) }
+}
+
+enum QuickCaptureSpaceSwitch: Equatable {
+    case openTarget
+    case move
+    case confirm
+
+    static func action(hasContent: Bool, hasLocalEdits: Bool, targetHasContent: Bool) -> Self {
+        guard hasContent, hasLocalEdits else { return .openTarget }
+        return targetHasContent ? .confirm : .move
+    }
+}
+
+struct QuickCaptureDraftContent: Equatable {
+    let name: String
+    let description: String
+    let blocks: [BlockInformation]
+    let copyableBlocks: [BlockInformation]
+    let hasContent: Bool
+
+    init(details: ObjectDetails, blocks: [BlockInformation]) {
+        name = details.name
+        description = details.description
+        hasContent = details.name.isNotEmpty || details.description.isNotEmpty || blocks.contains { info in
+            switch info.content {
+            case .smartblock, .layout, .tableRow, .tableColumn, .featuredRelations, .relation:
+                return false
+            case .text(let text):
+                return text.text.isNotEmpty
+            default:
+                return true
+            }
+        }
+        self.blocks = blocks.filter { info in
+            guard info.kind == .block else { return false }
+            switch info.content {
+            case .featuredRelations: return false
+            case .text(let text): return text.contentType != .title && text.contentType != .description
+            default: return true
+            }
+        }
+        // The copy RPC expands a table itself. Selecting its cells again duplicates them.
+        let tableCellIds = Set(blocks.flatMap { info -> [String] in
+            switch info.content {
+            case .tableRow, .tableColumn: return info.childrenIds
+            default: return []
+            }
+        })
+        copyableBlocks = self.blocks.filter { !tableCellIds.contains($0.id) }
+    }
+
+    // Compare all text, including table cells, and counts of each non-text block type.
+    // Block ids, parent ids and attachment object ids can change during cross-space paste.
+    func contains(_ source: Self) -> Bool {
+        guard name == source.name, description == source.description else { return false }
+        var remaining = blocks
+        for block in source.blocks {
+            if case .text(let text) = block.content, text.text.isEmpty { continue }
+            guard let index = remaining.firstIndex(where: { candidate in
+                guard candidate.content.type == block.content.type else { return false }
+                if case .text(let text) = block.content {
+                    return candidate.textContent?.text == text.text
+                }
+                return true
+            }) else { return false }
+            remaining.remove(at: index)
+        }
+        return true
+    }
+}

--- a/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureDraftStorage.swift
+++ b/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureDraftStorage.swift
@@ -3,13 +3,14 @@ import AnytypeCore
 
 protocol QuickCaptureDraftStorageProtocol: AnyObject, Sendable {
     func draftObjectId(spaceId: String) -> String?
+    func draftObjectIds() -> [String]
     func setDraftObjectId(_ objectId: String?, spaceId: String)
     func lastCaptureSpaceId() -> String?
     func setLastCaptureSpaceId(_ spaceId: String)
 }
 
 // Pointers to per-space quick capture draft objects on this device.
-// The draft content lives in the object itself; only the "which object is the draft" fact is local.
+// Draft content and isDraft sync. These ids only hint which draft this device resumes.
 final class QuickCaptureDraftStorage: QuickCaptureDraftStorageProtocol, Sendable {
 
     // [SpaceId: draft ObjectId]
@@ -18,6 +19,10 @@ final class QuickCaptureDraftStorage: QuickCaptureDraftStorageProtocol, Sendable
 
     func draftObjectId(spaceId: String) -> String? {
         storage.value[spaceId]
+    }
+
+    func draftObjectIds() -> [String] {
+        Array(storage.value.values)
     }
 
     func setDraftObjectId(_ objectId: String?, spaceId: String) {

--- a/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureService.swift
+++ b/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureService.swift
@@ -1,31 +1,40 @@
 import Foundation
 import Services
 import AnytypeCore
+import ProtobufMessages
 
-enum QuickCaptureError: Error {
+enum QuickCaptureError: LocalizedError {
     case contentCopyFailed
+    case draftUnavailable
+    case discoveryIncomplete
+    case targetHasContent
+
+    var errorDescription: String? { Loc.QuickCapture.operationFailed }
 }
 
 protocol QuickCaptureServiceProtocol: AnyObject, Sendable {
     func lastCaptureSpaceId() -> String?
+    func discoverDrafts() async throws -> QuickCaptureDraftDiscovery
     func obtainDraft(spaceId: String) async throws -> ObjectDetails
-    func hasDraftWithContent(spaceId: String) async -> Bool
-    func commitDraft(spaceId: String) async throws
-    func clearDraft(spaceId: String) async throws
-    func moveDraft(
-        from sourceSpaceId: String,
-        to targetSpaceId: String,
-        blocks: [BlockInformation],
-        name: String
-    ) async throws -> ObjectDetails
+    func hasDraftWithContent(spaceId: String) async throws -> Bool
+    func commitDraft(objectId: String, spaceId: String) async throws
+    func clearDraft(objectId: String, spaceId: String) async throws
+    func deleteDraftIfEmpty(objectId: String, spaceId: String) async throws -> Bool
+    func moveDraft(objectId: String, from sourceSpaceId: String, to targetSpaceId: String) async throws -> ObjectDetails
 }
 
 final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
 
     @Injected(\.quickCaptureDraftStorage)
     private var draftStorage: any QuickCaptureDraftStorageProtocol
-    @Injected(\.searchService)
-    private var searchService: any SearchServiceProtocol
+    @Injected(\.searchMiddleService)
+    private var searchService: any SearchMiddleServiceProtocol
+    @Injected(\.crossSpaceSearchMiddleService)
+    private var crossSpaceSearchService: any CrossSpaceSearchMiddleServiceProtocol
+    @Injected(\.participantsStorage)
+    private var participantsStorage: any ParticipantsStorageProtocol
+    @Injected(\.objectLifecycleService)
+    private var objectLifecycleService: any ObjectLifecycleServiceProtocol
     @Injected(\.objectActionsService)
     private var objectActionsService: any ObjectActionsServiceProtocol
     @Injected(\.objectTypeProvider)
@@ -37,156 +46,263 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
     @Injected(\.pasteboardMiddleService)
     private var pasteboardMiddleService: any PasteboardMiddlewareServiceProtocol
 
+    private let discoveryStorage = AtomicStorage<QuickCaptureDraftDiscovery?>(nil)
+
     func lastCaptureSpaceId() -> String? {
         draftStorage.lastCaptureSpaceId()
     }
 
+    func discoverDrafts() async throws -> QuickCaptureDraftDiscovery {
+        let participantIds = participantsStorage.participants.map(\.id).filter(\.isNotEmpty)
+        guard participantIds.isNotEmpty else { throw QuickCaptureError.discoveryIncomplete }
+        var drafts = [ObjectDetails]()
+        var offset = 0
+        while true {
+            try Task.checkCancellation()
+            let result = try await crossSpaceSearchService.search(
+                data: QuickCaptureDraft.discoveryRequest(
+                    participantIds: participantIds, localDraftIds: draftStorage.draftObjectIds(), offset: offset
+                )
+            )
+            drafts.append(contentsOf: result.records.filter { isDraft($0, spaceId: $0.spaceId) })
+            guard result.allStoresLoaded else {
+                let discovery = QuickCaptureDraftDiscovery(drafts: drafts, isComplete: false)
+                discoveryStorage.value = discovery
+                return discovery
+            }
+            guard result.records.count == 100 else { break }
+            offset += result.records.count
+        }
+        let discovery = QuickCaptureDraftDiscovery(drafts: drafts, isComplete: true)
+        discoveryStorage.value = discovery
+        return discovery
+    }
+
     func obtainDraft(spaceId: String) async throws -> ObjectDetails {
-        // Types + property details caches without workspaceOpen/setActiveSpace - the full
-        // activation would make the space hub coordinator navigate under the capture sheet.
-        // The document itself brings its dependencies in the objectShow response.
+        // Prepare caches without navigating the space hub underneath the sheet.
         await activeSpaceManager.prepareSpaceForPreview(spaceId: spaceId)
         let details: ObjectDetails
-        if let restored = await storedDraft(spaceId: spaceId) {
+        if let restored = try await storedDraft(spaceId: spaceId) {
             details = restored
         } else {
-            details = try await createDraft(spaceId: spaceId, name: "")
+            details = try await createDraft(spaceId: spaceId)
         }
-        // Recorded only once the draft is in hand - reopening into a space that just
-        // failed to produce one would strand the user there every launch
+        draftStorage.setDraftObjectId(details.id, spaceId: spaceId)
         draftStorage.setLastCaptureSpaceId(spaceId)
         return details
     }
 
-    func hasDraftWithContent(spaceId: String) async -> Bool {
-        guard let details = await storedDraft(spaceId: spaceId) else { return false }
-        // Title and body preview - an untouched draft is not worth warning about
-        return details.name.isNotEmpty || details.snippet.isNotEmpty
+    func hasDraftWithContent(spaceId: String) async throws -> Bool {
+        guard let details = try await storedDraft(spaceId: spaceId, preferLocalHint: false) else { return false }
+        // A snippet cannot establish emptiness: an image-only draft has no text preview.
+        return try await draftContent(objectId: details.id, spaceId: spaceId).content.hasContent
     }
 
-    // Until anytype-heart has a real unsynced-draft state, drafts live as isHidden
-    // objects; committing publishes the object by removing the flag.
-    func commitDraft(spaceId: String) async throws {
-        guard let draftId = draftStorage.draftObjectId(spaceId: spaceId) else { return }
-        try await objectActionsService.updateBundledDetails(contextID: draftId, details: [.isHidden(false)])
-        draftStorage.setDraftObjectId(nil, spaceId: spaceId)
-        await markDraftTypeAsUsed(objectId: draftId, spaceId: spaceId)
+    func commitDraft(objectId: String, spaceId: String) async throws {
+        _ = try await requireDraft(objectId: objectId, spaceId: spaceId)
+        // Both flags must change in the same write, or discovery can reopen a published note.
+        try await objectActionsService.updateBundledDetails(
+            contextID: objectId, details: [.isDraft(false), .isHidden(false)]
+        )
+        clearPointer(objectId: objectId, spaceId: spaceId)
+        await markDraftTypeAsUsed(objectId: objectId, spaceId: spaceId)
     }
 
-    func clearDraft(spaceId: String) async throws {
-        guard let draftId = draftStorage.draftObjectId(spaceId: spaceId) else { return }
-        try await deleteDraft(objectId: draftId, spaceId: spaceId)
+    func clearDraft(objectId: String, spaceId: String) async throws {
+        _ = try await requireDraft(objectId: objectId, spaceId: spaceId)
+        try await objectActionsService.delete(objectIds: [objectId])
+        clearPointer(objectId: objectId, spaceId: spaceId)
     }
 
-    func moveDraft(
-        from sourceSpaceId: String,
-        to targetSpaceId: String,
-        blocks: [BlockInformation],
-        name: String
-    ) async throws -> ObjectDetails {
+    func deleteDraftIfEmpty(objectId: String, spaceId: String) async throws -> Bool {
+        let snapshot = try await draftContent(objectId: objectId, spaceId: spaceId)
+        guard snapshot.details.isHidden, !snapshot.content.hasContent else { return false }
+        try Task.checkCancellation()
+        try await objectActionsService.delete(objectIds: [objectId])
+        clearPointer(objectId: objectId, spaceId: spaceId)
+        return true
+    }
+
+    func moveDraft(objectId: String, from sourceSpaceId: String, to targetSpaceId: String) async throws -> ObjectDetails {
         guard sourceSpaceId != targetSpaceId else {
-            return try await obtainDraft(spaceId: sourceSpaceId)
+            return try await requireDraft(objectId: objectId, spaceId: sourceSpaceId)
         }
-        guard let sourceDraftId = draftStorage.draftObjectId(spaceId: sourceSpaceId) else {
-            return try await obtainDraft(spaceId: targetSpaceId)
-        }
-
-        // An empty paragraph carries nothing - copying it yields an empty slot, which
-        // must not be mistaken for a failed copy
-        let carriesContent = blocks.contains { info in
-            if case let .text(text) = info.content { return text.text.isNotEmpty }
-            return true
-        }
-        var copiedBlocks = [String]()
-        if carriesContent {
-            let copyResult = try await pasteboardMiddleService.copy(
-                blockInformations: blocks,
-                objectId: sourceDraftId,
+        let source = try await draftContent(objectId: objectId, spaceId: sourceSpaceId)
+        let copiedBlocks: [String]
+        if source.content.copyableBlocks.contains(where: { !$0.content.isEmpty }) {
+            copiedBlocks = try await pasteboardMiddleService.copy(
+                blockInformations: source.content.copyableBlocks,
+                objectId: objectId,
                 selectedTextRange: NSRange(location: 0, length: 0)
-            )
-            copiedBlocks = copyResult?.blockSlot ?? []
-            guard copiedBlocks.isNotEmpty else {
-                // Refuse rather than carry on towards deleting the source
-                throw QuickCaptureError.contentCopyFailed
-            }
+            )?.blockSlot ?? []
+            guard copiedBlocks.isNotEmpty else { throw QuickCaptureError.contentCopyFailed }
+        } else {
+            copiedBlocks = []
         }
 
         await activeSpaceManager.prepareSpaceForPreview(spaceId: targetSpaceId)
-
-        // Nothing is destroyed until the content is safely in the target space
-        let replacedDraftId = draftStorage.draftObjectId(spaceId: targetSpaceId)
-        let newDraft = try await createDraft(spaceId: targetSpaceId, name: name)
-        do {
-            if copiedBlocks.isNotEmpty {
-                let firstBlockId = try await blockService.addFirstBlock(contextId: newDraft.id, info: .emptyText)
-                _ = try await pasteboardMiddleService.pasteBlock(
-                    copiedBlocks,
-                    objectId: newDraft.id,
-                    context: .focused(blockId: firstBlockId, range: NSRange(location: 0, length: 0))
-                )
-            }
-        } catch {
-            try? await objectActionsService.delete(objectIds: [newDraft.id])
-            draftStorage.setDraftObjectId(replacedDraftId, spaceId: targetSpaceId)
-            throw error
+        if let existing = try await storedDraft(spaceId: targetSpaceId, preferLocalHint: false) {
+            let snapshot = try await draftContent(objectId: existing.id, spaceId: targetSpaceId)
+            guard !snapshot.content.hasContent else { throw QuickCaptureError.targetHasContent }
         }
+        // Even an empty off-screen draft can receive a remote edit while copying.
+        // Leave it intact; discovery keeps it reachable if that happens.
+        let target = try await createDraft(spaceId: targetSpaceId, sourceTypeId: source.details.type)
 
-        if let replacedDraftId {
-            try? await objectActionsService.delete(objectIds: [replacedDraftId])
+        // Keep both pointers throughout copying. Even a partial paste remains recoverable.
+        draftStorage.setDraftObjectId(target.id, spaceId: targetSpaceId)
+        if copiedBlocks.isNotEmpty {
+            let firstBlockId = try await blockService.addFirstBlock(contextId: target.id, info: .emptyText)
+            _ = try await pasteboardMiddleService.pasteBlock(
+                copiedBlocks, objectId: target.id,
+                context: .focused(blockId: firstBlockId, range: NSRange(location: 0, length: 0))
+            )
         }
-        // A failed delete keeps the pointer, so the leftover copy stays reachable
-        // instead of becoming a hidden object nothing can ever open
-        try? await deleteDraft(objectId: sourceDraftId, spaceId: sourceSpaceId)
+        try await objectActionsService.updateBundledDetails(
+            contextID: target.id,
+            details: [.name(source.content.name), .description(source.content.description), .isDraft(true), .isHidden(true)]
+        )
+        let copied = try await draftContent(objectId: target.id, spaceId: targetSpaceId)
+        guard copied.content.contains(source.content) else { throw QuickCaptureError.contentCopyFailed }
 
-        // Only now is the target where the draft actually lives - a failed move above
-        // leaves the user on the source space, and reopening must agree with that
+        // Re-read immediately before deletion: neither publication nor a concurrent edit
+        // may turn a successful copy into permission to delete different content.
+        let currentSource = try await draftContent(objectId: objectId, spaceId: sourceSpaceId)
+        guard currentSource.content == source.content else { throw QuickCaptureError.contentCopyFailed }
+        try Task.checkCancellation()
+        // Destination bookkeeping precedes destruction. Cancellation can leave duplicates,
+        // but must never leave the only remaining copy without a pointer.
         draftStorage.setLastCaptureSpaceId(targetSpaceId)
-        return newDraft
+        try await objectActionsService.delete(objectIds: [objectId])
+        clearPointer(objectId: objectId, spaceId: sourceSpaceId)
+        return copied.details
     }
 
-    // MARK: - Private
+    // MARK: - Draft resolution
 
-    private func storedDraft(spaceId: String) async -> ObjectDetails? {
-        guard let draftId = draftStorage.draftObjectId(spaceId: spaceId) else { return nil }
-        // Ids filter only - the default search filters exclude hidden objects
-        let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [draftId]).first
-        guard let details, !details.isDeleted, !details.isArchived else {
-            // Empty drafts are auto-deleted by the middleware on close - the pointer just goes stale
-            draftStorage.setDraftObjectId(nil, spaceId: spaceId)
-            return nil
+    func storedDraft(spaceId: String, preferLocalHint: Bool = true) async throws -> ObjectDetails? {
+        var localDraft: ObjectDetails?
+        // Opening a known draft never waits for stores in other spaces to warm up.
+        if let draftId = draftStorage.draftObjectId(spaceId: spaceId) {
+            var details = try await fetchDetails(objectId: draftId, spaceId: spaceId)
+            if isDraft(details, spaceId: spaceId) {
+                if QuickCaptureDraft.needsMigration(details) {
+                    try await objectActionsService.updateBundledDetails(contextID: details.id, details: [.isDraft(true)])
+                    details = details.updated(by: [QuickCaptureDraft.relationKey: true.protobufValue])
+                }
+                localDraft = details
+                if preferLocalHint, let newer = discoveryStorage.value?.newestDraft(spaceId: spaceId), newer.id != details.id,
+                   (newer.createdDate ?? .distantPast) > (details.createdDate ?? .distantPast) {
+                    // The dot and switching logic resolve the same cross-device draft.
+                    let resolved = try await requireDraft(objectId: newer.id, spaceId: spaceId)
+                    draftStorage.setDraftObjectId(resolved.id, spaceId: spaceId)
+                    return resolved
+                }
+                if preferLocalHint { return details }
+            } else {
+                // Only positive evidence invalidates the local hint, never an empty search/error.
+                clearPointer(objectId: draftId, spaceId: spaceId)
+            }
         }
+
+        guard let participant = participantsStorage.participants.first(where: { $0.spaceId == spaceId && $0.id.isNotEmpty }) else {
+            if let localDraft { return localDraft }
+            throw QuickCaptureError.discoveryIncomplete
+        }
+        // ObjectSearch initializes this space's index before returning. Its successful
+        // answer is authoritative for this space, unlike an incomplete cross-space snapshot.
+        // This also lets the first capture open without waiting on other spaces at all.
+        let request = QuickCaptureDraft.discoveryRequest(participantIds: [participant.id])
+        let records = try await searchService.search(
+            spaceId: spaceId, filters: request.filters, sorts: request.sorts, keys: request.keys, limit: 1
+        )
+        let candidates = (records + [localDraft].compactMap { $0 }).filter { isDraft($0, spaceId: spaceId) }
+        if let candidate = candidates.max(by: { ($0.createdDate ?? .distantPast) < ($1.createdDate ?? .distantPast) }) {
+            let details = try await requireDraft(objectId: candidate.id, spaceId: spaceId)
+            draftStorage.setDraftObjectId(details.id, spaceId: spaceId)
+            return details
+        }
+        if let known = discoveryStorage.value?.newestDraft(spaceId: spaceId) {
+            // A conflicting positive snapshot is still a draft to resolve, never permission
+            // to manufacture a replacement on an inconclusive answer.
+            return try await requireDraft(objectId: known.id, spaceId: spaceId)
+        }
+        return nil
+    }
+
+    private func fetchDetails(objectId: String, spaceId: String) async throws -> ObjectDetails {
+        let records = try await searchService.search(
+            spaceId: spaceId,
+            filters: [SearchHelper.includeIdsFilter([objectId])],
+            keys: QuickCaptureDraft.keys,
+            limit: 1
+        )
+        if let details = records.first { return details }
+        // Search absence is inconclusive. ObjectShow can positively report deletion.
+        do {
+            let model = try await objectLifecycleService.openForPreview(contextId: objectId, spaceId: spaceId)
+            guard let details = model.details.first(where: { $0.id == objectId }) else {
+                throw QuickCaptureError.draftUnavailable
+            }
+            return ObjectDetails(id: details.id, values: details.details.fields)
+        } catch let error as Anytype_Rpc.Object.Show.Response.Error where error.code == .objectDeleted {
+            return ObjectDetails(id: objectId, values: [BundledPropertyKey.isDeleted.rawValue: true.protobufValue])
+        }
+    }
+
+    private func requireDraft(objectId: String, spaceId: String) async throws -> ObjectDetails {
+        let details = try await fetchDetails(objectId: objectId, spaceId: spaceId)
+        guard isDraft(details, spaceId: spaceId) else { throw QuickCaptureError.draftUnavailable }
         return details
     }
 
-    private func deleteDraft(objectId: String, spaceId: String) async throws {
-        try await objectActionsService.delete(objectIds: [objectId])
+    private func isDraft(_ details: ObjectDetails, spaceId: String) -> Bool {
+        QuickCaptureDraft.isDraft(details, participantId: participantsStorage.participants.first { $0.spaceId == spaceId }?.id)
+    }
+
+    private func draftContent(objectId: String, spaceId: String) async throws -> (details: ObjectDetails, content: QuickCaptureDraftContent) {
+        let model = try await objectLifecycleService.openForPreview(contextId: objectId, spaceId: spaceId)
+        guard model.rootID == objectId,
+              model.blocks.contains(where: { $0.id == objectId }),
+              let rawDetails = model.details.first(where: { $0.id == objectId }) else {
+            throw QuickCaptureError.draftUnavailable
+        }
+        let details = ObjectDetails(id: objectId, values: rawDetails.details.fields)
+        guard isDraft(details, spaceId: spaceId) else { throw QuickCaptureError.draftUnavailable }
+        let blocks = model.blocks.compactMap { BlockInformationConverter.convert(block: $0) }
+        guard blocks.count == model.blocks.count else { throw QuickCaptureError.contentCopyFailed }
+        return (details, QuickCaptureDraftContent(details: details, blocks: blocks))
+    }
+
+    private func clearPointer(objectId: String, spaceId: String) {
+        if let discovery = discoveryStorage.value {
+            discoveryStorage.value = QuickCaptureDraftDiscovery(
+                drafts: discovery.drafts.filter { $0.id != objectId }, isComplete: discovery.isComplete
+            )
+        }
+        guard draftStorage.draftObjectId(spaceId: spaceId) == objectId else { return }
         draftStorage.setDraftObjectId(nil, spaceId: spaceId)
     }
 
     private func markDraftTypeAsUsed(objectId: String, spaceId: String) async {
-        guard let details = try? await searchService.searchObjects(spaceId: spaceId, objectIds: [objectId]).first,
-              details.type.isNotEmpty else { return }
-        try? await objectActionsService.updateBundledDetails(
-            contextID: details.type,
-            details: [.lastUsedDate(.now)]
-        )
+        guard let details = try? await fetchDetails(objectId: objectId, spaceId: spaceId), details.type.isNotEmpty else { return }
+        try? await objectActionsService.updateBundledDetails(contextID: details.type, details: [.lastUsedDate(.now)])
     }
 
-    // Callers prepare the space caches (prepareSpaceForPreview) before this
-    private func createDraft(spaceId: String, name: String) async throws -> ObjectDetails {
-        let type = try objectTypeProvider.defaultObjectType(spaceId: spaceId)
-        // isHidden travels with the create request: a separate details write would
-        // clear editorDeleteEmpty, so the draft would look edited from the start
+    private func createDraft(spaceId: String, sourceTypeId: String? = nil) async throws -> ObjectDetails {
+        let type: ObjectType
+        if let sourceTypeId,
+           let sourceType = try? objectTypeProvider.objectType(id: sourceTypeId),
+           let targetType = try? objectTypeProvider.objectType(uniqueKey: sourceType.uniqueKey, spaceId: spaceId) {
+            type = targetType
+        } else {
+            type = try objectTypeProvider.defaultObjectType(spaceId: spaceId)
+        }
         let details = try await objectActionsService.createObject(
-            name: name,
-            typeUniqueKey: type.uniqueKey,
-            shouldDeleteEmptyObject: true,
-            shouldSelectType: true,
-            shouldSelectTemplate: false,
-            spaceId: spaceId,
-            origin: .none,
-            templateId: nil,
-            additionalDetails: [.isHidden(true)]
+            name: "", typeUniqueKey: type.uniqueKey,
+            shouldDeleteEmptyObject: true, shouldSelectType: true, shouldSelectTemplate: false,
+            spaceId: spaceId, origin: .none, templateId: nil,
+            additionalDetails: [.isDraft(true), .isHidden(true)]
         )
         draftStorage.setDraftObjectId(details.id, spaceId: spaceId)
         return details

--- a/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureService.swift
+++ b/Anytype/Sources/ServiceLayer/QuickCapture/QuickCaptureService.swift
@@ -47,6 +47,11 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
     private var pasteboardMiddleService: any PasteboardMiddlewareServiceProtocol
 
     private let discoveryStorage = AtomicStorage<QuickCaptureDraftDiscovery?>(nil)
+    // Object.ListDelete returns before the space index drops the object, so a search right
+    // after clearing a draft can hand the deleted draft back. Opening it then hangs on the
+    // editor placeholder or fails resolution once the index catches up. Anything this device
+    // deleted is never resolved again; the set only holds ids deleted in this session.
+    private let deletedDraftIds = AtomicStorage<Set<String>>([])
 
     func lastCaptureSpaceId() -> String? {
         draftStorage.lastCaptureSpaceId()
@@ -99,11 +104,15 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
     }
 
     func commitDraft(objectId: String, spaceId: String) async throws {
-        _ = try await requireDraft(objectId: objectId, spaceId: spaceId)
+        let details = try await requireDraft(objectId: objectId, spaceId: spaceId)
         // Both flags must change in the same write, or discovery can reopen a published note.
-        try await objectActionsService.updateBundledDetails(
-            contextID: objectId, details: [.isDraft(false), .isHidden(false)]
-        )
+        // A legacy draft was never created with isDraft, so its space has no such relation and
+        // Object.SetDetails would reject the key; isHidden alone un-drafts it.
+        var published: [BundledDetails] = [.isHidden(false)]
+        if QuickCaptureDraft.hasDraftFlag(details) {
+            published.append(.isDraft(false))
+        }
+        try await objectActionsService.updateBundledDetails(contextID: objectId, details: published)
         clearPointer(objectId: objectId, spaceId: spaceId)
         await markDraftTypeAsUsed(objectId: objectId, spaceId: spaceId)
     }
@@ -111,7 +120,7 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
     func clearDraft(objectId: String, spaceId: String) async throws {
         _ = try await requireDraft(objectId: objectId, spaceId: spaceId)
         try await objectActionsService.delete(objectIds: [objectId])
-        clearPointer(objectId: objectId, spaceId: spaceId)
+        forgetDeletedDraft(objectId: objectId, spaceId: spaceId)
     }
 
     func deleteDraftIfEmpty(objectId: String, spaceId: String) async throws -> Bool {
@@ -119,7 +128,7 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
         guard snapshot.details.isHidden, !snapshot.content.hasContent else { return false }
         try Task.checkCancellation()
         try await objectActionsService.delete(objectIds: [objectId])
-        clearPointer(objectId: objectId, spaceId: spaceId)
+        forgetDeletedDraft(objectId: objectId, spaceId: spaceId)
         return true
     }
 
@@ -158,9 +167,10 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
                 context: .focused(blockId: firstBlockId, range: NSRange(location: 0, length: 0))
             )
         }
+        // isDraft and isHidden were set when the target was created; only the copied metadata is written here.
         try await objectActionsService.updateBundledDetails(
             contextID: target.id,
-            details: [.name(source.content.name), .description(source.content.description), .isDraft(true), .isHidden(true)]
+            details: [.name(source.content.name), .description(source.content.description)]
         )
         let copied = try await draftContent(objectId: target.id, spaceId: targetSpaceId)
         guard copied.content.contains(source.content) else { throw QuickCaptureError.contentCopyFailed }
@@ -174,7 +184,7 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
         // but must never leave the only remaining copy without a pointer.
         draftStorage.setLastCaptureSpaceId(targetSpaceId)
         try await objectActionsService.delete(objectIds: [objectId])
-        clearPointer(objectId: objectId, spaceId: sourceSpaceId)
+        forgetDeletedDraft(objectId: objectId, spaceId: sourceSpaceId)
         return copied.details
     }
 
@@ -184,12 +194,11 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
         var localDraft: ObjectDetails?
         // Opening a known draft never waits for stores in other spaces to warm up.
         if let draftId = draftStorage.draftObjectId(spaceId: spaceId) {
-            var details = try await fetchDetails(objectId: draftId, spaceId: spaceId)
+            let details = try await fetchDetails(objectId: draftId, spaceId: spaceId)
             if isDraft(details, spaceId: spaceId) {
-                if QuickCaptureDraft.needsMigration(details) {
-                    try await objectActionsService.updateBundledDetails(contextID: details.id, details: [.isDraft(true)])
-                    details = details.updated(by: [QuickCaptureDraft.relationKey: true.protobufValue])
-                }
+                // A legacy draft (hidden, no isDraft) is not stamped here: Object.SetDetails
+                // rejects isDraft in a space where no object was created with it. It stays
+                // reachable through the local pointer and is un-drafted on publish by isHidden.
                 localDraft = details
                 if preferLocalHint, let newer = discoveryStorage.value?.newestDraft(spaceId: spaceId), newer.id != details.id,
                    (newer.createdDate ?? .distantPast) > (details.createdDate ?? .distantPast) {
@@ -257,7 +266,13 @@ final class QuickCaptureService: QuickCaptureServiceProtocol, Sendable {
     }
 
     private func isDraft(_ details: ObjectDetails, spaceId: String) -> Bool {
-        QuickCaptureDraft.isDraft(details, participantId: participantsStorage.participants.first { $0.spaceId == spaceId }?.id)
+        guard !deletedDraftIds.value.contains(details.id) else { return false }
+        return QuickCaptureDraft.isDraft(details, participantId: participantsStorage.participants.first { $0.spaceId == spaceId }?.id)
+    }
+
+    private func forgetDeletedDraft(objectId: String, spaceId: String) {
+        _ = deletedDraftIds.access { $0.insert(objectId) }
+        clearPointer(objectId: objectId, spaceId: spaceId)
     }
 
     private func draftContent(objectId: String, spaceId: String) async throws -> (details: ObjectDetails, content: QuickCaptureDraftContent) {

--- a/Anytype/Sources/Utilities/UserDefaults/UserDefaultsStorage.swift
+++ b/Anytype/Sources/Utilities/UserDefaults/UserDefaultsStorage.swift
@@ -14,6 +14,7 @@ protocol UserDefaultsStorageProtocol: AnyObject, Sendable {
     var userInterfaceStyle: UIUserInterfaceStyle { get set }
     var autoDownloadSizeLimitRawValue: Int { get set }
     var autoDownloadUseCellular: Bool { get set }
+    var spaceHubLastMessageDates: [String: Date] { get set }
 
     func wallpaperPublisher(spaceId: String) -> AnyPublisher<SpaceWallpaperType, Never>
     func wallpapersPublisher() -> AnyPublisher<[String: SpaceWallpaperType], Never>
@@ -55,6 +56,12 @@ final class UserDefaultsStorage: UserDefaultsStorageProtocol, @unchecked Sendabl
 
     @UserDefault("UserData.AutoDownloadUseCellular", defaultValue: false)
     var autoDownloadUseCellular: Bool
+
+    // MARK: - Space Hub
+    // Key - spaceId, value - date of the latest chat message the Space Hub last showed for it.
+    // Chat previews load slowly after launch; this keeps the hub in its last order until they land.
+    @UserDefault("UserData.SpaceHubLastMessageDates", defaultValue: [:])
+    var spaceHubLastMessageDates: [String: Date]
 
     // MARK: - UserInterfaceStyle
     @UserDefault("UserData.UserInterfaceStyle", defaultValue: UIUserInterfaceStyle.unspecified.rawValue)
@@ -102,6 +109,7 @@ final class UserDefaultsStorage: UserDefaultsStorageProtocol, @unchecked Sendabl
         showUnstableMiddlewareError = true
         autoDownloadSizeLimitRawValue = -1
         autoDownloadUseCellular = false
+        spaceHubLastMessageDates = [:]
     }
     
 }

--- a/Anytype/Sources/Utilities/UserDefaults/UserDefaultsStorage.swift
+++ b/Anytype/Sources/Utilities/UserDefaults/UserDefaultsStorage.swift
@@ -15,6 +15,7 @@ protocol UserDefaultsStorageProtocol: AnyObject, Sendable {
     var autoDownloadSizeLimitRawValue: Int { get set }
     var autoDownloadUseCellular: Bool { get set }
     var spaceHubLastMessageDates: [String: Date] { get set }
+    var unifiedSearchDiscovered: Bool { get set }
 
     func wallpaperPublisher(spaceId: String) -> AnyPublisher<SpaceWallpaperType, Never>
     func wallpapersPublisher() -> AnyPublisher<[String: SpaceWallpaperType], Never>
@@ -62,6 +63,12 @@ final class UserDefaultsStorage: UserDefaultsStorageProtocol, @unchecked Sendabl
     // Chat previews load slowly after launch; this keeps the hub in its last order until they land.
     @UserDefault("UserData.SpaceHubLastMessageDates", defaultValue: [:])
     var spaceHubLastMessageDates: [String: Date]
+
+    // MARK: - Unified Search
+    // True once the user opened unified search from the hub, or from the first launch for a
+    // fresh install. Until then the hub's search entry glimmers so upgraders notice the feature.
+    @UserDefault("UserData.UnifiedSearchDiscovered", defaultValue: false)
+    var unifiedSearchDiscovered: Bool
 
     // MARK: - UserInterfaceStyle
     @UserDefault("UserData.UserInterfaceStyle", defaultValue: UIUserInterfaceStyle.unspecified.rawValue)

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -1347,7 +1347,7 @@ public enum Loc {
     public static func inSpacePlusOne(_ p1: Any) -> String {
       return Loc.tr("UI", "UnifiedSearch.inSpacePlusOne", String(describing: p1), fallback: "in %@ + 1 other Channel")
     }
-    public static let placeholder = Loc.tr("UI", "UnifiedSearch.placeholder", fallback: "Search and filter objects, messages")
+    public static let placeholder = Loc.tr("UI", "UnifiedSearch.placeholder", fallback: "Search everything")
     public enum Accessibility {
       public static func filterBy(_ p1: Any) -> String {
         return Loc.tr("UI", "UnifiedSearch.Accessibility.filterBy", String(describing: p1), fallback: "Filter by %@")

--- a/Modules/Loc/Sources/Loc/Generated/Strings.swift
+++ b/Modules/Loc/Sources/Loc/Generated/Strings.swift
@@ -1075,16 +1075,20 @@ public enum Loc {
     public static let clearDraft = Loc.tr("UI", "QuickCapture.clearDraft", fallback: "Clear draft")
     public static let clearDraftFailed = Loc.tr("UI", "QuickCapture.clearDraftFailed", fallback: "Couldn't clear the draft. It's still here.")
     public static let clearDraftTitle = Loc.tr("UI", "QuickCapture.clearDraftTitle", fallback: "Delete this draft?")
+    public static let discardMyDraft = Loc.tr("UI", "QuickCapture.discardMyDraft", fallback: "Discard my draft")
+    public static let draftsInOtherSpaces = Loc.tr("UI", "QuickCapture.draftsInOtherSpaces", fallback: "Unsent drafts in other spaces")
+    public static let keepBoth = Loc.tr("UI", "QuickCapture.keepBoth", fallback: "Keep both")
     public static let moveFailed = Loc.tr("UI", "QuickCapture.moveFailed", fallback: "Couldn't move the draft. Your note stayed where it was.")
     public static let openObject = Loc.tr("UI", "QuickCapture.openObject", fallback: "Open")
-    public static let replaceDraft = Loc.tr("UI", "QuickCapture.replaceDraft", fallback: "Replace")
-    public static let replaceDraftMessage = Loc.tr("UI", "QuickCapture.replaceDraftMessage", fallback: "Its unsent draft will be deleted permanently.")
-    public static func replaceDraftTitle(_ p1: Any) -> String {
-      return Loc.tr("UI", "QuickCapture.replaceDraftTitle", String(describing: p1), fallback: "Replace draft in %@?")
+    public static let operationFailed = Loc.tr("UI", "QuickCapture.operationFailed", fallback: "Couldn't finish this action. Your drafts are safe. Please try again.")
+    public static let switchDraftMessage = Loc.tr("UI", "QuickCapture.switchDraftMessage", fallback: "Keep this draft in its space, or permanently discard it. The other space's draft will open.")
+    public static func switchDraftTitle(_ p1: Any) -> String {
+      return Loc.tr("UI", "QuickCapture.switchDraftTitle", String(describing: p1), fallback: "%@ already has a draft")
     }
     public static func typeCreatedIn(_ p1: Any, _ p2: Any) -> String {
       return Loc.tr("UI", "QuickCapture.typeCreatedIn", String(describing: p1), String(describing: p2), fallback: "%1$@ created in %2$@")
     }
+    public static let unsentDraft = Loc.tr("UI", "QuickCapture.unsentDraft", fallback: "Unsent draft")
   }
   public enum RedactedText {
     public static let pageTitle = Loc.tr("UI", "RedactedText.pageTitle", fallback: "Wake up, Neo")
@@ -1343,6 +1347,7 @@ public enum Loc {
     public static func inSpacePlusOne(_ p1: Any) -> String {
       return Loc.tr("UI", "UnifiedSearch.inSpacePlusOne", String(describing: p1), fallback: "in %@ + 1 other Channel")
     }
+    public static let placeholder = Loc.tr("UI", "UnifiedSearch.placeholder", fallback: "Search and filter objects, messages")
     public enum Accessibility {
       public static func filterBy(_ p1: Any) -> String {
         return Loc.tr("UI", "UnifiedSearch.Accessibility.filterBy", String(describing: p1), fallback: "Filter by %@")

--- a/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
@@ -105199,7 +105199,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Search and filter objects, messages"
+            "value" : "Search everything"
           }
         }
       }

--- a/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
+++ b/Modules/Loc/Sources/Loc/Resources/UI.xcstrings
@@ -75842,37 +75842,61 @@
         }
       }
     },
-    "QuickCapture.replaceDraft" : {
+    "QuickCapture.discardMyDraft" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Replace"
+            "value" : "Discard my draft"
           }
         }
       }
     },
-    "QuickCapture.replaceDraftMessage" : {
+    "QuickCapture.switchDraftMessage" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Its unsent draft will be deleted permanently."
+            "value" : "Keep this draft in its space, or permanently discard it. The other space's draft will open."
           }
         }
       }
     },
-    "QuickCapture.replaceDraftTitle" : {
+    "QuickCapture.switchDraftTitle" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Replace draft in %@?"
+            "value" : "%@ already has a draft"
           }
         }
+      }
+    },
+    "QuickCapture.keepBoth" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Keep both" } }
+      }
+    },
+    "QuickCapture.operationFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Couldn't finish this action. Your drafts are safe. Please try again." } }
+      }
+    },
+    "QuickCapture.unsentDraft" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unsent draft" } }
+      }
+    },
+    "QuickCapture.draftsInOtherSpaces" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unsent drafts in other spaces" } }
       }
     },
     "QuickCapture.openObject" : {
@@ -105165,6 +105189,17 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "撤消/重做"
+          }
+        }
+      }
+    },
+    "UnifiedSearch.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search and filter objects, messages"
           }
         }
       }

--- a/Modules/Services/Sources/Models/Details/BundledDetails.swift
+++ b/Modules/Services/Sources/Models/Details/BundledDetails.swift
@@ -18,6 +18,7 @@ public enum BundledDetails: Sendable {
     case lastUsedDate(Date)
     case templateNamePrefillType(Int)
     case isHidden(Bool)
+    case isDraft(Bool)
 }
 
 extension BundledDetails {
@@ -38,6 +39,8 @@ extension BundledDetails {
         case .lastUsedDate: BundledPropertyKey.lastUsedDate.rawValue
         case .templateNamePrefillType: BundledPropertyKey.templateNamePrefillType.rawValue
         case .isHidden: BundledPropertyKey.isHidden.rawValue
+        // GO-7499: keep the wire key until it arrives in the bundled relation generator input.
+        case .isDraft: "isDraft"
         }
     }
 
@@ -57,6 +60,7 @@ extension BundledDetails {
         case .lastUsedDate(let date): date.protobufValue
         case .templateNamePrefillType(let int): int.protobufValue
         case .isHidden(let bool): bool.protobufValue
+        case .isDraft(let bool): bool.protobufValue
         }
     }
 

--- a/docs/plans/20260905-quick-capture-android-improvements-handoff.md
+++ b/docs/plans/20260905-quick-capture-android-improvements-handoff.md
@@ -1,0 +1,158 @@
+# Quick Capture — what Android changed, for iOS to port
+
+**Date:** 2026-09-05 · **From:** Android (DROID-4587, PR anyproto/anytype-kotlin#3339) · **Depends on:** GO-7499
+
+Android built quick capture from the iOS handoff (IOS-6617), then dogfooded it hard and reworked several parts. This is the reverse handoff: the decisions, the model, and the traps. Nothing here is Android-specific unless marked.
+
+Everything is behind an experimental flag; on-device AI behind a second one.
+
+---
+
+## 1. Product decisions worth adopting
+
+### 1.1 Never ask a question when the user hasn't typed
+
+This is the single most important behavioural rule, and it took three rounds of dogfooding to get right.
+
+Switching the target space mid-capture *feels* like it needs a confirmation, so we added one. Wrong. If the user has not typed anything **this session**, there is no text in flight, nothing is at stake, and any dialog is noise. Switching is then pure navigation: the current draft stays where it is, the target space's draft opens, exactly as if the sheet had been opened there.
+
+It gets worse after the first switch: the draft on screen now belongs to the space you just moved into, so offering to carry it onward is nonsense.
+
+The final tree — a prompt appears **only when something is genuinely given up**:
+
+| Draft on screen | Target space | Result |
+|---|---|---|
+| empty | anything | opens the target's draft, no dialog |
+| **untouched this session** | anything | opens the target's draft, no dialog |
+| edited, has text | no draft / empty draft | draft moves with you ("text follows the chip"), no dialog |
+| edited, has text | holds text | **Keep both** / **Discard my draft** |
+
+Note "untouched" ≠ "empty". A restored draft is non-empty the moment it opens. You need a separate signal for *the user typed during this sheet session*; emptiness cannot stand in for it.
+
+**Android implementation:** a flag set in the single funnel every text edit passes through (`sendTextChange`, which both the title and body blocks route through), reset naturally because the editor VM is rebuilt per draft. **Known gap:** paste, mention insertion and the first keystroke into a trailing placeholder bypass that funnel, so they don't currently mark the draft as edited. Check the equivalent paths on iOS.
+
+### 1.2 Never overwrite a draft the user cannot see
+
+The original contract had "replace the target space's draft". We shipped it, then removed it.
+
+The target's draft is off-screen and its content is never shown. Asking someone to authorise a permanent delete of something they cannot see is not a real choice. The target's draft is now **never** destroyed by a space switch. The question is only ever about the draft in front of them:
+
+- **Keep both** — this draft stays in its space, the target's opens
+- **Discard my draft** — this one is deleted, the target's opens
+
+Both land in the same place. Dismissing does nothing.
+
+### 1.3 The unsent-draft dot
+
+A 6dp amber dot marks an unsent draft, in two places with two scopes:
+
+- **space picker row** — "this space has a draft"
+- **space chip in the header** — "some space *other than this one* has a draft"
+
+The chip's dot is the aggregate of the picker's, minus the current space. Without it the feature has a hole: the sheet always opens where you last captured, so after discarding that draft nothing tells you unfinished drafts exist elsewhere — the picker is the only affordance and nothing suggests opening it.
+
+Details that mattered:
+- We first used a pencil in the list and a dot on the chip. Two glyphs for one state read as two states. **One mark, one meaning.**
+- 6dp is Material's small-badge size. A **numeric** badge is 16dp with 11sp text — nearly 3× the height, next to an 18dp chevron. Don't. The count also wouldn't change what the user does (they'd still open the picker).
+- In the list, **reserve the dot's gutter on every row**. Showing it only on marked rows shifts those names sideways and breaks the text column.
+- On the chip, put the dot **before** the chevron with an asymmetric gap (wider before, tighter after) so it reads as belonging to the control, not as punctuation after the space name.
+
+### 1.4 Opening must never wait on the cross-space query
+
+Cold start can leave per-space stores warming for seconds. The sheet resolves which draft to open from the **device-local pointer via a direct single-space lookup**, and runs cross-space discovery *alongside* on its own task.
+
+Discovery deliberately does **not** choose which space opens. Jumping the user into a different space because a newer draft exists there moves them somewhere they didn't ask to go — telling them (the dot) is enough.
+
+---
+
+## 2. The `isDraft` model (cross-device drafts)
+
+Drafts always synced between devices. What they lacked was a property to **ask the store for them by**, so each device could only reopen the draft its own local pointer named — a note started on the phone was unreachable from the tablet even though the object was right there.
+
+**GO-7499** adds `isDraft` (bool). Discovery is then one cross-space query:
+
+```
+isDraft == true AND creator IN {my participant ids}   ordered by createdDate desc
+```
+
+The device-local pointer survives only as a hint for which draft *this* device resumes.
+
+### Non-obvious constraints
+
+- **`creator` is per space.** The same account is a *different* participant object in every space. A cross-space query filtering on one creator id matches drafts in exactly one space and silently reports none anywhere else. Use an `IN` over all your participant ids (the account-wide participant subscription already has them). No per-space fan-out.
+- **Publishing must clear `isDraft` and `isHidden` in the same write.** Otherwise every note ever sent keeps matching the query, and newest-first eventually reopens a published note *as a draft*.
+- **A partial cross-space result is "unknown", not "empty".** Creating a draft on an inconclusive answer is how a space ends up with two.
+- **More than one draft per space becomes reachable** (two devices, both offline). Newest opens; the other must **not** be auto-deleted — deletion is permanent and the loser is someone's unsent text.
+- **Hidden is not private.** A hidden draft in a shared space still syncs to every member; `isHidden` only keeps it out of *our* UI. If unsent text must not leave the device, that's a heart-side guarantee this design does not provide.
+
+### GO-7499 also covers resurrection
+
+Undo, version restore, replica merge and duplicate must never bring `isDraft`/`isHidden` back on a published object. The client **cannot** defend against this: "still a draft" and "flags came back from history" are byte-identical states, and the sheet's trash deletes drafts permanently. Worth confirming iOS has the same exposure.
+
+---
+
+## 3. Pitfalls (the expensive part)
+
+These cost the most time. Most are not Android-specific.
+
+### Data loss
+
+1. **Emptiness checks that fail open, feeding a delete.** Our "does the target draft have content?" helper returned `false` on any fetch error, and the delete downstream only checked "does this object still exist". One transient error = permanent deletion of a real note. **A destructive operation must establish its own precondition at the point of deletion, and fail closed.**
+
+2. **Reading a relation you never requested.** The same helper read `snippet`, which wasn't in the fetch's `keys` — so it was *always* null and the check silently degenerated to title-only. Body-only drafts read as empty and were destroyed without a prompt. Audit every `keys` list against the fields actually read afterwards. A mock will happily return the field regardless, so a behavioural test won't catch it — assert on the request.
+
+3. **Bookkeeping placed after an uninterruptible commit.** (Kotlin-specific mechanism, universal shape.) Our move use case deleted the source inside a non-cancellable block, but wrote the draft pointers in the *caller's* success handler — which never runs if the sheet was dismissed mid-move. Result: source deleted, target holding the text, no pointer to it, unreachable by construction. **Write the pointer before destroying the only other copy**, inside the same uninterruptible section. Worst case then is a recoverable duplicate.
+
+4. **Verifying a copy by "some text landed".** After a cross-space copy we checked text arrived before deleting the source. A note plus an image passed the check and could still lose the image. Count non-text blocks on both sides too.
+
+5. **The publish window.** After publishing succeeds there's still bookkeeping and an analytics call before the sheet dismisses, and the UI stays live throughout, with state still naming the now-published object. Tapping the chip or the trash in that window moves or deletes a real note. Latch on send and stand down every destructive path.
+
+6. **Failing to *find* a draft is not proof it's gone.** Whenever a lookup came back empty we cleared the pointer and created a fresh draft — orphaning the real one. Only clear on positive evidence.
+
+### Detection failures (all made a real draft invisible)
+
+7. **Creator as a query filter.** Scoping the fetch with `creator == mine` excluded any object whose `creator` is unset or whose participant we couldn't resolve. "Not found" is indistinguishable from "no draft here". Fetch by id, apply creator to the **result**, and veto only when both sides are known and differ.
+
+8. **Requiring `isDraft == true`.** Drafts created before the client started writing the relation have no value at all. Treat three states: `true` → draft, `false` → published (never resurrect), **absent** → fall back to `isHidden`.
+
+9. **UI and logic reading different sources.** The picker's dot came from the cross-space query; every decision read only the local pointer. A draft made on another device was advertised in the UI and invisible to the logic — so switching there offered to start a new one, which would have orphaned it. **One accessor for "does this space have a draft".**
+
+10. **`Flow.first { }` throws** when the flow completes without a match, and a timeout wrapper does not catch it — failing the whole lookup. Use the nullable variant.
+
+### UI
+
+11. **Material `AlertDialog` renders `dismissButton` on the LEFT.** We had the destructive action there, in exactly the position the same feature's *other* dialog uses for Cancel. Muscle memory would have deleted a note. Destructive belongs in the confirm slot, and ideally in a design-system dialog with a filled warning button rather than red text alone.
+
+12. **Caret landed at position 0 on a non-empty title.** Our title holder applied the cursor *before* setting the text, so it measured the widget's previous (empty) contents, judged the position out of range and dropped it. Latent for years — the base editor only auto-focuses *empty* titles, where 0 and end coincide. Quick capture reopening a saved draft is the first thing that focuses a non-empty one. **Check the equivalent ordering on iOS.**
+
+13. **A permanent type bar fights whatever else owns the bottom edge.** Ours suppressed itself whenever the ordinary block toolbar appeared — which is on every focus change — so it vanished during typing, while never seeing the undo/redo panel it was written for (that lived outside the state object it inspected). It only *looked* correct because the render pipeline re-raised it on the next keystroke: two writers with opposite intent, resolved by whichever fired last.
+
+14. **Restoring focus to a title needs the title's own path.** The title is a child of the header block, not of the root, so a "focus the last text block" helper never sees it. A one-line capture creates no body block at all, so the most common restored draft got no caret, no keyboard and no type bar.
+
+### Process
+
+15. Two four-lens Opus review rounds. **The second round's top finding was that a fix from the first round was wrong in both directions.** Re-review after fixing; the fix is not automatically safer than the bug.
+16. Several bugs surfaced as the *wrong dialog* rather than as an obvious failure, which made them easy to misread as UX complaints. When a prompt appears at a strange moment, suspect a predicate returning the wrong answer before redesigning the prompt.
+
+---
+
+## 4. Also fixed along the way (outside the feature)
+
+Latent bugs this work exposed — check for equivalents:
+
+- A space-view subscription didn't request the join-date relation it sorted on, so the tiebreaker had always been dead.
+- Internal flags encoded as a scalar rather than a list were parsed into an empty list.
+- A space-icon view fell back to a fixed corner radius and font for any size outside a hard-coded whitelist.
+- An object-create path dropped its prefilled details on the default-type branch.
+
+---
+
+## 5. Still open on Android
+
+- Space picker stays interactive during the pre-switch flush, so two fast taps can stack dialogs.
+- Paste / mentions don't mark a draft as edited (§1.1).
+- Reconciliation when two devices both create a draft in one space.
+- A loading-placeholder height hint so the editor's skeleton matches the real header instead of collapsing into it.
+- On-device AI type suggestion is implemented and silent on every failure path, but has never run — no test device with the required runtime.
+
+**Reference:** `anytype-kotlin/docs/quick-capture-android-spec.md` (§5a is the draft model, §13 the open verification items). Branch `ki/droid-4587-quick-capture-pencil-entry-on-vault-cross-device-drafts`, 14 commits.


### PR DESCRIPTION
## Summary
- Quick Capture: port the Android draft decisions (anytype-kotlin#3339) — cross-device `isDraft` drafts, no prompt unless typed text is at stake, unsent-draft dots. `isDraft` is now set only at creation (`Object.SetDetails` rejects it in spaces without the relation), a draft this device just deleted is never resolved again (fixes the stuck placeholder and "Try again" after clearing), dots mark only drafts with content, and the picker lists drafts first.
- Space Hub: remember each space's last message date so the list keeps its order while chat previews load after launch (port of anytype-kotlin#3342, without the spinner).
- Search entry: "Search everything" label on the hub's bottom bar and a glimmer on the glass capsule for existing users until their first tap; fresh installs skip it.