### PR TITLE
IOS-6623 Fix editor cover jump on pull and cross-fade bottom bars on back swipe

### DIFF
--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/NavigationView/AnytypeNavigationCoordinator.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/NavigationView/AnytypeNavigationCoordinator.swift
@@ -9,6 +9,7 @@ final class AnytypeNavigationCoordinator: NSObject, UINavigationControllerDelega
     let builder = AnytypeDestinationBuilderHolder()
     var currentViewControllers = [UIHostingController<AnytypeNavigationViewBridge>]()
     var numberOfTransactions: Int = 0
+    var popProgress: AnytypeNavigationPopProgress?
 
     init(path: Binding<[AnyHashable]>, pathChanging: Binding<Bool>) {
         self._path = path
@@ -20,6 +21,7 @@ final class AnytypeNavigationCoordinator: NSObject, UINavigationControllerDelega
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
         pathChanging = true
         navigationController.transitionCoordinator?.notifyWhenInteractionChanges { [weak self] transaction in
+            self?.popProgress?.settle(cancelled: transaction.isCancelled, duration: transaction.transitionDuration)
             if transaction.isCancelled {
                 self?.pathChanging = false
             }
@@ -52,6 +54,9 @@ final class AnytypeNavigationCoordinator: NSObject, UINavigationControllerDelega
             }
         }
         
+        // Same synchronous block as the path update above, so the interpolated opacity of any
+        // swipe-tracking chrome hands over to its settled value without a frame in between.
+        popProgress?.reset()
         pathChanging = false
     }
 }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/NavigationView/AnytypeNavigationPopProgress.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/NavigationView/AnytypeNavigationPopProgress.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SwiftUI
+
+/// How far an in-flight back swipe has travelled: 0 at rest, 1 when the top screen has fully
+/// slid off. Published by `AnytypeNavigationView` so chrome that lives outside the navigation
+/// stack can cross-fade in step with the finger instead of snapping when the gesture commits.
+@Observable
+final class AnytypeNavigationPopProgress {
+
+    /// True from the first moment of a back swipe until the navigation path has caught up with
+    /// its outcome. Readers should interpolate towards the destination screen only while set.
+    private(set) var isPopping = false
+
+    /// 0...1 fraction of the screen width the swipe has covered.
+    private(set) var value: CGFloat = 0
+
+    func update(_ value: CGFloat) {
+        isPopping = true
+        self.value = min(max(value, 0), 1)
+    }
+
+    /// The finger has lifted and UIKit is animating the remainder itself. Run out the rest of
+    /// the progress on a comparable clock so the cross-fade lands with the slide.
+    func settle(cancelled: Bool, duration: TimeInterval) {
+        guard isPopping else { return }
+
+        let target: CGFloat = cancelled ? 0 : 1
+        let remaining = abs(target - value)
+
+        withAnimation(.easeOut(duration: duration * remaining)) {
+            value = target
+        }
+    }
+
+    /// The navigation path now reflects the finished pop, so the interpolation has nothing left
+    /// to say. This has to happen in the same transaction as the path update: readers switch
+    /// from the interpolated value to the settled one, and a gap between the two would flash.
+    func reset() {
+        guard isPopping else { return }
+
+        isPopping = false
+        value = 0
+    }
+}
+
+extension EnvironmentValues {
+    @Entry var anytypeNavigationPopProgress = AnytypeNavigationPopProgress()
+}
+
+extension View {
+
+    func anytypeNavigationPopProgress(_ progress: AnytypeNavigationPopProgress) -> some View {
+        environment(\.anytypeNavigationPopProgress, progress)
+    }
+
+    /// Fades this in as a back swipe reveals the screen it belongs to, against the chrome of the
+    /// screen being left behind fading out. Fully visible whenever no swipe is in flight, so a
+    /// screen that is simply on top is unaffected.
+    func anytypeNavigationPopRevealFade() -> some View {
+        modifier(AnytypeNavigationPopRevealFade())
+    }
+}
+
+private struct AnytypeNavigationPopRevealFade: ViewModifier {
+
+    @Environment(\.anytypeNavigationPopProgress) private var popProgress
+
+    func body(content: Content) -> some View {
+        content.opacity(popProgress.isPopping ? Double(popProgress.value) : 1)
+    }
+}

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/NavigationView/AnytypeNavigationView.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/NavigationView/AnytypeNavigationView.swift
@@ -20,16 +20,25 @@ struct AnytypeNavigationViewRepresentable: UIViewControllerRepresentable {
     @Binding var pathChanging: Bool
     let moduleSetup: (_ builder: AnytypeDestinationBuilderHolder) -> Void
 
-    func makeUIViewController(context: Context) -> UINavigationController {
+    func makeUIViewController(context: Context) -> FullScreenSwipeNavigationController {
         let controller =  FullScreenSwipeNavigationController()
         controller.setNavigationBarHidden(true, animated: false)
         controller.delegate = context.coordinator
-        
+
+        let popProgress = context.environment.anytypeNavigationPopProgress
+        context.coordinator.popProgress = popProgress
+        controller.onInteractivePopProgress = { [weak popProgress] progress in
+            popProgress?.update(progress)
+        }
+        controller.onInteractivePopAborted = { [weak popProgress] in
+            popProgress?.settle(cancelled: true, duration: Constants.abortedSwipeDuration)
+        }
+
         moduleSetup(context.coordinator.builder)
         return controller
     }
     
-    func updateUIViewController(_ controller: UINavigationController, context: Context) {
+    func updateUIViewController(_ controller: FullScreenSwipeNavigationController, context: Context) {
         let builder = context.coordinator.builder
         var freeViewControllers = context.coordinator.currentViewControllers
         var viewControllers = [UIHostingController<AnytypeNavigationViewBridge>]()
@@ -65,5 +74,11 @@ struct AnytypeNavigationViewRepresentable: UIViewControllerRepresentable {
     
     func makeCoordinator() -> AnytypeNavigationCoordinator {
         return AnytypeNavigationCoordinator(path: _path, pathChanging: _pathChanging)
+    }
+}
+
+private extension AnytypeNavigationViewRepresentable {
+    enum Constants {
+        static let abortedSwipeDuration: TimeInterval = 0.25
     }
 }

--- a/Anytype/Sources/PresentationLayer/Common/SwiftUI/NavigationView/FullScreenSwipeNavigationController.swift
+++ b/Anytype/Sources/PresentationLayer/Common/SwiftUI/NavigationView/FullScreenSwipeNavigationController.swift
@@ -1,31 +1,58 @@
 import UIKit
 
 final class FullScreenSwipeNavigationController: UINavigationController, UIGestureRecognizerDelegate {
-    
+
+    /// Fraction of the screen width the in-flight back swipe has covered.
+    var onInteractivePopProgress: ((CGFloat) -> Void)?
+
+    /// The swipe ended without UIKit driving a transition, so nobody else will report an outcome.
+    var onInteractivePopAborted: (() -> Void)?
+
     override public func viewDidLoad() {
         super.viewDidLoad()
         setupFullScreenSwipe()
     }
-    
+
     func setupFullScreenSwipe() {
+        // The system edge swipe drives the same transition, so it has to report progress too.
+        interactivePopGestureRecognizer?.addTarget(self, action: #selector(handleBackSwipe))
+
         guard let target = interactivePopGestureRecognizer?.delegate else { return }
-        
+
         let selector = NSSelectorFromString("handleNavigationTransition:")
         if target.responds(to: selector) {
             let panGestureRecognizer = UIPanGestureRecognizer(
                 target: target,
                 action: selector
             )
+            // Added after UIKit's own target, so by the time this runs the transition has begun.
+            panGestureRecognizer.addTarget(self, action: #selector(handleBackSwipe))
             panGestureRecognizer.delegate = self
             self.view.addGestureRecognizer(panGestureRecognizer)
         }
     }
-    
+
+    @objc private func handleBackSwipe(_ recognizer: UIPanGestureRecognizer) {
+        switch recognizer.state {
+        case .began, .changed:
+            let width = view.bounds.width
+            guard width > 0 else { return }
+            onInteractivePopProgress?(recognizer.translation(in: view).x / width)
+        case .ended, .cancelled, .failed:
+            // A live transition reports its own outcome through the transition coordinator.
+            if transitionCoordinator == nil {
+                onInteractivePopAborted?()
+            }
+        default:
+            break
+        }
+    }
+
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         guard viewControllers.count > 1 else { return false }
-        
+
         guard let panGestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer else { return false }
-        
+
         let translation = panGestureRecognizer.translation(in: panGestureRecognizer.view)
         return translation.x > 0
     }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/BottomPanel/HomeBottomPanelContainer.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/BottomPanel/HomeBottomPanelContainer.swift
@@ -4,7 +4,8 @@ import SwiftUI
 struct HomeBottomPanelContainer<Content: View, BottomContent: View>: View {
     
     @State private var bottomPanelState = HomeBottomPanelState()
-    
+    @State private var popProgress = AnytypeNavigationPopProgress()
+
     private var content: Content
     private var bottomPanel: BottomContent
     @Binding private var path: HomePath
@@ -26,16 +27,29 @@ struct HomeBottomPanelContainer<Content: View, BottomContent: View>: View {
                     bottomSize = $0
                 }
                 .anytypeIgnoreBottomSafeArea()
-                .opacity(bottomPanelHidden ? 0 : 1)
+                .opacity(bottomPanelOpacity)
+                .allowsHitTesting(bottomPanelOpacity > 0)
                 .animation(.default, value: path.count)
         }
         .homeBottomPanelState($bottomPanelState)
+        .anytypeNavigationPopProgress(popProgress)
     }
-    
-    private var bottomPanelHidden: Bool {
-        if let item = path.path.last {
-            return bottomPanelState.hidden(for: item) ?? false
-        }
-        return false
+
+    // The panel sits outside the navigation stack, so a back swipe would otherwise leave it
+    // hanging over the revealed screen until the gesture commits. While a swipe is in flight,
+    // cross-fade towards what the destination screen asks for, in step with the finger. The
+    // revealed screen's own bar fades in against this, so the two trade places under the thumb.
+    private var bottomPanelOpacity: Double {
+        let current = opacity(for: path.path.last)
+
+        guard popProgress.isPopping else { return current }
+
+        let destination = opacity(for: path.path.dropLast().last)
+        return current + (destination - current) * Double(popProgress.value)
+    }
+
+    private func opacity(for item: AnyHashable?) -> Double {
+        guard let item, let hidden = bottomPanelState.hidden(for: item) else { return 1 }
+        return hidden ? 0 : 1
     }
 }

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomBarMetrics.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomBarMetrics.swift
@@ -1,0 +1,14 @@
+import CoreGraphics
+
+/// Geometry shared by the vault's bottom bar and a space's bottom panel.
+///
+/// One replaces the other across a navigation pop, and the compose button exists on both. It
+/// only reads as the same button staying put if both bars size and inset their controls
+/// identically, so these numbers belong to the pair rather than to either bar. The two are
+/// anchored by different mechanisms, a safe area bar against a bottom-pinned overlay, but both
+/// measure this bottom inset from the same edge.
+enum HomeBottomBarMetrics {
+    static let controlHeight: CGFloat = 48
+    static let horizontalInset: CGFloat = 24
+    static let bottomInset: CGFloat = 0
+}

--- a/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/HomeNavigationContainer/Panel/HomeBottomNavigationPanelView.swift
@@ -52,9 +52,9 @@ private struct HomeBottomNavigationPanelViewInternal: View {
                     }
                 }
             }
-            .padding(.horizontal, 24)
+            .padding(.horizontal, HomeBottomBarMetrics.horizontalInset)
             .padding(.top, 16)
-            .padding(.bottom, 8)
+            .padding(.bottom, HomeBottomBarMetrics.bottomInset)
         }
         .frame(maxWidth: .infinity)
         .background {
@@ -89,7 +89,7 @@ private struct HomeBottomNavigationPanelViewInternal: View {
                 .renderingMode(.template)
                 .foregroundStyle(Color.Control.primary)
         }
-        .frame(width: 48, height: 48)
+        .frame(width: HomeBottomBarMetrics.controlHeight, height: HomeBottomBarMetrics.controlHeight)
         .glassEffectInteractiveIOS26(in: Circle())
     }
 
@@ -180,14 +180,14 @@ private struct HomeBottomNavigationPanelViewInternal: View {
                     .renderingMode(.template)
                     .foregroundStyle(Color.Control.primary)
             }
-            .frame(width: 48, height: 48)
+            .frame(width: HomeBottomBarMetrics.controlHeight, height: HomeBottomBarMetrics.controlHeight)
             .glassEffectInteractiveIOS26(in: Circle())
             .menuOrder(.fixed)
         } else {
             Image(asset: .X32.Island.create)
                 .renderingMode(.template)
                 .foregroundStyle(Color.Control.primary)
-                .frame(width: 48, height: 48)
+                .frame(width: HomeBottomBarMetrics.controlHeight, height: HomeBottomBarMetrics.controlHeight)
                 .contentShape(Circle())
                 .glassEffectInteractiveIOS26(in: Circle())
                 .onTapGesture {

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubView.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/SpaceHubView.swift
@@ -67,6 +67,9 @@ struct SpaceHubView: View {
                             onTapCreateGroupChannel: { model.onTapCreateGroupChannel() },
                             onTapJoinViaQrCode: { model.onTapJoinViaQrCode() }
                         )
+                        // Trades places with a space's bottom panel: that one fades out as this
+                        // fades in, both tracking the back swipe rather than snapping at the end
+                        .anytypeNavigationPopRevealFade()
                     }
                     // The hub has no text input of its own, but a keyboard raised in a
                     // presented sheet still insets this hierarchy - the bar would ride up

--- a/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/VaultSearchBarButton.swift
+++ b/Anytype/Sources/PresentationLayer/Modules/SpaceHub/Subviews/VaultSearchBarButton.swift
@@ -31,8 +31,11 @@ struct VaultSearchBottomBar: View {
                     createMenu
                 }
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
+            // Matches the space bottom panel so the compose button does not shift when one
+            // bar replaces the other across a navigation pop
+            .padding(.horizontal, HomeBottomBarMetrics.horizontalInset)
+            .padding(.top, 10)
+            .padding(.bottom, HomeBottomBarMetrics.bottomInset)
         }
         .fitIPadToReadableContentGuide()
     }
@@ -41,10 +44,14 @@ struct VaultSearchBottomBar: View {
         Button {
             onTapQuickCapture()
         } label: {
-            Image(systemName: "square.and.pencil")
+            // Identical to the create button on a space's bottom panel - same icon, size and
+            // glass - so it reads as one button standing still across a navigation pop
+            Image(asset: .X32.Island.create)
+                .renderingMode(.template)
                 .foregroundStyle(Color.Control.primary)
-                .frame(width: 44, height: 44)
-                .barBackground
+                .frame(width: HomeBottomBarMetrics.controlHeight, height: HomeBottomBarMetrics.controlHeight)
+                .contentShape(Circle())
+                .glassEffectInteractiveIOS26(in: Circle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel("QuickCaptureButton")
@@ -57,14 +64,14 @@ struct VaultSearchBottomBar: View {
             HStack(spacing: 8) {
                 Image(asset: .X18.search)
                     // Reduce Motion gets a still cue in place of the glimmer
-                    .foregroundStyle(highlightSearch && reduceMotion ? Color.Control.accent100 : Color.Control.secondary)
+                    .foregroundStyle(highlightSearch && reduceMotion ? Color.Control.accent100 : Color.Control.primary)
                 // Call to action for the unified search entry: it now covers every channel, objects and messages
                 AnytypeText(Loc.UnifiedSearch.placeholder, style: .uxBodyRegular)
                     .foregroundStyle(Color.Text.secondary)
                 Spacer()
             }
-            .padding(.vertical, 11)
             .padding(.horizontal, 12)
+            .frame(height: HomeBottomBarMetrics.controlHeight)
             // Part of the glass content, applied before the glass: anything layered after
             // glassEffect sits outside the glass element and makes the bar's scroll-edge
             // effect fall back to a hard dark band under the toolbar
@@ -105,7 +112,7 @@ struct VaultSearchBottomBar: View {
         } label: {
             Image(systemName: "plus")
                 .foregroundStyle(Color.Control.primary)
-                .frame(width: 44, height: 44)
+                .frame(width: HomeBottomBarMetrics.controlHeight, height: HomeBottomBarMetrics.controlHeight)
                 .glassEffect(.regular.interactive(), in: .circle)
         }
     }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Header/Filled/ObjectHeaderFilledContentView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Header/Filled/ObjectHeaderFilledContentView.swift
@@ -97,20 +97,8 @@ private extension ObjectHeaderFilledContentView  {
         shimmeringView.shimmerSpeed = 120
     }
 
+    // Only a downward pull past the top - a negative offset - stretches the cover.
     func updateCoverTransform(_ offset: CGFloat) {
-        let offset = offset
-
-        guard offset.isLess(than: CGFloat.zero) else {
-            headerView.applyCoverTransform(.identity)
-            return
-        }
-
-        let coverHeight = sizeConfiguration?.coverHeight ?? 0
-        let scaleY = (abs(offset) + coverHeight) / coverHeight
-
-        var t = CGAffineTransform.identity
-        t = t.scaledBy(x: scaleY, y: scaleY)
-
-        headerView.applyCoverTransform(t)
+        headerView.setCoverStretch(by: max(-offset, 0))
     }
 }

--- a/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Header/Filled/Subviews/ObjectHeaderView.swift
+++ b/Anytype/Sources/PresentationLayer/TextEditor/EditorPage/Views/Header/Filled/Subviews/ObjectHeaderView.swift
@@ -36,32 +36,28 @@ final class ObjectHeaderView: UIView {
         setupView()
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
-        coverViewCenter = coverView.layer.position
-    }
-
     // MARK: - Internal functions
-    private lazy var coverViewCenter: CGPoint = coverView.layer.position
 
-    func applyCoverTransform(_ transform: CGAffineTransform) {
-        if coverView.transform.isIdentity, !transform.isIdentity {
-            let maxY = coverViewCenter.y + coverView.bounds.height / 2
-            coverView.layer.position = CGPoint(x: coverViewCenter.x, y: maxY)
-            coverView.layer.anchorPoint = CGPoint(x: 0.5, y: 1.0)
-        } else if transform.isIdentity {
-            coverView.layer.position = coverViewCenter
-            coverView.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+    /// Grows the cover upward by `amount` points, its bottom edge pinned in place.
+    ///
+    /// This is a plain transform about the default center anchor: scale up, then shift up by
+    /// half the growth. Auto Layout owns the cover's `center` and re-applies it on every
+    /// layout pass, so moving the layer's anchor point to the bottom edge instead makes the
+    /// next pass put the bottom edge where the center belongs and the cover jumps up by half
+    /// its height.
+    func setCoverStretch(by amount: CGFloat) {
+        let coverHeight = converViewHeightConstraint?.constant ?? 0
+
+        UIView.performWithoutAnimation {
+            guard amount > 0, coverHeight > 0 else {
+                coverView.transform = .identity
+                return
+            }
+
+            let scale = (coverHeight + amount) / coverHeight
+            coverView.transform = CGAffineTransform(translationX: 0, y: -amount / 2)
+                .scaledBy(x: scale, y: scale)
         }
-
-//         Disable CALayer implicit animations
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-
-        coverView.transform = transform
-
-        CATransaction.commit()
     }
 }
 


### PR DESCRIPTION
## Summary

- Editor cover no longer jumps up by half its height on a small pull. The stretch moved the cover layer's anchor point to its bottom edge and rewrote `layer.position` by hand, so the next layout pass put the bottom edge where Auto Layout's `center` belongs. It is now a plain transform about the default centre anchor, and the header owns the geometry.
- The navigation layer publishes interactive back-swipe progress, and both bottom bars cross-fade against it. A space's panel fades out as the vault's bar fades in, tracking the finger and reversing if the swipe is cancelled, instead of snapping once the gesture commits.
- Both bars share one control height, edge inset and bottom inset, and the vault's compose button is now identical to the space panel's. Its search icon is white to match.

https://claude.ai/code/session_012Yrapunupi7UyN9zAQ7LWH
